### PR TITLE
perf(broadcasts): change detection - skip values that didn't move

### DIFF
--- a/app/Services/External/ExternalControlService.php
+++ b/app/Services/External/ExternalControlService.php
@@ -144,6 +144,7 @@ class ExternalControlService
 
             foreach ($controls as $control) {
                 $action = is_array($update) ? ($update['action'] ?? null) : null;
+                $oldValue = (string) ($control->value ?? '');
 
                 if ($action === 'increment') {
                     $step = (float) ($control->config['step'] ?? 1);
@@ -155,6 +156,15 @@ class ExternalControlService
                     $newValue = (string) ($current + $amount);
                 } else {
                     $newValue = OverlayControl::sanitizeValue($control->type, $update);
+                }
+
+                // Change detection: a value that didn't move (within an epsilon
+                // for noisy floats) is dropped from BOTH persistence and the
+                // broadcast. A parked GPS device drifting in the 6th decimal
+                // emits nothing; the stored value stays at the last broadcast
+                // value so drift can't accumulate.
+                if (! $this->valueChanged($key, $control->type, $oldValue, $newValue)) {
+                    continue;
                 }
 
                 $control->update(['value' => $newValue]);
@@ -185,6 +195,42 @@ class ExternalControlService
         if (! empty($batch)) {
             ControlValuesBatchUpdated::dispatch($user->twitch_id, $batch);
         }
+    }
+
+    /**
+     * Whether a control value moved enough to be worth persisting and
+     * broadcasting. Numeric keys with a configured epsilon (GPS floats) use a
+     * threshold compare; other numeric controls use an exact numeric compare;
+     * text/boolean controls use an exact string compare.
+     */
+    private function valueChanged(string $key, string $type, string $old, string $new): bool
+    {
+        $epsilon = $this->epsilonFor($key, $type);
+
+        if ($epsilon !== null) {
+            return abs((float) $new - (float) $old) > $epsilon;
+        }
+
+        return $new !== $old;
+    }
+
+    /**
+     * Resolve the change-detection epsilon for a key, or null when an exact
+     * string comparison should be used (text/boolean controls).
+     */
+    private function epsilonFor(string $key, string $type): ?float
+    {
+        $map = config('controls.change_detection.epsilon', []);
+
+        if (array_key_exists($key, $map)) {
+            return (float) $map[$key];
+        }
+
+        if (in_array($type, ['number', 'counter'], true)) {
+            return (float) ($map['default'] ?? 0.0);
+        }
+
+        return null;
     }
 
     /**

--- a/config/controls.php
+++ b/config/controls.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Change detection
+    |--------------------------------------------------------------------------
+    |
+    | Service control updates (GPS pings, donations) only broadcast when the
+    | value actually moved. For noisy floats - a stationary scooter's GPS still
+    | jitters in the 6th decimal - we compare against an epsilon: a change <=
+    | epsilon is dropped from BOTH the broadcast and persistence, so the stored
+    | value stays at the last broadcast value (no drift creep) and a parked
+    | device emits nothing.
+    |
+    | Keyed by control key. 1e-5 degrees is ~1.1m of latitude. Keys not listed
+    | fall back to `default` when numeric (number/counter), or to an exact
+    | string comparison for text/boolean controls. Tune here without a deploy.
+    |
+    */
+
+    'change_detection' => [
+        'epsilon' => [
+            'lat' => 1e-5,
+            'lng' => 1e-5,
+            'speed' => 0.5,
+            'bearing' => 1.0,
+            'distance' => 0.0,
+            'default' => 0.0,
+        ],
+    ],
+
+];

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,14 @@
 # CHANGELOG JUNE 2026
 
+## June 14th, 2026 - perf(broadcasts): change detection - don't broadcast values that didn't move
+
+Building on batching: a service control whose value didn't actually change no longer persists or broadcasts. For noisy GPS floats - a parked device still jitters in the 6th decimal - the comparison uses a per-key epsilon, so a scooter at a red light emits nothing. Step 3 of 4 on the fan-out fix. No data migration; no frontend change.
+
+- **`ExternalControlService::applyUpdates`** compares each new value against the stored one before persisting/broadcasting. A change within epsilon is dropped from BOTH the DB write and the batch - the stored value stays at the last broadcast value so sub-threshold drift can't accumulate. `increment`/`add` of 0 naturally drop out too.
+- **`config/controls.php`** holds the per-key epsilons (`lat`/`lng` 1e-5 deg ~ 1.1m, `speed` 0.5, `bearing` 1.0; numeric keys default to exact compare; text/boolean use exact string compare). Tunable without a deploy.
+- Stacks on the batch: a stationary device's batch comes out empty, so no broadcast fires at all. A freshly-loaded overlay still reads current values from the DB at render, so suppression never leaves it stale.
+- Tests: repeated identical coordinates broadcast once, not twice; movement beyond the epsilon re-broadcasts (kept under the teleport cap). Full suite green (857); Pint clean.
+
 ## June 14th, 2026 - perf(broadcasts): batch service control updates into one broadcast per tick
 
 A single GPS ping flowed through `ExternalControlService::applyUpdates()` and dispatched one `ControlValueUpdated` per control instance - ~11 keys times however many overlays duplicate each control - fanning one ping out to ~50 Reverb broadcasts. This collapses a whole service tick into ONE `ControlValuesBatchUpdated` carrying every changed key. Step 2 of 4 on the fan-out fix (after input metering). No data migration.

--- a/tests/Feature/GpsWebhookTest.php
+++ b/tests/Feature/GpsWebhookTest.php
@@ -226,6 +226,52 @@ test('a location ping produces one batched broadcast, not one per control', func
     Event::assertNotDispatched(ControlValueUpdated::class);
 });
 
+test('repeated identical coordinates do not re-broadcast (change detection)', function () {
+    Event::fake([ControlValuesBatchUpdated::class]);
+
+    [$user, $integration] = makeMobileIntegration();
+
+    foreach (['lat', 'lng'] as $key) {
+        OverlayControl::provisionServiceControl($user, 'gps', [
+            'key' => $key, 'type' => 'text', 'label' => $key, 'value' => '0',
+        ]);
+    }
+
+    postMobile($integration->webhook_token, mobilePayload([
+        'latitude' => 52.0, 'longitude' => 4.0, 'serial' => '1', 'timestamp' => time(),
+    ]))->assertStatus(200);
+
+    // Identical fix (different serial so it isn't deduped) - a parked device.
+    postMobile($integration->webhook_token, mobilePayload([
+        'latitude' => 52.0, 'longitude' => 4.0, 'serial' => '2', 'timestamp' => time() + 5,
+    ]))->assertStatus(200);
+
+    // Only the first ping moved the value; the identical second emits nothing.
+    Event::assertDispatched(ControlValuesBatchUpdated::class, 1);
+});
+
+test('movement beyond the epsilon re-broadcasts', function () {
+    Event::fake([ControlValuesBatchUpdated::class]);
+
+    [$user, $integration] = makeMobileIntegration();
+
+    OverlayControl::provisionServiceControl($user, 'gps', [
+        'key' => 'lat', 'type' => 'text', 'label' => 'lat', 'value' => '0',
+    ]);
+
+    $t = time();
+    postMobile($integration->webhook_token, mobilePayload([
+        'latitude' => 52.0, 'longitude' => 4.0, 'serial' => '1', 'timestamp' => $t,
+    ]))->assertStatus(200);
+
+    // ~110 m later (well above the 1e-5 epsilon, well under the teleport cap).
+    postMobile($integration->webhook_token, mobilePayload([
+        'latitude' => 52.001, 'longitude' => 4.0, 'serial' => '2', 'timestamp' => $t + 5,
+    ]))->assertStatus(200);
+
+    Event::assertDispatched(ControlValuesBatchUpdated::class, 2);
+});
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Distance accumulation
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Step 3 of 4** on the fan-out fix. **Based on `feat/batch-broadcasts` (#120)** since both edit `applyUpdates` - GitHub will auto-retarget this to `main` once #120 merges.

## Fix
A service control whose value didn't change no longer persists or broadcasts. Noisy GPS floats use a per-key epsilon, so a parked device drifting in the 6th decimal emits nothing.

- `applyUpdates` compares new vs stored before persist/broadcast; a within-epsilon change is dropped from BOTH the DB write and the batch (stored value stays put so drift can't accumulate). `increment`/`add` of 0 drop too.
- `config/controls.php` holds per-key epsilons (`lat`/`lng` 1e-5 ≈ 1.1m, `speed` 0.5, `bearing` 1.0; numeric default exact; text/boolean exact string compare). Tunable without a deploy.
- A freshly-loaded overlay reads current values from the DB at render, so suppression never leaves it stale.

No data migration; no frontend change. Tests: identical coords broadcast once not twice; supra-epsilon move re-broadcasts. Full suite green; Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)