### PR TITLE
fix(gps): stop GPS distance running away, split session vs lifetime reset

### DIFF
--- a/app/Http/Controllers/Settings/GpsIntegrationController.php
+++ b/app/Http/Controllers/Settings/GpsIntegrationController.php
@@ -6,6 +6,7 @@ use App\Events\ControlValueUpdated;
 use App\Http\Controllers\Controller;
 use App\Models\ExternalIntegration;
 use App\Models\OverlayControl;
+use App\Models\User;
 use App\Services\External\ExternalControlService;
 use App\Services\External\ExternalServiceRegistry;
 use App\Services\MapSlugService;
@@ -166,7 +167,13 @@ class GpsIntegrationController extends Controller
             ->with('success', 'Overlabels GPS disconnected.');
     }
 
-    public function resetDistance(): JsonResponse
+    /**
+     * Reset the CURRENT session distance and stats to 0. Low-stakes: the
+     * cumulative odometer and last position are left untouched, so the session
+     * simply restarts counting from here. (Sessions also reset themselves on
+     * the next session_start; this is for mid-session corrections.)
+     */
+    public function resetSession(): JsonResponse
     {
         $user = auth()->user();
 
@@ -178,10 +185,61 @@ class GpsIntegrationController extends Controller
             return response()->json(['error' => 'Not connected.'], 404);
         }
 
-        // Reset distance controls to 0
+        $this->resetControls($user, [
+            'session_distance',
+            'session_max_speed',
+            'session_avg_speed',
+            'session_duration',
+        ]);
+
+        // Clear only the per-session accumulators; leave cumulative distance and
+        // last position alone. Restamp the session start so duration counts from now.
+        $settings = $integration->settings ?? [];
+        unset(
+            $settings['session_distance_km'],
+            $settings['session_max_speed_ms'],
+            $settings['session_speed_sum_ms'],
+            $settings['session_speed_count'],
+        );
+        $settings['session_started_at_unix'] = now()->timestamp;
+        $integration->settings = $settings;
+        $integration->save();
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Reset the LIFETIME (cumulative) distance to 0. Destructive and
+     * unrecoverable: this is the all-time odometer. Lifetime distance lives only
+     * in the `distance` control value, so we zero that and keep the last
+     * position - the odometer just restarts from the current spot.
+     */
+    public function resetLifetime(): JsonResponse
+    {
+        $user = auth()->user();
+
+        $integration = ExternalIntegration::where('user_id', $user->id)
+            ->where('service', 'gps')
+            ->first();
+
+        if (! $integration) {
+            return response()->json(['error' => 'Not connected.'], 404);
+        }
+
+        $this->resetControls($user, ['distance']);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Zero the given GPS control keys and broadcast each change so overlays
+     * update live.
+     */
+    private function resetControls(User $user, array $keys): void
+    {
         $controls = OverlayControl::where('user_id', $user->id)
             ->where('source', 'gps')
-            ->where('key', 'distance')
+            ->whereIn('key', $keys)
             ->where('source_managed', true)
             ->with('template')
             ->get();
@@ -201,13 +259,5 @@ class GpsIntegrationController extends Controller
                 $user->twitch_id,
             );
         }
-
-        // Clear last position from settings
-        $settings = $integration->settings ?? [];
-        unset($settings['last_lat'], $settings['last_lng']);
-        $integration->settings = $settings;
-        $integration->save();
-
-        return response()->json(['status' => 'ok']);
     }
 }

--- a/app/Services/External/Drivers/GpsServiceDriver.php
+++ b/app/Services/External/Drivers/GpsServiceDriver.php
@@ -8,9 +8,24 @@ use App\Models\ExternalIntegration;
 use App\Services\External\NormalizedExternalEvent;
 use App\Services\Location\GeoMath;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class GpsServiceDriver implements ExternalServiceDriver, StatefulExternalServiceDriver
 {
+    /**
+     * Reject any ping whose distance from the previous fix implies a speed
+     * faster than this. Catches GPS "teleports" (null-island fixes, garbage
+     * coordinates) that would otherwise inject thousands of phantom km. Well
+     * above any real car/train speed, so legitimate movement is never dropped.
+     */
+    private const MAX_PLAUSIBLE_KMH = 400.0;
+
+    /**
+     * Ignore sub-metre jitter so a stationary device doesn't slowly accrue
+     * distance from GPS noise.
+     */
+    private const MIN_DELTA_KM = 0.001;
+
     public function getServiceKey(): string
     {
         return 'gps';
@@ -206,102 +221,142 @@ class GpsServiceDriver implements ExternalServiceDriver, StatefulExternalService
         NormalizedExternalEvent $event,
         array &$updates
     ): void {
-        $settings = $integration->settings ?? [];
+        $type = $event->getEventType();
+        $raw = $event->getRaw();
 
-        if ($event->getEventType() === 'session_start') {
-            $this->resetSessionState($integration, $settings, $event->getRaw()['session_id'] ?? null);
+        if ($type === 'session_start') {
+            $this->mutateSettingsLocked($integration, function (array &$settings) use ($raw) {
+                $this->resetSessionState($settings, $raw['session_id'] ?? null);
+            });
             $updates['session_distance'] = '0';
             $updates['session_max_speed'] = '0';
             $updates['session_avg_speed'] = '0';
             $updates['session_duration'] = '0';
+
             return;
         }
 
-        if ($event->getEventType() === 'session_end') {
+        if ($type === 'session_end') {
             // Freeze the final duration so overlays show the total session length
-            // even after pings stop arriving.
-            $startedAt = $settings['session_started_at_unix'] ?? null;
+            // even after pings stop arriving. Read-only, no lock needed.
+            $startedAt = ($integration->settings ?? [])['session_started_at_unix'] ?? null;
             if ($startedAt !== null) {
                 $updates['session_duration'] = (string) max(0, now()->timestamp - (int) $startedAt);
             }
+
             return;
         }
 
-        if ($event->getEventType() !== 'location_update') {
+        if ($type !== 'location_update') {
             return;
         }
 
-        $raw = $event->getRaw();
         $lat = $raw['latitude'] ?? $raw['lat'] ?? null;
         $lng = $raw['longitude'] ?? $raw['lng'] ?? $raw['lon'] ?? null;
 
-        if ($lat === null || $lng === null) {
+        // A ping with no usable coordinate, or one outside the valid lat/lng
+        // range (garbage like lat=1, lon=1e150), can't drive distance or
+        // position. Drop the position-derived control updates so we never
+        // broadcast a junk fix.
+        if ($lat === null || $lng === null || ! $this->isValidCoordinate((float) $lat, (float) $lng)) {
+            $this->dropPositionUpdates($updates);
+
             return;
         }
 
         $lat = (float) $lat;
         $lng = (float) $lng;
-        $sessionId = $raw['session_id'] ?? null;
+        $fixAt = isset($raw['timestamp'])
+            ? (int) $raw['timestamp']
+            : (isset($raw['time']) ? (int) $raw['time'] : now()->timestamp);
 
-        // If the incoming session_id doesn't match what we've been tracking
-        // (session_start lost, stale state, first deployment), treat this ping
-        // as the start of a fresh session.
-        $trackedSessionId = $settings['session_id'] ?? null;
-        if ($sessionId !== null && $trackedSessionId !== $sessionId) {
-            $this->resetSessionState($integration, $settings, $sessionId);
-            $trackedSessionId = $sessionId;
-        }
+        // All reads and writes of the per-session accumulators happen under a
+        // row lock so overlapping webhook requests (rapid pings, settings_sync)
+        // can't clobber each other's updates — that lost-update race is how a
+        // session reset silently got reverted and the counter ran away.
+        $rejected = false;
+        $this->mutateSettingsLocked($integration, function (array &$settings) use (&$updates, &$rejected, $raw, $lat, $lng, $fixAt) {
+            $sessionId = $raw['session_id'] ?? null;
 
-        $lastLat = $settings['last_lat'] ?? null;
-        $lastLng = $settings['last_lng'] ?? null;
-
-        $deltaKm = 0.0;
-        if ($lastLat !== null && $lastLng !== null) {
-            $deltaKm = GeoMath::haversineDistance((float) $lastLat, (float) $lastLng, $lat, $lng);
-            if ($deltaKm > 0.001) {
-                $updates['distance'] = ['action' => 'add', 'amount' => round($deltaKm, 4)];
-            } else {
-                $deltaKm = 0.0;
+            // New session_id (session_start lost, stale state, first deploy):
+            // treat this ping as the start of a fresh session.
+            if ($sessionId !== null && ($settings['session_id'] ?? null) !== $sessionId) {
+                $this->resetSessionState($settings, $sessionId);
             }
+
+            $lastLat = $settings['last_lat'] ?? null;
+            $lastLng = $settings['last_lng'] ?? null;
+            $lastFixAt = $settings['last_fix_at_unix'] ?? null;
+
+            $deltaKm = 0.0;
+            if ($lastLat !== null && $lastLng !== null) {
+                $deltaKm = GeoMath::haversineDistance((float) $lastLat, (float) $lastLng, $lat, $lng);
+
+                // Teleport guard: if the implied speed is physically impossible,
+                // this is a bad fix. Reject it without advancing position so the
+                // next good ping measures from the last real location.
+                if ($lastFixAt !== null) {
+                    $elapsed = max(1, $fixAt - (int) $lastFixAt);
+                    $impliedKmh = $deltaKm / ($elapsed / 3600);
+                    if ($impliedKmh > self::MAX_PLAUSIBLE_KMH) {
+                        $rejected = true;
+
+                        return;
+                    }
+                }
+
+                if ($deltaKm > self::MIN_DELTA_KM) {
+                    $updates['distance'] = ['action' => 'add', 'amount' => round($deltaKm, 4)];
+                } else {
+                    $deltaKm = 0.0;
+                }
+            }
+
+            // Per-session distance (replacement, not add — we hold the accumulator in settings).
+            $sessionDistanceKm = (float) ($settings['session_distance_km'] ?? 0.0) + $deltaKm;
+            $settings['session_distance_km'] = $sessionDistanceKm;
+            $updates['session_distance'] = (string) round($sessionDistanceKm, 4);
+
+            // Speed stats in raw m/s.
+            $speedMsRaw = $raw['speed'] ?? $raw['spd'] ?? null;
+            if ($speedMsRaw !== null) {
+                $speedMs = (float) $speedMsRaw;
+                $maxMs = max((float) ($settings['session_max_speed_ms'] ?? 0.0), $speedMs);
+                $sumMs = (float) ($settings['session_speed_sum_ms'] ?? 0.0) + $speedMs;
+                $count = (int) ($settings['session_speed_count'] ?? 0) + 1;
+
+                $settings['session_max_speed_ms'] = $maxMs;
+                $settings['session_speed_sum_ms'] = $sumMs;
+                $settings['session_speed_count'] = $count;
+
+                $updates['session_max_speed'] = (string) round($maxMs, 4);
+                $updates['session_avg_speed'] = (string) round($sumMs / $count, 4);
+            }
+
+            // Duration in seconds since session_start.
+            $startedAt = (int) ($settings['session_started_at_unix'] ?? $fixAt);
+            $updates['session_duration'] = (string) max(0, now()->timestamp - $startedAt);
+
+            $settings['last_lat'] = $lat;
+            $settings['last_lng'] = $lng;
+            $settings['last_fix_at_unix'] = $fixAt;
+        });
+
+        if ($rejected) {
+            $this->dropPositionUpdates($updates);
         }
-
-        // Per-session distance (replacement, not add — we hold the accumulator in settings).
-        $sessionDistanceKm = (float) ($settings['session_distance_km'] ?? 0.0) + $deltaKm;
-        $settings['session_distance_km'] = $sessionDistanceKm;
-        $updates['session_distance'] = (string) round($sessionDistanceKm, 4);
-
-        // Speed stats in raw m/s.
-        $speedMsRaw = $raw['speed'] ?? $raw['spd'] ?? null;
-        if ($speedMsRaw !== null) {
-            $speedMs = (float) $speedMsRaw;
-            $maxMs = max((float) ($settings['session_max_speed_ms'] ?? 0.0), $speedMs);
-            $sumMs = (float) ($settings['session_speed_sum_ms'] ?? 0.0) + $speedMs;
-            $count = (int) ($settings['session_speed_count'] ?? 0) + 1;
-
-            $settings['session_max_speed_ms'] = $maxMs;
-            $settings['session_speed_sum_ms'] = $sumMs;
-            $settings['session_speed_count'] = $count;
-
-            $updates['session_max_speed'] = (string) round($maxMs, 4);
-            $updates['session_avg_speed'] = (string) round($sumMs / $count, 4);
-        }
-
-        // Duration in seconds since session_start.
-        $startedAt = (int) ($settings['session_started_at_unix'] ?? now()->timestamp);
-        $updates['session_duration'] = (string) max(0, now()->timestamp - $startedAt);
-
-        $integration->settings = array_merge($settings, [
-            'last_lat' => $lat,
-            'last_lng' => $lng,
-        ]);
-        $integration->save();
     }
 
     /**
      * Wipe all per-session running counters and stamp a new session_started_at.
-     * Leaves last_lat/last_lng alone — those drive the cumulative `distance` control.
+     * Also clears last_lat/last_lng so the first ping of the new session
+     * establishes its own baseline instead of differencing against the previous
+     * session's end point (which injected phantom cross-session distance into
+     * both the session and cumulative counters).
+     *
+     * Mutates $settings in place; the caller owns persistence (under lock).
      */
-    private function resetSessionState(ExternalIntegration $integration, array &$settings, ?string $sessionId): void
+    private function resetSessionState(array &$settings, ?string $sessionId): void
     {
         $settings = array_merge($settings, [
             'session_id' => $sessionId,
@@ -311,7 +366,57 @@ class GpsServiceDriver implements ExternalServiceDriver, StatefulExternalService
             'session_speed_sum_ms' => 0.0,
             'session_speed_count' => 0,
         ]);
-        $integration->settings = $settings;
-        $integration->save();
+
+        unset($settings['last_lat'], $settings['last_lng'], $settings['last_fix_at_unix']);
+    }
+
+    /**
+     * Read-modify-write the integration's settings JSONB under a row lock so
+     * concurrent GPS webhook requests for the same integration serialize
+     * instead of clobbering each other. The caller's in-memory model is synced
+     * to the committed state so a later last_received_at write doesn't revert it.
+     */
+    private function mutateSettingsLocked(ExternalIntegration $integration, callable $mutator): void
+    {
+        DB::transaction(function () use ($integration, $mutator) {
+            $fresh = ExternalIntegration::whereKey($integration->getKey())
+                ->lockForUpdate()
+                ->first();
+
+            if ($fresh === null) {
+                return;
+            }
+
+            $settings = $fresh->settings ?? [];
+            $mutator($settings);
+            $fresh->settings = $settings;
+            $fresh->save();
+
+            // Sync the caller's model to committed state and mark it clean so the
+            // controller's subsequent last_received_at update only touches that
+            // column, never rewriting (stale) settings.
+            $integration->setRawAttributes($fresh->getAttributes(), true);
+        });
+    }
+
+    /**
+     * A coordinate is usable only inside the real lat/lng range. Exact (0,0)
+     * is the classic "no fix yet" sentinel, so it's rejected too.
+     */
+    private function isValidCoordinate(float $lat, float $lng): bool
+    {
+        return is_finite($lat) && is_finite($lng)
+            && $lat >= -90.0 && $lat <= 90.0
+            && $lng >= -180.0 && $lng <= 180.0
+            && ! ($lat === 0.0 && $lng === 0.0);
+    }
+
+    /**
+     * Strip position-derived control updates so a rejected/garbage fix is never
+     * broadcast to overlays or the public map.
+     */
+    private function dropPositionUpdates(array &$updates): void
+    {
+        unset($updates['lat'], $updates['lng'], $updates['speed'], $updates['bearing']);
     }
 }

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,16 @@
 # CHANGELOG JUNE 2026
 
+## June 13th, 2026 - fix(gps): stop GPS distance running away, and split session vs lifetime reset
+
+A streamer's `c:gps:session_distance` showed 5785 km after 18 metres of actual movement. Tracing prod data, the cause was a class of bugs around the GPS distance accumulators, not a single typo: the phone occasionally emits garbage fixes (confirmed in prod: `lat=1, lon=1e150`, and near-null-island coordinates), and nothing on the backend defended against them. A single bad fix near latitude 0 differenced against a real location in NL injects ~5783 km in one haversine delta - which is exactly the magic number that kept appearing.
+
+- **Bad-fix validation gate** (`GpsServiceDriver::beforeControlUpdates`). Pings are now rejected when the coordinate is out of range (catches `lon=1e150`), is exact `(0,0)` null-island, or implies a physically impossible speed from the previous fix (> 400 km/h - a teleport). Rejected fixes don't touch distance, don't advance the last position, and aren't broadcast. A new `last_fix_at_unix` is stored to power the speed check.
+- **Clean per-session baseline.** `resetSessionState()` now also clears `last_lat`/`last_lng`, so the first ping of a new session establishes its own baseline instead of differencing against where the previous session ended (that was adding hundreds of phantom km per session, e.g. a London->NL session boundary = +326 km). Confirmed: a new `session_start` (or the first ping of a new `session_id`) resets `session_distance` to 0.
+- **Lost-update race fixed.** All reads-and-writes of the integration's `settings` JSONB now go through `mutateSettingsLocked()` (transaction + `lockForUpdate`), so overlapping webhook requests can't clobber each other - which is how a session reset silently got reverted and the counter ran away.
+- **Reset split into two actions** (was one casually-worded button that quietly wiped everything). `reset-session` (low-stakes: zeroes the current session's distance/speed/duration, leaves the lifetime odometer and last position alone) and `reset-lifetime` (destructive: zeroes the all-time cumulative distance only). The lifetime reset lives in a red-bordered box and is gated behind a type-to-confirm dialog (must type `RESET`). Copy rewritten to stop implying the lifetime wipe is a "start of trip/stream" convenience.
+- Tests: bad-fix rejection (out-of-range, null-island, teleport), session baseline reset, and the two split reset endpoints. GPS suite green (25 passed); Pint, ESLint, and the build are clean.
+- The legacy `gps_pings` table is unused (no writer); ignored here.
+
 ## June 13th, 2026 - ops(metering): turn on broadcast metering in prod (observe-only)
 
 Flipped prod to start counting. `config/deploy.yml` now sets `BROADCAST_CONNECTION: metered` (wraps the reverb driver with `MeteredBroadcaster`) plus `METERING_ENABLED: "true"` and an empty `METERING_FREE_MONTHLY_BROADCASTS` (no enforced cap - observe-only). All three are plaintext `env.clear` values, not secrets. Counters land in the existing `overlabels-redis` accessory.

--- a/resources/js/pages/settings/integrations/gps.vue
+++ b/resources/js/pages/settings/integrations/gps.vue
@@ -13,6 +13,14 @@ import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { type BreadcrumbItem } from '@/types';
 
 interface IntegrationData {
@@ -111,13 +119,34 @@ function save() {
   });
 }
 
-async function resetDistance() {
-  if (!confirm('Reset distance to 0? This cannot be undone.')) return;
+async function resetSession() {
+  if (!confirm('Reset the current session distance and stats to 0? Your lifetime total is not affected.')) return;
   resetting.value = true;
   try {
-    await axios.post('/settings/integrations/overlabels-mobile/reset-distance');
+    await axios.post('/settings/integrations/overlabels-mobile/reset-session');
+    toastType.value = 'success';
+    toastMessage.value = 'Session distance reset.';
   } finally {
     resetting.value = false;
+  }
+}
+
+const lifetimeDialogOpen = ref(false);
+const lifetimeConfirmText = ref('');
+const resettingLifetime = ref(false);
+const lifetimeConfirmed = computed(() => lifetimeConfirmText.value.trim().toUpperCase() === 'RESET');
+
+async function resetLifetime() {
+  if (!lifetimeConfirmed.value) return;
+  resettingLifetime.value = true;
+  try {
+    await axios.post('/settings/integrations/overlabels-mobile/reset-lifetime');
+    toastType.value = 'success';
+    toastMessage.value = 'Lifetime distance reset to 0.';
+    lifetimeDialogOpen.value = false;
+    lifetimeConfirmText.value = '';
+  } finally {
+    resettingLifetime.value = false;
   }
 }
 
@@ -350,19 +379,43 @@ function formatDate(iso: string | null): string {
         <!-- Reset Distance -->
         <template v-if="integration.connected">
           <Separator />
+
+          <!-- Session reset: low-stakes -->
           <div class="space-y-2">
-            <p class="font-medium text-sm">Reset distance</p>
-            <p class="text-muted-foreground text-sm">
-              Reset the accumulated GPS distance back to 0 km. Useful at the start of a new trip or stream.
+            <p class="font-medium text-sm">Reset session distance</p>
+            <p class="text-foreground text-sm">
+              Zero out the current session's distance, speed and duration stats. Your lifetime total is
+              untouched. Note: a new session already resets these automatically - this is for fixing a
+              session mid-stream.
             </p>
             <Button
               variant="outline"
               size="sm"
               type="button"
+              class="cursor-pointer"
               :disabled="resetting"
-              @click="resetDistance"
+              @click="resetSession"
             >
-              {{ resetting ? 'Resetting...' : 'Reset distance to 0' }}
+              {{ resetting ? 'Resetting...' : 'Reset session distance' }}
+            </Button>
+          </div>
+
+          <!-- Lifetime reset: destructive -->
+          <div class="space-y-2 rounded-md border border-destructive/40 p-4">
+            <p class="font-medium text-sm text-destructive">Reset lifetime distance</p>
+            <p class="text-foreground text-sm">
+              This wipes your all-time cumulative distance back to 0 km. It is permanent and cannot be
+              undone - every kilometre you have ever logged is gone. This is not the same as starting a
+              new trip or stream (use the session reset above, or just start a new session).
+            </p>
+            <Button
+              variant="destructive"
+              size="sm"
+              type="button"
+              class="cursor-pointer"
+              @click="lifetimeDialogOpen = true"
+            >
+              Reset lifetime distance
             </Button>
           </div>
         </template>
@@ -405,5 +458,51 @@ function formatDate(iso: string | null): string {
     </SettingsLayout>
 
     <RekaToast v-if="toastMessage" :message="toastMessage" :type="toastType" @dismiss="toastMessage = null" />
+
+    <!-- Lifetime reset: type-to-confirm guard -->
+    <Dialog v-model:open="lifetimeDialogOpen">
+      <DialogContent class="max-w-md">
+        <DialogHeader>
+          <DialogTitle class="text-destructive">Reset lifetime distance?</DialogTitle>
+          <DialogDescription class="text-foreground">
+            This permanently wipes your all-time cumulative distance back to 0 km. It cannot be undone.
+            Your current session distance is not affected.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div class="space-y-2">
+          <Label for="lifetime-confirm" class="text-sm">
+            Type <span class="font-mono font-semibold">RESET</span> to confirm.
+          </Label>
+          <Input
+            id="lifetime-confirm"
+            v-model="lifetimeConfirmText"
+            autocomplete="off"
+            placeholder="RESET"
+            @keyup.enter="resetLifetime"
+          />
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            type="button"
+            class="cursor-pointer"
+            @click="lifetimeDialogOpen = false"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            type="button"
+            class="cursor-pointer"
+            :disabled="!lifetimeConfirmed || resettingLifetime"
+            @click="resetLifetime"
+          >
+            {{ resettingLifetime ? 'Resetting...' : 'Reset lifetime distance' }}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   </AppLayout>
 </template>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -73,7 +73,8 @@ Route::middleware('auth.redirect')->group(function () {
         Route::post('/overlabels-mobile', [GpsIntegrationController::class, 'save'])->name('overlabels-mobile.save');
         Route::post('/overlabels-mobile/regenerate-token', [GpsIntegrationController::class, 'regenerateToken'])->name('overlabels-mobile.regenerate-token');
         Route::delete('/overlabels-mobile', [GpsIntegrationController::class, 'disconnect'])->name('overlabels-mobile.disconnect');
-        Route::post('/overlabels-mobile/reset-distance', [GpsIntegrationController::class, 'resetDistance'])->name('overlabels-mobile.reset-distance');
+        Route::post('/overlabels-mobile/reset-session', [GpsIntegrationController::class, 'resetSession'])->name('overlabels-mobile.reset-session');
+        Route::post('/overlabels-mobile/reset-lifetime', [GpsIntegrationController::class, 'resetLifetime'])->name('overlabels-mobile.reset-lifetime');
 
         Route::get('/streamlabs', [StreamLabsIntegrationController::class, 'show'])->name('streamlabs.show');
         Route::get('/streamlabs/redirect', [StreamLabsIntegrationController::class, 'redirect'])->name('streamlabs.redirect');

--- a/tests/Feature/GpsWebhookTest.php
+++ b/tests/Feature/GpsWebhookTest.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Events\ControlValueUpdated;
+use App\Models\ExternalEvent;
 use App\Models\ExternalIntegration;
 use App\Models\OverlayControl;
 use App\Models\User;
+use App\Services\External\Drivers\GpsServiceDriver;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Event;
@@ -273,6 +275,103 @@ test('second ping accumulates haversine distance', function () {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
+// Bad-fix rejection
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('out-of-range coordinate is rejected: no distance, no position broadcast', function () {
+    Event::fake([ControlValueUpdated::class]);
+
+    [$user, $integration] = makeMobileIntegration('test-mobile-token', [
+        'last_lat' => 52.3676,
+        'last_lng' => 4.9041,
+        'last_fix_at_unix' => time() - 5,
+        'session_distance_km' => 3.0,
+    ]);
+
+    foreach (['distance', 'session_distance', 'lat', 'lng'] as $key) {
+        OverlayControl::provisionServiceControl($user, 'gps', [
+            'key' => $key,
+            'type' => in_array($key, ['distance', 'session_distance']) ? 'number' : 'text',
+            'label' => $key,
+            'value' => $key === 'distance' ? '10' : ($key === 'session_distance' ? '3' : 'prev'),
+        ]);
+    }
+
+    // lon = 1e150 style garbage (out of the valid -180..180 range).
+    postMobile($integration->webhook_token, mobilePayload([
+        'latitude' => 1.0,
+        'longitude' => 1.0e150,
+        'timestamp' => time(),
+        'serial' => '2',
+    ]))->assertStatus(200);
+
+    // Distance counters untouched, position controls not overwritten with junk.
+    $this->assertDatabaseHas('overlay_controls', ['user_id' => $user->id, 'source' => 'gps', 'key' => 'distance', 'value' => '10']);
+    $this->assertDatabaseHas('overlay_controls', ['user_id' => $user->id, 'source' => 'gps', 'key' => 'session_distance', 'value' => '3']);
+    $this->assertDatabaseHas('overlay_controls', ['user_id' => $user->id, 'source' => 'gps', 'key' => 'lat', 'value' => 'prev']);
+
+    // Last good position is preserved for the next real ping.
+    $integration->refresh();
+    expect((float) $integration->settings['last_lat'])->toBe(52.3676);
+});
+
+test('null-island (0,0) fix is rejected', function () {
+    Event::fake([ControlValueUpdated::class]);
+
+    [$user, $integration] = makeMobileIntegration('test-mobile-token', [
+        'last_lat' => 52.3676,
+        'last_lng' => 4.9041,
+        'last_fix_at_unix' => time() - 5,
+    ]);
+
+    OverlayControl::provisionServiceControl($user, 'gps', [
+        'key' => 'distance', 'type' => 'number', 'label' => 'Distance', 'value' => '0',
+    ]);
+
+    postMobile($integration->webhook_token, mobilePayload([
+        'latitude' => 0,
+        'longitude' => 0,
+        'timestamp' => time(),
+        'serial' => '2',
+    ]))->assertStatus(200);
+
+    $this->assertDatabaseHas('overlay_controls', ['user_id' => $user->id, 'source' => 'gps', 'key' => 'distance', 'value' => '0']);
+    $integration->refresh();
+    expect((float) $integration->settings['last_lat'])->toBe(52.3676);
+});
+
+test('teleport fix (impossible implied speed) is rejected', function () {
+    Event::fake([ControlValueUpdated::class]);
+
+    $ts = time();
+
+    // Last good fix in Amsterdam, 10s ago.
+    [$user, $integration] = makeMobileIntegration('test-mobile-token', [
+        'last_lat' => 52.3676,
+        'last_lng' => 4.9041,
+        'last_fix_at_unix' => $ts - 10,
+        'session_distance_km' => 1.5,
+    ]);
+
+    OverlayControl::provisionServiceControl($user, 'gps', [
+        'key' => 'distance', 'type' => 'number', 'label' => 'Distance', 'value' => '1.5',
+    ]);
+
+    // ~5800 km away in 10 seconds -> millions of km/h. Valid coordinate, but a teleport.
+    postMobile($integration->webhook_token, mobilePayload([
+        'latitude' => 0.1,
+        'longitude' => 0.1,
+        'timestamp' => $ts,
+        'serial' => '2',
+    ]))->assertStatus(200);
+
+    // Distance unchanged, last position NOT advanced to the bad point.
+    $this->assertDatabaseHas('overlay_controls', ['user_id' => $user->id, 'source' => 'gps', 'key' => 'distance', 'value' => '1.5']);
+    $integration->refresh();
+    expect((float) $integration->settings['last_lat'])->toBe(52.3676);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
 // Speed unit conversion
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -312,35 +411,126 @@ test('speed_unit setting does not affect stored speed (always raw m/s)', functio
 // Distance reset
 // ──────────────────────────────────────────────────────────────────────────────
 
-test('reset distance endpoint clears distance and position', function () {
+test('reset-session zeroes session distance/stats but leaves lifetime and position intact', function () {
     Event::fake([ControlValueUpdated::class]);
 
     [$user, $integration] = makeMobileIntegration('test-mobile-token', [
         'last_lat' => 52.3676,
         'last_lng' => 4.9041,
+        'last_fix_at_unix' => time(),
+        'session_distance_km' => 5785.36,
+        'session_max_speed_ms' => 30.0,
+        'session_speed_sum_ms' => 120.0,
+        'session_speed_count' => 4,
     ]);
 
     OverlayControl::provisionServiceControl($user, 'gps', [
-        'key' => 'distance', 'type' => 'number', 'label' => 'Distance', 'value' => '42.5',
+        'key' => 'distance', 'type' => 'number', 'label' => 'distance', 'value' => '4321',
+    ]);
+    foreach (['session_distance', 'session_max_speed', 'session_avg_speed', 'session_duration'] as $key) {
+        OverlayControl::provisionServiceControl($user, 'gps', [
+            'key' => $key, 'type' => 'number', 'label' => $key, 'value' => '999',
+        ]);
+    }
+
+    $this->actingAs($user)
+        ->post('/settings/integrations/overlabels-mobile/reset-session')
+        ->assertStatus(200)
+        ->assertJson(['status' => 'ok']);
+
+    foreach (['session_distance', 'session_max_speed', 'session_avg_speed', 'session_duration'] as $key) {
+        $this->assertDatabaseHas('overlay_controls', [
+            'user_id' => $user->id, 'source' => 'gps', 'key' => $key, 'value' => '0',
+        ]);
+    }
+
+    // Lifetime odometer untouched.
+    $this->assertDatabaseHas('overlay_controls', [
+        'user_id' => $user->id, 'source' => 'gps', 'key' => 'distance', 'value' => '4321',
+    ]);
+
+    $integration->refresh();
+    expect($integration->settings)->not()->toHaveKey('session_distance_km');
+    expect($integration->settings)->not()->toHaveKey('session_speed_count');
+    // Position is preserved so the session keeps measuring from here.
+    expect((float) $integration->settings['last_lat'])->toBe(52.3676);
+});
+
+test('reset-lifetime zeroes the cumulative distance only', function () {
+    Event::fake([ControlValueUpdated::class]);
+
+    [$user, $integration] = makeMobileIntegration('test-mobile-token', [
+        'last_lat' => 52.3676,
+        'last_lng' => 4.9041,
+        'session_distance_km' => 12.0,
+    ]);
+
+    OverlayControl::provisionServiceControl($user, 'gps', [
+        'key' => 'distance', 'type' => 'number', 'label' => 'distance', 'value' => '8000',
+    ]);
+    OverlayControl::provisionServiceControl($user, 'gps', [
+        'key' => 'session_distance', 'type' => 'number', 'label' => 'session_distance', 'value' => '12',
     ]);
 
     $this->actingAs($user)
-        ->post('/settings/integrations/overlabels-mobile/reset-distance')
+        ->post('/settings/integrations/overlabels-mobile/reset-lifetime')
         ->assertStatus(200)
         ->assertJson(['status' => 'ok']);
 
     $this->assertDatabaseHas('overlay_controls', [
-        'user_id' => $user->id,
-        'source' => 'gps',
-        'key' => 'distance',
-        'value' => '0',
+        'user_id' => $user->id, 'source' => 'gps', 'key' => 'distance', 'value' => '0',
+    ]);
+    // Session distance is independent and untouched.
+    $this->assertDatabaseHas('overlay_controls', [
+        'user_id' => $user->id, 'source' => 'gps', 'key' => 'session_distance', 'value' => '12',
     ]);
 
+    Event::assertDispatched(ControlValueUpdated::class);
+});
+
+test('session_start clears last position so first ping starts a clean baseline', function () {
+    Event::fake([ControlValueUpdated::class]);
+
+    // Previous session ended in Amsterdam.
+    [$user, $integration] = makeMobileIntegration('test-mobile-token', [
+        'last_lat' => 52.3676,
+        'last_lng' => 4.9041,
+        'last_fix_at_unix' => time() - 86400,
+        'session_distance_km' => 12.0,
+    ]);
+
+    OverlayControl::provisionServiceControl($user, 'gps', [
+        'key' => 'distance', 'type' => 'number', 'label' => 'Distance', 'value' => '12',
+    ]);
+    OverlayControl::provisionServiceControl($user, 'gps', [
+        'key' => 'session_distance', 'type' => 'number', 'label' => 'Session Distance', 'value' => '12',
+    ]);
+
+    $sessionId = 'fresh-baseline-session';
+
+    postMobile($integration->webhook_token, [
+        'event' => 'session_start',
+        'session_id' => $sessionId,
+        'timestamp' => (string) time(),
+    ])->assertStatus(200);
+
+    // Baseline wiped: a new session must not difference against the old endpoint.
     $integration->refresh();
     expect($integration->settings)->not()->toHaveKey('last_lat');
-    expect($integration->settings)->not()->toHaveKey('last_lng');
+    expect((float) $integration->settings['session_distance_km'])->toBe(0.0);
 
-    Event::assertDispatched(ControlValueUpdated::class);
+    // First real ping in a far-away city adds 0 (it sets the baseline), not a phantom jump.
+    postMobile($integration->webhook_token, mobilePayload([
+        'latitude' => 51.5072,
+        'longitude' => -0.1276, // London
+        'timestamp' => time(),
+        'serial' => '1',
+        'session_id' => $sessionId,
+    ]))->assertStatus(200);
+
+    $this->assertDatabaseHas('overlay_controls', [
+        'user_id' => $user->id, 'source' => 'gps', 'key' => 'session_distance', 'value' => '0',
+    ]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -375,7 +565,7 @@ test('connect creates integration with auto-generated token and provisions contr
         ->where('source_managed', true)
         ->count();
 
-    $expected = count((new \App\Services\External\Drivers\GpsServiceDriver())->getAutoProvisionedControls());
+    $expected = count((new GpsServiceDriver)->getAutoProvisionedControls());
     expect($controlCount)->toBe($expected);
 });
 
@@ -573,7 +763,7 @@ test('location_update with session_id stores it in payload', function () {
     ]), ['session_id' => $sessionId]))
         ->assertStatus(200);
 
-    $event = \App\Models\ExternalEvent::where('user_id', $user->id)
+    $event = ExternalEvent::where('user_id', $user->id)
         ->where('message_id', "gps_{$ts}_1")
         ->first();
 


### PR DESCRIPTION
## Problem

A streamer's `c:gps:session_distance` showed **5785 km after 18 metres** of real movement. Tracing prod data, the cause was a class of bugs around the GPS distance accumulators, not a single typo:

- The phone intermittently emits garbage fixes (confirmed in prod: `lat=1, lon=1e150`, and near-null-island coordinates).
- A single bad fix near latitude 0 differenced against a real NL location injects ~5783 km in one haversine delta - exactly the magic number that kept appearing.
- Nothing on the backend defended against it.

## Fixes

- **Bad-fix validation gate** (`GpsServiceDriver::beforeControlUpdates`): reject out-of-range coords, exact `(0,0)` null-island, and teleports (implied speed > 400 km/h). Rejected fixes don't touch distance, don't advance position, and aren't broadcast. Stores `last_fix_at_unix` for the speed check.
- **Clean per-session baseline**: `resetSessionState()` now clears `last_lat`/`last_lng`, so a new session starts its own baseline instead of differencing against the previous session's endpoint (was adding hundreds of phantom km per session boundary).
- **Lost-update race fixed**: all settings-JSONB writes go through `mutateSettingsLocked()` (transaction + `lockForUpdate`), so overlapping webhook requests can't clobber a reset.
- **Reset split into two actions**: `reset-session` (low-stakes) and `reset-lifetime` (destructive, gated behind a type-to-confirm `RESET` dialog). Copy rewritten so the lifetime wipe is no longer dressed up as a "start of trip" convenience.

## Tests

Added coverage for bad-fix rejection (out-of-range, null-island, teleport), session baseline reset, and both reset endpoints. GPS suite green (25 passed); Pint, ESLint, and build clean.

## Prod

The runaway value on the affected user was already zeroed out manually (session controls + accumulators), lifetime odometer left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)