### PR TITLE
ci: re-enable tests + lint workflows, isolate/harden the test DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,11 @@ STREAMELEMENTS_LISTENER_SECRET=
 MAP_SLUG_ALPHABET=
 MAP_SLUG_MIN_LENGTH=8
 
+# Twitch (main app) - OAuth + EventSub. Required for Twitch integration.
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+TWITCH_REDIRECT_URI=
+
 # Twitch bot (@overlabels shared account) - separate Twitch Developer app
 TWITCHBOT_CLIENT_ID=
 TWITCHBOT_CLIENT_SECRET=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,34 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    # Throwaway Postgres for the test run. Matches phpunit.xml, which forces
+    # DB_CONNECTION=pgsql and DB_DATABASE=laravel_foxes_test. This container is
+    # created fresh for the job and destroyed after - it never touches anything real.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: laravel_foxes_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    # Connection coordinates for both `artisan migrate` and pest. phpunit.xml
+    # supplies DB_CONNECTION + DB_DATABASE; these provide host/port/credentials.
+    env:
+      DB_CONNECTION: pgsql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_DATABASE: laravel_foxes_test
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +51,8 @@ jobs:
         with:
           php-version: 8.4
           tools: composer:v2
-          coverage: xdebug
+          extensions: pdo, pdo_pgsql, pgsql
+          coverage: none
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -48,6 +77,12 @@ jobs:
 
       - name: Build Assets
         run: npm run build
+
+      # The suite uses DatabaseTransactions (rollback-only), so nothing migrates
+      # the schema on its own. Migrate the throwaway test DB up front so tables
+      # exist before any test runs, regardless of test order.
+      - name: Migrate Test Database
+        run: php artisan migrate --force
 
       - name: Tests
         run: ./vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,12 @@ jobs:
       DB_DATABASE: laravel_foxes_test
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
+      # Keep non-DB stores off the database so the post-autoload-dump scripts
+      # (package:discover, help:build-index) and migrate don't touch tables that
+      # don't exist yet. Mirrors phpunit.xml's test environment.
+      CACHE_STORE: array
+      SESSION_DRIVER: array
+      QUEUE_CONNECTION: sync
 
     steps:
       - name: Checkout

--- a/config/services.php
+++ b/config/services.php
@@ -25,8 +25,10 @@ return [
         'url' => env('CLOUDINARY_URL'),
     ],
     'twitch' => [
-        'client_id' => env('TWITCH_CLIENT_ID'),
-        'client_secret' => env('TWITCH_CLIENT_SECRET'),
+        // Default to '' so secret-less environments (CI, fresh installs) don't
+        // fatal when services type these into non-nullable string properties.
+        'client_id' => env('TWITCH_CLIENT_ID', ''),
+        'client_secret' => env('TWITCH_CLIENT_SECRET', ''),
         'redirect' => env('TWITCH_REDIRECT_URI'),
         'cache_ttl' => (int) env('TWITCH_CACHE_TTL', 10),
     ],

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,14 @@
 # CHANGELOG JUNE 2026
 
+## June 12th, 2026 - ci: re-enable the tests + lint workflows, isolate the test DB
+
+The `tests` and `linter` GitHub Actions workflows had been `disabled_manually` (since the backend was rough and the test job couldn't even connect to a database). The backend is in good shape now, so both are back on - with the bugs that kept them red fixed.
+
+- **`tests.yml` had a fatal gap: no database.** `phpunit.xml` forces `DB_CONNECTION=pgsql` / `DB_DATABASE=laravel_foxes_test`, but the workflow spun up no Postgres, so the suite could never connect on CI. Added a throwaway `postgres:16` service container (DB `laravel_foxes_test`, user/pass `postgres`), the `pdo_pgsql` extension, and job-level `DB_*` env so both `artisan migrate` and pest target it. Switched `coverage: xdebug` -> `coverage: none` (no coverage was being collected; xdebug just slowed the run 2-3x).
+- **Removed `RefreshDatabase` from the test suite entirely.** It lived in only 2 files (`EventSubExpansionTest`, `OverlayBroadcastingAuthTest`); every other test already uses `DatabaseTransactions` (rollback-only, never drops tables). Converted those two to match, and deleted the commented-out global `RefreshDatabase` line in `tests/Pest.php`. Nothing in the suite now does a `migrate:fresh`. Tests were always isolated to `laravel_foxes_test` (separate from dev `laravel_foxes`) via the phpunit override + immutable `.env` loading - this just removes the footgun outright.
+- **CI migrates the test DB up front.** Because the suite is now rollback-only (nothing auto-migrates the schema), `tests.yml` runs `php artisan migrate --force` against the fresh container before pest, so tables exist regardless of test order. Note for local runs: after adding a new migration, migrate `laravel_foxes_test` once (`$env:DB_DATABASE='laravel_foxes_test'; php artisan migrate; Remove-Item Env:DB_DATABASE`) or it'll be stale.
+- **Cleared the 17 lint errors** that would have kept `linter` red - all unused imports/vars in `gpslogger.vue` (a deprecated stub), `TemplateCodeEditor.vue`, `admin/updates/edit.vue`, and an unused `v-for` index in `templates/show.vue`. ESLint, vue-tsc, and the build are all clean.
+
 ## June 12th, 2026 - chore(deps): update Composer and npm packages, including framework majors
 
 A full dependency sweep: every direct Composer and npm package taken to its latest compatible version, with the breaking changes from the major bumps fixed and the whole suite (tests, build, typecheck) kept green. No application behavior changes - this is maintenance.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,7 @@
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="pgsql"/>
         <env name="DB_DATABASE" value="laravel_foxes_test"/>

--- a/resources/js/components/templates/TemplateCodeEditor.vue
+++ b/resources/js/components/templates/TemplateCodeEditor.vue
@@ -8,7 +8,6 @@ import { Codemirror } from 'vue-codemirror';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
 import { ChevronDown, ChevronUp, FileCode2, Code, Maximize, Minimize, Palette, Wind, Video } from '@lucide/vue';
 import AddToObsButton from '@/components/AddToObsButton.vue';
-import { Badge } from '@/components/ui/badge';
 
 const headValue = defineModel<string>('head', { required: true });
 const htmlValue = defineModel<string>('body', { required: true });

--- a/resources/js/pages/admin/updates/edit.vue
+++ b/resources/js/pages/admin/updates/edit.vue
@@ -2,7 +2,6 @@
 import AppLayout from '@/layouts/AppLayout.vue';
 import PageHeader from '@/components/PageHeader.vue';
 import { Head, router, useForm } from '@inertiajs/vue3';
-import { Input } from '@/components/ui/input';
 import { computed, ref, onMounted, onUnmounted } from 'vue';
 import { Codemirror } from 'vue-codemirror';
 import { html as cmHtml } from '@codemirror/lang-html';

--- a/resources/js/pages/settings/integrations/gpslogger.vue
+++ b/resources/js/pages/settings/integrations/gpslogger.vue
@@ -1,16 +1,8 @@
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue';
-import { Head, useForm, Link, usePage } from '@inertiajs/vue3';
-import axios from 'axios';
-import QRCode from 'qrcode';
+import { Head } from '@inertiajs/vue3';
 import AppLayout from '@/layouts/AppLayout.vue';
 import SettingsLayout from '@/layouts/settings/Layout.vue';
 import HeadingSmall from '@/components/HeadingSmall.vue';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Separator } from '@/components/ui/separator';
 import { type BreadcrumbItem } from '@/types';
 
 interface IntegrationData {
@@ -22,7 +14,7 @@ interface IntegrationData {
   has_token: boolean;
 }
 
-const props = defineProps<{
+defineProps<{
   integration: IntegrationData;
 }>();
 

--- a/resources/js/pages/templates/show.vue
+++ b/resources/js/pages/templates/show.vue
@@ -276,7 +276,7 @@ const breadcrumbs: BreadcrumbItem[] = [
         <div
           class="flex max-w-full touch-pan-x lg:touch-none overflow-auto">
           <button
-            v-for="(tab, index) in mainTabs"
+            v-for="tab in mainTabs"
             :key="tab.key"
             type="button"
             @click="mainTab = tab.key"

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -4,7 +4,7 @@ use App\Models\User;
 
 test('guests are redirected to the login page', function () {
     $response = $this->get('/dashboard');
-    $response->assertRedirect('/login?redirect_to=https%3A%2F%2Foverlabels.test%2Fdashboard');
+    $response->assertRedirect('/login?redirect_to='.urlencode(url('/dashboard')));
 });
 
 test('authenticated users can visit the dashboard', function () {

--- a/tests/Feature/EventSubExpansionTest.php
+++ b/tests/Feature/EventSubExpansionTest.php
@@ -3,9 +3,9 @@
 use App\Models\User;
 use App\Services\TemplateDataMapperService;
 use App\Services\TwitchScopeService;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
-uses(RefreshDatabase::class);
+uses(DatabaseTransactions::class);
 
 test('null twitch_scopes falls back to legacy scope set', function () {
     $user = User::factory()->create(['twitch_scopes' => null]);

--- a/tests/Feature/OverlayBroadcastingAuthTest.php
+++ b/tests/Feature/OverlayBroadcastingAuthTest.php
@@ -2,9 +2,9 @@
 
 use App\Models\OverlayAccessToken;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
-uses(RefreshDatabase::class);
+uses(DatabaseTransactions::class);
 
 beforeEach(function () {
     config()->set('broadcasting.connections.reverb.key', 'test-key');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,7 +14,6 @@ use Tests\TestCase;
 */
 
 pest()->extend(TestCase::class)
- // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature', 'Unit');
 
 /*


### PR DESCRIPTION
Re-enables the `tests` and `linter` GitHub Actions workflows (both were `disabled_manually`), fixing the bugs that kept them red.

## tests.yml was structurally broken
`phpunit.xml` forces `DB_CONNECTION=pgsql` / `DB_DATABASE=laravel_foxes_test`, but the workflow started **no database** - the suite could never connect. Fixed:
- Throwaway `postgres:16` service container (matches phpunit), `pdo_pgsql` extension, job-level `DB_*` env
- `coverage: xdebug` -> `coverage: none` (nothing collected coverage; xdebug just slowed it ~2-3x)
- Added a `php artisan migrate --force` step before pest

## Removed RefreshDatabase from the suite
It was in only 2 files; everything else uses `DatabaseTransactions` (rollback-only, never drops tables). Converted both + removed the commented global in `Pest.php`. **Nothing does `migrate:fresh` anymore.** Tests were always isolated to `laravel_foxes_test` (separate from dev `laravel_foxes`); this removes the footgun outright.

> Local note: suite is now rollback-only, so after adding a migration, migrate `laravel_foxes_test` once or it'll be stale.

## linter
Fixed the 17 unused-import/var errors (deprecated `gpslogger.vue` stub, `TemplateCodeEditor.vue`, `admin/updates/edit.vue`, an unused `v-for` index). ESLint + vue-tsc + build all clean. Full suite: 841 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)