### PR TITLE
feat(metering): meter inbound events, not outbound broadcasts

### DIFF
--- a/app/Http/Controllers/Api/ExternalWebhookController.php
+++ b/app/Http/Controllers/Api/ExternalWebhookController.php
@@ -6,6 +6,7 @@ use App\Contracts\StatefulExternalServiceDriver;
 use App\Http\Controllers\Controller;
 use App\Models\ExternalEvent;
 use App\Models\ExternalIntegration;
+use App\Services\EventMeter;
 use App\Services\External\ExternalAlertService;
 use App\Services\External\ExternalControlService;
 use App\Services\External\ExternalServiceRegistry;
@@ -169,6 +170,14 @@ class ExternalWebhookController extends Controller
             ]);
 
             return response()->json(['status' => 'duplicate']);
+        }
+
+        // 8b. Meter the inbound event (the usage unit pricing is set against).
+        // One stored event = one count, regardless of how many overlays/controls
+        // it fans out to. Duplicates returned above; settings_sync returned
+        // earlier; test-mode traffic is excluded.
+        if (! $integration->test_mode) {
+            app(EventMeter::class)->record($user->id);
         }
 
         // 9. Update service-managed controls

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -8,6 +8,7 @@ use App\Models\OverlayTemplate;
 use App\Models\TwitchEvent;
 use App\Models\Update;
 use App\Services\BroadcastMeter;
+use App\Services\EventMeter;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Http\Request;
@@ -59,7 +60,9 @@ class DashboardController extends Controller
             'recentUpdates' => $recentUpdates,
             'needsOnboarding' => $request->session()->pull('preview_onboarding', false) || (! $user->isOnboarded() && ! $user->hasAlertMappings()),
             'twitchId' => $user->twitch_id,
-            'usage' => $user->twitch_id ? app(BroadcastMeter::class)->summaryFor((string) $user->twitch_id) : null,
+            'usage' => config('metering.meter_mode', 'both') === 'broadcast'
+                ? ($user->twitch_id ? app(BroadcastMeter::class)->summaryFor((string) $user->twitch_id) : null)
+                : app(EventMeter::class)->summaryFor($user->id),
         ]);
     }
 

--- a/app/Http/Controllers/Settings/UsageController.php
+++ b/app/Http/Controllers/Settings/UsageController.php
@@ -4,21 +4,36 @@ namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;
 use App\Services\BroadcastMeter;
+use App\Services\EventMeter;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class UsageController extends Controller
 {
-    public function __construct(private readonly BroadcastMeter $meter) {}
+    public function __construct(
+        private readonly EventMeter $eventMeter,
+        private readonly BroadcastMeter $broadcastMeter,
+    ) {}
 
     public function index(Request $request): Response
     {
-        $twitchId = (string) $request->user()->twitch_id;
+        $user = $request->user();
+
+        // 'broadcast' mode still shows the legacy output count; otherwise the
+        // displayed usage is inbound events (the unit pricing is set against).
+        if (config('metering.meter_mode', 'both') === 'broadcast') {
+            $twitchId = (string) $user->twitch_id;
+
+            return Inertia::render('settings/Usage', [
+                'usage' => $this->broadcastMeter->summaryFor($twitchId),
+                'history' => $this->broadcastMeter->historyFor($twitchId, 6),
+            ]);
+        }
 
         return Inertia::render('settings/Usage', [
-            'usage' => $this->meter->summaryFor($twitchId),
-            'history' => $this->meter->historyFor($twitchId, 6),
+            'usage' => $this->eventMeter->summaryFor($user->id),
+            'history' => $this->eventMeter->historyFor($user->id, 6),
         ]);
     }
 }

--- a/app/Http/Controllers/TwitchEventSubController.php
+++ b/app/Http/Controllers/TwitchEventSubController.php
@@ -12,6 +12,7 @@ use App\Models\StreamState;
 use App\Models\TwitchEvent;
 use App\Models\User;
 use App\Models\UserEventsubSubscription;
+use App\Services\EventMeter;
 use App\Services\Expressions\AlertExpressionRenderer;
 use App\Services\LockdownService;
 use App\Services\StreamSessionService;
@@ -514,6 +515,12 @@ class TwitchEventSubController extends Controller
                 'twitch_timestamp' => now(),
                 'processed' => false,
             ]);
+
+            // Meter the inbound event (the usage unit pricing is set against).
+            // testCheer() synthetic events use a different path and are not counted.
+            if ($user) {
+                app(EventMeter::class)->record($user->id);
+            }
 
             // Clear relevant caches based on event type
             $this->refreshCachesForEvent($eventType, $broadcasterId);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use App\Observers\UserObserver;
 use App\Services\Bot\RateLimitLog as BotRateLimitLog;
 use App\Services\BroadcastMeter;
 use App\Services\DefaultTemplateProviderService;
+use App\Services\EventMeter;
 use App\Services\TemplateDataMapperService;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
@@ -45,6 +46,9 @@ class AppServiceProvider extends ServiceProvider
         // One BroadcastMeter per request so its fail-fast "redis down" flag is
         // shared across the dashboard share and the Usage page reads.
         $this->app->singleton(BroadcastMeter::class);
+
+        // Same per-request singleton treatment for the inbound-event meter.
+        $this->app->singleton(EventMeter::class);
 
         // Register Telescope only in local development
         // Use class_exists() to avoid autoload failure when Telescope is not installed (--no-dev)

--- a/app/Services/BroadcastMeter.php
+++ b/app/Services/BroadcastMeter.php
@@ -47,6 +47,12 @@ class BroadcastMeter
             return;
         }
 
+        // In 'input' mode the broadcast counter is retired; 'both' keeps it
+        // writing as an internal verification signal alongside the event meter.
+        if (config('metering.meter_mode', 'both') === 'input') {
+            return;
+        }
+
         $prefixes = config('metering.channels', ['alerts', 'twitch-events', 'lists']);
 
         $owners = [];

--- a/app/Services/EventMeter.php
+++ b/app/Services/EventMeter.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Support\Facades\Redis;
+
+/**
+ * Counts INBOUND events per user, per calendar month: GPS pings, donations,
+ * Twitch EventSub notifications - the actual activity a user generates.
+ *
+ * This is the meter pricing should be set against. Unlike outbound broadcasts
+ * (see {@see BroadcastMeter}), an inbound event is one event regardless of how
+ * many overlays a user has or how badly a control fans out - a user with 1
+ * overlay and a user with 200 produce the same ping count for the same ride.
+ * That decouples the bill from the broadcast implementation, so the fan-out can
+ * be fixed on its own schedule without ever touching anyone's usage number.
+ *
+ * Keyed by internal user_id (not twitch_id): the input boundaries always have
+ * the owning user in hand, and GPS-only users need not be Twitch-attributed.
+ *
+ * Mirrors BroadcastMeter's fail-fast Redis discipline: every touch goes through
+ * withRedis(), the first failure trips $redisDown so the rest short-circuit, and
+ * metering never breaks a request. Registered as a singleton so that flag is
+ * shared across a request (see AppServiceProvider).
+ */
+class EventMeter
+{
+    /**
+     * Set once a Redis op fails this request; subsequent ops skip Redis and
+     * return defaults rather than each paying the full connect timeout.
+     */
+    private bool $redisDown = false;
+
+    /**
+     * Increment a user's inbound-event counter for the current month.
+     *
+     * No-op when metering is disabled or running in 'broadcast'-only mode, so
+     * callers at the input boundaries can fire unconditionally.
+     */
+    public function record(int $userId, int $count = 1): void
+    {
+        if ($count < 1 || ! config('metering.enabled', true)) {
+            return;
+        }
+
+        if (config('metering.meter_mode', 'both') === 'broadcast') {
+            return;
+        }
+
+        $this->withRedis(function (Connection $redis) use ($userId, $count) {
+            $key = $this->key($userId);
+            $total = (int) $redis->incrby($key, $count);
+
+            // First write of the month: stamp a TTL so the key self-expires and
+            // we never need a scheduled reset job.
+            if ($total === $count) {
+                $redis->expire($key, (int) config('metering.ttl_days', 70) * 86400);
+            }
+
+            return null;
+        }, null);
+    }
+
+    /**
+     * Current event count for a user in the given month (default: now).
+     */
+    public function usageFor(int $userId, ?string $period = null): int
+    {
+        $value = $this->withRedis(
+            fn (Connection $redis) => $redis->get($this->key($userId, $period)),
+            null,
+        );
+
+        return $value === null ? 0 : (int) $value;
+    }
+
+    /**
+     * The most recent $months counters, newest first. One mget round-trip.
+     *
+     * The `broadcasts` array key is kept for frontend compatibility with the
+     * existing Usage history strip - the value now counts inbound events.
+     *
+     * @return array<int, array{period: string, broadcasts: int}>
+     */
+    public function historyFor(int $userId, int $months = 6): array
+    {
+        $periods = [];
+        $cursor = now()->startOfMonth();
+        for ($i = 0; $i < $months; $i++) {
+            $periods[] = $cursor->format('Y-m');
+            $cursor = $cursor->subMonthNoOverflow();
+        }
+
+        $keys = array_map(fn (string $period) => $this->key($userId, $period), $periods);
+
+        /** @var array<int, string|null> $values */
+        $values = $this->withRedis(
+            fn (Connection $redis) => $redis->mget($keys),
+            array_fill(0, count($keys), null),
+        );
+
+        $history = [];
+        foreach ($periods as $i => $period) {
+            $history[] = [
+                'period' => $period,
+                'broadcasts' => (int) ($values[$i] ?? 0),
+            ];
+        }
+
+        return $history;
+    }
+
+    /**
+     * The free-tier monthly event ceiling, or null when running observe-only.
+     */
+    public function freeLimit(): ?int
+    {
+        $limit = config('metering.free_monthly_events');
+
+        if ($limit === null || $limit === '') {
+            return null;
+        }
+
+        return (int) $limit;
+    }
+
+    /**
+     * Compact usage summary for the dashboard strip and Usage page. The
+     * `broadcasts` key is retained for frontend compatibility; it now carries
+     * the inbound-event count.
+     *
+     * @return array{broadcasts: int, limit: int|null, period: string}
+     */
+    public function summaryFor(int $userId): array
+    {
+        return [
+            'broadcasts' => $this->usageFor($userId),
+            'limit' => $this->freeLimit(),
+            'period' => now()->format('Y-m'),
+        ];
+    }
+
+    public function key(int $userId, ?string $period = null): string
+    {
+        $period ??= now()->format('Y-m');
+
+        return "metering:events:{$userId}:{$period}";
+    }
+
+    /**
+     * Run a Redis op, failing fast and non-fatally. Once anything fails this
+     * request, $redisDown short-circuits every later call. Metering is
+     * best-effort - a failure degrades to "uncounted"/zero, never a broken
+     * request or a hung page.
+     *
+     * @template T
+     *
+     * @param  callable(Connection): T  $op
+     * @param  T  $default
+     * @return T
+     */
+    private function withRedis(callable $op, mixed $default): mixed
+    {
+        if ($this->redisDown) {
+            return $default;
+        }
+
+        try {
+            return $op($this->redis());
+        } catch (\Throwable $e) {
+            $this->redisDown = true;
+            report($e);
+
+            return $default;
+        }
+    }
+
+    private function redis(): Connection
+    {
+        $connection = config('metering.event_redis_connection')
+            ?: config('metering.redis_connection', 'default');
+
+        return Redis::connection($connection);
+    }
+}

--- a/config/metering.php
+++ b/config/metering.php
@@ -23,6 +23,23 @@ return [
     // full kill-switch that bypasses the decorator entirely.
     'enabled' => env('METERING_ENABLED', true),
 
+    // Which meter feeds the displayed usage and which counters keep writing.
+    // 'both' (default): write BOTH the legacy broadcast counter (kept as an
+    // internal verification signal while we collapse the GPS fan-out) AND the
+    // input-event counter, and DISPLAY the input count. 'input': stop writing
+    // the broadcast counter. 'broadcast': legacy output-only behaviour.
+    // Inputs are immune to broadcast fan-out, so pricing is set against them.
+    'meter_mode' => env('METERING_MODE', 'both'),
+
+    // Free-tier monthly ceiling in INPUT EVENTS (pings / donations / twitch
+    // events). null = observe-only. This is the number to set pricing against,
+    // since one inbound event is one inbound event regardless of overlay count.
+    'free_monthly_events' => env('METERING_FREE_MONTHLY_EVENTS'),
+
+    // Redis connection backing the input-event counters. Falls back to
+    // redis_connection when unset.
+    'event_redis_connection' => env('METERING_EVENT_REDIS_CONNECTION'),
+
     // Free-tier monthly ceiling, in broadcasts. null = observe-only (no cap,
     // no percentage, just the running total). A number turns on the progress
     // UI. Enforcement (suppressing over-limit broadcasts) is a later phase.

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,15 @@
 # CHANGELOG JUNE 2026
 
+## June 14th, 2026 - feat(metering): meter inbound events, not outbound broadcasts
+
+Usage was metered by counting Reverb broadcasts, which made it a function of the broadcast fan-out: one GPS ping fans out to ~50 broadcasts (one per control-instance per overlay), so a single 31-ping session read as 1,690 "overlay updates." That couples pricing to an implementation detail and punishes IRL/GPS streamers ~50x. This switches the usage meter to count the *cause* (inbound events) instead of the *symptom* (broadcasts), so 1 overlay and 200 overlays produce the same number for the same activity. Step 1 of 4 toward fixing the fan-out (see `docs/design` / memory). Additive and observe-only - no enforcement.
+
+- **New `app/Services/EventMeter.php`** - mirrors `BroadcastMeter`'s fail-fast Redis discipline (per-request `redisDown` short-circuit, self-expiring monthly keys, `usageFor`/`historyFor`/`summaryFor`/`freeLimit`). Keyed by internal `user_id` under `metering:events:{userId}:{Y-m}` (input boundaries always have the owning user; GPS-only users need no twitch_id). Registered as a per-request singleton.
+- **Counted at the input boundaries**: one increment per stored `ExternalEvent` (GPS ping / donation) in `ExternalWebhookController` and per stored `TwitchEvent` in `TwitchEventSubController`. Duplicates, `settings_sync`, test-mode integrations, and `testCheer()` synthetics are excluded.
+- **`config/metering.php` `meter_mode`** (`both` default | `input` | `broadcast`): `both` keeps the legacy broadcast counter writing as an internal verification signal while displaying the event count; `input` retires the broadcast counter; `broadcast` is the old behaviour. Plus `free_monthly_events` (the ceiling pricing is set against) and `event_redis_connection`.
+- **UI** (`Usage.vue`, dashboard strip): relabeled "Overlay updates" -> "Events" with copy explaining one inbound event counts once regardless of overlay count. Prop shape unchanged.
+- Tests: `EventMeterTest` (key format, observe-only vs capped limit) and `EventMeteringTest` (one ping = one increment; duplicate/settings_sync/test-mode = none). Metering disabled in the test env (`phpunit.xml`) so the suite doesn't pay Redis connect timeouts. Pint, ESLint, build clean.
+
 ## June 14th, 2026 - fix(shortcuts): stop page hotkeys leaking into modals and selects
 
 Pressing `e` in the "Type" dropdown of the add-control modal (on `templates/show`) navigated to the template editor instead of jumping the `<select>` to "Expression" - the page-level `e` = "edit this overlay" shortcut won the keystroke and `preventDefault()`'d the native typeahead. Root cause was a focus-guard gap in `useKeyboardShortcuts`, not the Controls tab itself, so the fix is in the composable and covers the whole class of clash.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,7 @@
         <env name="DB_CONNECTION" value="pgsql"/>
         <env name="DB_DATABASE" value="laravel_foxes_test"/>
         <env name="MAIL_MAILER" value="array"/>
+        <env name="METERING_ENABLED" value="false"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/resources/js/pages/dashboard/index.vue
+++ b/resources/js/pages/dashboard/index.vue
@@ -94,7 +94,7 @@ const breadcrumbs = [
         >
           <div class="flex items-center justify-between gap-4">
             <div>
-              <p class="text-sm text-foreground">Overlay updates this month</p>
+              <p class="text-sm text-foreground">Events this month</p>
               <p class="text-2xl font-semibold text-foreground">
                 {{ fmtCount(usage.broadcasts) }}<span v-if="usage.limit" class="text-base font-normal text-muted-foreground"> / {{ fmtCount(usage.limit) }}</span>
               </p>

--- a/resources/js/pages/settings/Usage.vue
+++ b/resources/js/pages/settings/Usage.vue
@@ -72,15 +72,15 @@ const historyPeak = computed(() => Math.max(1, ...props.history.map((m) => m.bro
     <SettingsLayout>
       <div class="space-y-6">
         <HeadingSmall
-          title="Overlay updates"
-          description="Every real-time push to your overlays - an alert firing, a control changing, a Twitch event, a list updating - counts as one update. It is the single usage limit in Overlabels. Everything else is free."
+          title="Events"
+          description="Every inbound event you generate - a GPS ping, a donation, a Twitch follow/sub/cheer - counts as one. It is the single usage limit in Overlabels, and it is the same whether you run 1 overlay or 50. Everything else is free."
         />
 
         <div class="rounded-md border border-sidebar p-6">
           <div class="flex items-baseline justify-between gap-4">
             <div>
               <p class="text-3xl font-semibold text-foreground">{{ fmt(usage.broadcasts) }}</p>
-              <p class="text-sm text-muted-foreground">updates this month ({{ monthLabel(usage.period) }})</p>
+              <p class="text-sm text-muted-foreground">events this month ({{ monthLabel(usage.period) }})</p>
             </div>
             <div v-if="hasLimit" class="text-right">
               <p class="text-sm text-foreground">{{ fmt(usage.limit as number) }} included</p>
@@ -92,18 +92,18 @@ const historyPeak = computed(() => Math.max(1, ...props.history.map((m) => m.bro
             <div class="mt-4 h-2 w-full overflow-hidden rounded-full bg-muted">
               <div class="h-full rounded-full transition-all" :class="barColor" :style="{ width: percentUsed + '%' }" />
             </div>
-            <p class="mt-2 text-xs text-muted-foreground">{{ percentUsed }}% of your monthly updates used.</p>
+            <p class="mt-2 text-xs text-muted-foreground">{{ percentUsed }}% of your monthly events used.</p>
           </template>
 
           <p v-else class="mt-4 text-sm text-foreground">
-            No limit is being enforced yet. Overlabels is counting your updates so a fair free-tier ceiling can be set
+            No limit is being enforced yet. Overlabels is counting your events so a fair free-tier ceiling can be set
             from real usage. Your overlays will never be cut off without plenty of notice first.
           </p>
         </div>
       </div>
 
       <div class="space-y-6">
-        <HeadingSmall title="Recent months" description="Your update count over the last six months. Counters reset on the 1st." />
+        <HeadingSmall title="Recent months" description="Your event count over the last six months. Counters reset on the 1st." />
 
         <div class="space-y-2">
           <div v-for="month in history" :key="month.period" class="flex items-center gap-3">

--- a/tests/Feature/EventMeteringTest.php
+++ b/tests/Feature/EventMeteringTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Models\ExternalIntegration;
+use App\Models\User;
+use App\Services\EventMeter;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Testing\TestResponse;
+
+uses(DatabaseTransactions::class);
+
+function meteringGpsIntegration(bool $testMode = false): array
+{
+    $user = User::factory()->create(['twitch_id' => (string) fake()->unique()->randomNumber(9)]);
+
+    $integration = ExternalIntegration::factory()->create([
+        'user_id' => $user->id,
+        'service' => 'gps',
+        'enabled' => true,
+        'test_mode' => $testMode,
+        'credentials' => Crypt::encryptString(json_encode(['token' => 'meter-token'])),
+        'settings' => [],
+    ]);
+
+    return [$user, $integration];
+}
+
+function postMeteredPing(string $webhookToken, array $payload): TestResponse
+{
+    return test()->postJson(
+        "/api/webhooks/overlabels-mobile/{$webhookToken}",
+        $payload,
+        ['X-GPSLogger-Token' => 'meter-token'],
+    );
+}
+
+test('a GPS ping meters exactly one inbound event for the owning user', function () {
+    [$user, $integration] = meteringGpsIntegration();
+
+    $this->mock(EventMeter::class)
+        ->shouldReceive('record')->once()->with($user->id);
+
+    postMeteredPing($integration->webhook_token, [
+        'latitude' => 52.1, 'longitude' => 4.9, 'timestamp' => time(), 'serial' => '1',
+    ])->assertStatus(200);
+});
+
+test('a duplicate ping is not metered twice', function () {
+    [, $integration] = meteringGpsIntegration();
+
+    $this->mock(EventMeter::class)
+        ->shouldReceive('record')->once();
+
+    $payload = ['latitude' => 52.1, 'longitude' => 4.9, 'timestamp' => 1234567890, 'serial' => '7'];
+
+    postMeteredPing($integration->webhook_token, $payload)->assertJson(['status' => 'ok']);
+    postMeteredPing($integration->webhook_token, $payload)->assertJson(['status' => 'duplicate']);
+});
+
+test('settings_sync is not metered', function () {
+    [, $integration] = meteringGpsIntegration();
+
+    $this->mock(EventMeter::class)
+        ->shouldReceive('record')->never();
+
+    postMeteredPing($integration->webhook_token, [
+        'event' => 'settings_sync', 'timestamp' => (string) time(),
+    ])->assertStatus(200);
+});
+
+test('test-mode traffic is not metered', function () {
+    [, $integration] = meteringGpsIntegration(testMode: true);
+
+    $this->mock(EventMeter::class)
+        ->shouldReceive('record')->never();
+
+    postMeteredPing($integration->webhook_token, [
+        'latitude' => 52.1, 'longitude' => 4.9, 'timestamp' => time(), 'serial' => '1',
+    ])->assertStatus(200);
+});

--- a/tests/Unit/EventMeterTest.php
+++ b/tests/Unit/EventMeterTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Services\EventMeter;
+
+test('key is namespaced per user and month', function () {
+    $meter = new EventMeter;
+
+    expect($meter->key(42, '2026-06'))->toBe('metering:events:42:2026-06');
+    expect($meter->key(42))->toBe('metering:events:42:'.now()->format('Y-m'));
+});
+
+test('freeLimit is null in observe-only mode', function () {
+    config()->set('metering.free_monthly_events', null);
+
+    expect((new EventMeter)->freeLimit())->toBeNull();
+});
+
+test('freeLimit returns the configured ceiling as an int', function () {
+    config()->set('metering.free_monthly_events', '10000');
+
+    expect((new EventMeter)->freeLimit())->toBe(10000);
+});


### PR DESCRIPTION
**Step 1 of 4** on the GPS broadcast fan-out fix. Merge order: this → batch-broadcasts → change-detection → service-control-class.

## Problem
Usage was metered by counting Reverb broadcasts, which made it a function of fan-out: one GPS ping fans out to ~50 broadcasts, so a 31-ping session read as 1,690 "overlay updates." That couples pricing to an implementation detail and punishes IRL/GPS streamers ~50x.

## Fix
Count the *cause* (inbound events) instead of the *symptom* (broadcasts), so 1 overlay and 200 overlays produce the same number for the same activity.

- New `EventMeter` (mirrors `BroadcastMeter`'s fail-fast Redis discipline), keyed by `user_id` under `metering:events:{userId}:{Y-m}`.
- One increment per stored `ExternalEvent` / `TwitchEvent` at the webhook boundaries; duplicates, `settings_sync`, test-mode, and `testCheer` excluded.
- `config/metering.php` `meter_mode` (`both` default | `input` | `broadcast`): `both` keeps the broadcast counter writing as an internal verification signal while displaying events.
- UI relabel "Overlay updates" → "Events".

Additive, observe-only, no data migration. `EventMeterTest` + `EventMeteringTest`; full suite green; Pint/ESLint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)