### PR TITLE
ops(metering): enable broadcast metering in prod (observe-only)

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -154,8 +154,21 @@ env:
 
     QUEUE_CONNECTION: database
     CACHE_STORE: redis
-    BROADCAST_CONNECTION: reverb
+    # `metered` wraps the reverb driver to count outbound broadcasts per user
+    # (MeteredBroadcaster). Set back to `reverb` to bypass metering entirely.
+    BROADCAST_CONNECTION: metered
     FILESYSTEM_DISK: local
+
+    # Broadcast metering. Observe-only: counters are tallied and shown on the
+    # dashboard / Usage page, but nothing is suppressed. Leave
+    # METERING_FREE_MONTHLY_BROADCASTS empty for no enforced cap; set a number
+    # later (once real per-user data exists) to turn on the free-tier ceiling.
+    # NOTE: counters share the LRU/non-persistent cache Redis below, so they can
+    # be evicted under memory pressure and reset on a Redis restart - acceptable
+    # for observe-only, but move to a persistent, non-evicting store before any
+    # enforcement/billing.
+    METERING_ENABLED: "true"
+    METERING_FREE_MONTHLY_BROADCASTS: ""
 
     REDIS_HOST: overlabels-redis
     REDIS_PORT: "6379"

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,12 @@
 # CHANGELOG JUNE 2026
 
+## June 13th, 2026 - ops(metering): turn on broadcast metering in prod (observe-only)
+
+Flipped prod to start counting. `config/deploy.yml` now sets `BROADCAST_CONNECTION: metered` (wraps the reverb driver with `MeteredBroadcaster`) plus `METERING_ENABLED: "true"` and an empty `METERING_FREE_MONTHLY_BROADCASTS` (no enforced cap - observe-only). All three are plaintext `env.clear` values, not secrets. Counters land in the existing `overlabels-redis` accessory.
+
+- Still observe-only: broadcasts are tallied and shown on the dashboard / Usage page, nothing is suppressed.
+- Caveat for later: that Redis runs `allkeys-lru --save ""` (LRU eviction, no persistence), shared across cache DB 1 and the meter's DB 0, so counters can be evicted under memory pressure and reset on a Redis restart. Fine for gathering rough p50/p90 data; needs a persistent, non-evicting store before any enforcement or billing.
+
 ## June 13th, 2026 - feat(metering): count Reverb broadcasts per user (observe-only) with a Usage page
 
 Reverb fan-out is the one resource that gets expensive as more streamers join, so it becomes the single defacto usage limit in Overlabels - everything else stays free. This lays the foundation: a per-user, per-month counter of outbound broadcasts ("overlay updates"), surfaced in the dashboard and a new Usage settings page. It is OBSERVE-ONLY - nothing is suppressed yet. The free-tier number will be set from real data, then enforcement + a paid tier come later.


### PR DESCRIPTION
Turns on per-user Reverb broadcast counting in prod. **Observe-only** - counters are tallied and shown on the dashboard / Usage page, nothing is suppressed.

## Change (all in `config/deploy.yml` `env.clear`, plaintext - not secrets)

- `BROADCAST_CONNECTION: reverb` -> `metered` (wraps the reverb driver with `MeteredBroadcaster`)
- `METERING_ENABLED: "true"`
- `METERING_FREE_MONTHLY_BROADCASTS: ""` (empty = no enforced cap)

No `.kamal/secrets` changes needed - none of these are sensitive. Counters land in the existing `overlabels-redis` accessory (`REDIS_HOST: overlabels-redis`, already wired).

## Merging this deploys

Push to `main` triggers the Deploy workflow, which `kamal deploy`s and applies the new `env.clear` values. After deploy, the metered broadcaster is live and counting.

## Known caveat (fine for observe-only, fix before enforcement)

The prod Redis runs `redis-server --maxmemory 200mb --maxmemory-policy allkeys-lru --save ""`:
- `allkeys-lru` can evict metering counters under memory pressure (TTL doesn't protect them).
- `--save ""` means a Redis restart/crash wipes all counters to zero.
- The meter uses `REDIS_DB=0`, cache uses `REDIS_DB=1`, but eviction/persistence are per-instance, so the counters aren't isolated.

Good enough for gathering rough p50/p90 usage. Before enforcing a limit or tying it to billing, move counters to a persistent, non-evicting store (dedicated metering Redis, or `noeviction` + AOF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)