### PR TITLE
fix(auth): redirect to login when the session dies mid-visit

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,8 +15,11 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Symfony\Component\HttpFoundation\Response;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -73,5 +76,17 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        // A 419 means the CSRF/session token expired - usually a cleared cookie
+        // or a session that died mid-visit. For an Inertia request, returning the
+        // raw 419 leaves the SPA stuck on a response it can't parse. Convert it
+        // into an Inertia full-page redirect to login (preserving where the user
+        // was) so they re-authenticate instead of clicking into dead console
+        // errors. Non-Inertia requests keep Laravel's default 419 page.
+        $exceptions->respond(function (Response $response, Throwable $e, Request $request) {
+            if ($response->getStatusCode() === 419 && $request->header('X-Inertia')) {
+                return Inertia::location(route('login').'?redirect_to='.urlencode($request->fullUrl()));
+            }
+
+            return $response;
+        });
     })->create();

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,16 @@
 # CHANGELOG JUNE 2026
 
+## June 12th, 2026 - fix(auth): redirect to login when the session dies mid-visit instead of sitting on dead console errors
+
+When an authenticated session was lost mid-visit (expired, cookies cleared by a browser cleanup tool, etc.), the app didn't recover: clicking around only produced console errors and the UI sat there. Plain Inertia navigation already bounced to login (`RedirectIfUnauthenticated` returns `Inertia::location`), but two paths fell through:
+
+- **Direct `axios` calls** (20 components - controls, freesound, expression builder, fork wizard, etc.) got a `401` with no global handler, so each rejected into its own catch as a bare console error.
+- **State-changing requests after the cookie was gone** threw `419` (stale CSRF) before reaching the auth middleware, and the empty `withExceptions` block left Inertia stuck on a response it couldn't parse.
+
+- **Global axios response interceptor** (`resources/js/app.ts`): on `401` or `419`, bounce to `/login?redirect_to=<current url>` and swallow the rejection so callers don't also flash their own error UI. Covers every direct axios call and Inertia's own requests (same axios instance); Inertia auth redirects come back as `409 + X-Inertia-Location` and are handled natively, so they never hit this branch. Also centralizes the `withCredentials` / `X-Requested-With` defaults that previously lived ad-hoc in `TemplateTagsList.vue`.
+- **Server-side `419` handling** (`bootstrap/app.php`): a `419` on an Inertia request is converted to `Inertia::location(login)` (preserving the current URL), so CSRF-expired form posts redirect cleanly instead of erroring. Non-Inertia requests keep Laravel's default `419` page.
+- 2 feature tests in `AuthRedirectTest`: a `419` on an Inertia request becomes a `409` login location redirect; a `419` on a non-Inertia request stays a plain `419`. Full suite green (843 passing).
+
 ## June 12th, 2026 - ci: re-enable the tests + lint workflows, isolate the test DB
 
 The `tests` and `linter` GitHub Actions workflows had been `disabled_manually` (since the backend was rough and the test job couldn't even connect to a database). The backend is in good shape now, so both are back on - with the bugs that kept them red fixed.

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -7,8 +7,37 @@ import type { DefineComponent } from 'vue';
 import { createApp, h } from 'vue';
 import { ZiggyVue } from 'ziggy-js';
 import { initializeTheme } from './composables/useAppearance';
+import axios from 'axios';
 import Echo from 'laravel-echo';
 import Pusher from 'pusher-js';
+
+// Global axios defaults: send the session cookie and mark requests as XHR so
+// Laravel treats them as stateful. (Previously set ad-hoc inside a component.)
+axios.defaults.withCredentials = true;
+axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+// When the session dies mid-visit (expired, cookies cleared by a cleanup tool,
+// etc.), the next request comes back 401 (unauthenticated) or 419 (stale CSRF
+// token). Without this, those reject into each caller's catch block as bare
+// console errors and the UI just sits there. Bounce to login instead, keeping
+// the current URL so the user lands back where they were after re-auth. This
+// covers every direct axios call AND Inertia's own requests (it uses this same
+// axios instance); Inertia auth redirects come back as 409 + X-Inertia-Location
+// and are handled natively, so they never reach this branch.
+axios.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        const status = error.response?.status;
+        const onLoginPage = window.location.pathname.startsWith('/login');
+        if ((status === 401 || status === 419) && !onLoginPage) {
+            window.location.href = '/login?redirect_to=' + encodeURIComponent(window.location.href);
+            // We're navigating away - swallow the rejection so callers don't
+            // also flash their own error UI on the way out.
+            return new Promise(() => {});
+        }
+        return Promise.reject(error);
+    },
+);
 
 const pinia = createPinia()
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';

--- a/resources/js/components/TemplateTagsList.vue
+++ b/resources/js/components/TemplateTagsList.vue
@@ -8,11 +8,8 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 
-// Configure axios to include CSRF token and credentials
-axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-axios.defaults.withCredentials = true;
-
-// Get CSRF token from the meta-tag if it exists
+// XHR + withCredentials defaults are configured globally in app.ts.
+// Add the CSRF token from the meta tag if it's present.
 const token = document.head.querySelector('meta[name="csrf-token"]');
 if (token) {
   axios.defaults.headers.common['X-CSRF-TOKEN'] = token.getAttribute('content');

--- a/tests/Feature/AuthRedirectTest.php
+++ b/tests/Feature/AuthRedirectTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+test('a 419 on an Inertia request is converted to a login location redirect', function () {
+    Route::post('/__test/419', fn () => abort(419))->middleware('web');
+
+    $response = $this->withHeader('X-Inertia', 'true')->post('/__test/419');
+
+    // Inertia::location() returns a 409 with the destination in X-Inertia-Location,
+    // which the client turns into a full-page visit to login.
+    $response->assertStatus(409);
+    expect($response->headers->get('X-Inertia-Location'))->toContain('/login');
+});
+
+test('a 419 on a non-Inertia request keeps the default 419 response', function () {
+    Route::post('/__test/419', fn () => abort(419))->middleware('web');
+
+    $response = $this->post('/__test/419');
+
+    $response->assertStatus(419);
+});


### PR DESCRIPTION
When an authenticated session is lost mid-visit (expired, cookies cleared by a browser cleanup tool, etc.), the app didn't recover - clicking only produced console errors and the UI sat there.

## Diagnosis
Plain Inertia navigation already redirected to login (`RedirectIfUnauthenticated` returns `Inertia::location`). Two paths fell through:
- **Direct `axios` calls** (20 components) got a `401` with no global handler -> bare console errors.
- **State-changing requests after the cookie was gone** threw `419` (stale CSRF) before reaching the auth middleware; the empty `withExceptions` block left Inertia stuck on an unparseable response.

## Fix
- **`resources/js/app.ts`** - global axios response interceptor: on `401`/`419`, bounce to `/login?redirect_to=<current url>` and swallow the rejection. Covers all 20 axios components and Inertia's own requests (shared instance). Centralizes the `withCredentials`/`X-Requested-With` defaults (removed the ad-hoc copy in `TemplateTagsList.vue`).
- **`bootstrap/app.php`** - convert `419` on Inertia requests to `Inertia::location(login)`, preserving the current URL; non-Inertia `419`s keep the default page.
- **`AuthRedirectTest`** - 2 feature tests. Full suite green (843 passing) locally; build + typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)