### PR TITLE
feat(controls): which-overlays-use-which-controls observability page

### DIFF
--- a/app/Http/Controllers/Settings/ControlUsageController.php
+++ b/app/Http/Controllers/Settings/ControlUsageController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Models\OverlayControl;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Read-only "which overlays use which controls" view. Answers from the UI what
+ * previously needed an SSH + ad-hoc query: every control the user owns, its
+ * scope (user-scoped service controls apply to all overlays; template-scoped
+ * controls list the specific overlays), and where the same key is duplicated
+ * across overlays (the broadcast fan-out smell).
+ */
+class ControlUsageController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $user = $request->user();
+
+        $controls = OverlayControl::where('user_id', $user->id)
+            ->with('template:id,name,slug')
+            ->orderBy('source')
+            ->orderBy('key')
+            ->get();
+
+        $groups = $controls
+            ->groupBy(fn (OverlayControl $c) => ($c->source ? $c->source.':' : '').$c->key)
+            ->map(function ($rows, string $displayKey) {
+                /** @var OverlayControl $first */
+                $first = $rows->first();
+                $templateScoped = $rows->whereNotNull('overlay_template_id');
+
+                return [
+                    'key' => $displayKey,
+                    'source' => $first->source,
+                    'type' => $first->type,
+                    'source_managed' => (bool) $first->source_managed,
+                    'user_scoped' => $rows->contains(fn (OverlayControl $c) => $c->overlay_template_id === null),
+                    'overlays' => $templateScoped
+                        ->map(fn (OverlayControl $c) => [
+                            'name' => $c->template?->name ?: 'Untitled overlay',
+                            'slug' => $c->template?->slug,
+                        ])
+                        ->values(),
+                    'instances' => $rows->count(),
+                    'value' => (string) ($first->value ?? ''),
+                ];
+            })
+            ->sortByDesc('instances')
+            ->values();
+
+        return Inertia::render('settings/Controls', [
+            'groups' => $groups,
+        ]);
+    }
+}

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,14 @@
 # CHANGELOG JUNE 2026
 
+## June 14th, 2026 - feat(controls): "which overlays use which controls" observability page
+
+Diagnosing the GPS fan-out required SSHing into prod and running ad-hoc queries because there was no way to answer "what controls exist and where do they live" from the UI. This adds a read-only `Settings -> Controls` page that lists every control you own, grouped by key, with its scope (user-scoped service controls show "All overlays"; template-scoped controls list the specific overlays), type, source, current value, and a flag when the same key is duplicated across multiple overlays (the fan-out smell). Follow-up to the service-control-class work.
+
+- New `ControlUsageController` (read-only) groups `OverlayControl` rows by `source:key`, eager-loads the template name/slug, sorts most-instances-first.
+- New `settings/Controls.vue` page + `Controls` entry in the settings nav.
+- Additive and read-only - no schema, no migration, no change to any hot path.
+- Tests: guests are redirected; the page renders grouped controls with scope/overlays/instances. Full suite green (854); Pint, ESLint, build clean.
+
 ## June 14th, 2026 - fix(shortcuts): stop page hotkeys leaking into modals and selects
 
 Pressing `e` in the "Type" dropdown of the add-control modal (on `templates/show`) navigated to the template editor instead of jumping the `<select>` to "Expression" - the page-level `e` = "edit this overlay" shortcut won the keystroke and `preventDefault()`'d the native typeahead. Root cause was a focus-guard gap in `useKeyboardShortcuts`, not the Controls tab itself, so the fix is in the composable and covers the whole class of clash.

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -18,6 +18,10 @@ const sidebarNavItems: NavItem[] = [
         title: 'Usage',
         href: '/settings/usage',
     },
+    {
+        title: 'Controls',
+        href: '/settings/controls',
+    },
 ];
 
 const page = usePage();

--- a/resources/js/pages/settings/Controls.vue
+++ b/resources/js/pages/settings/Controls.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3';
+import type { BreadcrumbItem } from '@/types';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/Layout.vue';
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import { Badge } from '@/components/ui/badge';
+
+interface ControlGroup {
+  key: string;
+  source: string | null;
+  type: string;
+  source_managed: boolean;
+  user_scoped: boolean;
+  overlays: Array<{ name: string; slug: string | null }>;
+  instances: number;
+  value: string;
+}
+
+defineProps<{ groups: ControlGroup[] }>();
+
+const breadcrumbItems: BreadcrumbItem[] = [
+  { title: 'Dashboard', href: '/dashboard' },
+  { title: 'Settings', href: '/settings/account' },
+  { title: 'Controls', href: '/settings/controls' },
+];
+</script>
+
+<template>
+  <AppLayout :breadcrumbs="breadcrumbItems">
+    <Head title="Controls" />
+
+    <SettingsLayout>
+      <div class="space-y-6">
+        <HeadingSmall
+          title="Controls"
+          description="Every control you own and where it lives. Service controls (GPS, donations) are user-scoped - one value shared across all your overlays. Controls bound to specific overlays are listed per overlay."
+        />
+
+        <div v-if="groups.length === 0" class="rounded-md border border-sidebar p-6 text-sm text-foreground">
+          You have no controls yet. Add them from an overlay's Controls tab.
+        </div>
+
+        <div v-else class="space-y-2">
+          <div
+            v-for="group in groups"
+            :key="group.key"
+            class="rounded-md border border-sidebar p-4"
+          >
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <div class="flex items-center gap-2">
+                <code class="font-mono text-sm text-foreground">[[[c:{{ group.key }}]]]</code>
+                <Badge variant="secondary">{{ group.type }}</Badge>
+                <Badge v-if="group.source" variant="secondary">{{ group.source }}</Badge>
+              </div>
+              <span class="text-xs text-muted-foreground">value: {{ group.value === '' ? '(empty)' : group.value }}</span>
+            </div>
+
+            <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">
+              <Badge v-if="group.user_scoped" variant="success">All overlays</Badge>
+              <template v-for="overlay in group.overlays" :key="overlay.slug ?? overlay.name">
+                <Badge variant="outline">{{ overlay.name }}</Badge>
+              </template>
+
+              <span
+                v-if="group.instances > 1"
+                class="text-xs text-amber-500 dark:text-amber-400"
+                title="The same control exists on multiple overlays - each copy broadcasts separately."
+              >
+                duplicated across {{ group.instances }} controls
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </SettingsLayout>
+  </AppLayout>
+</template>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Settings\BMACIntegrationController;
 use App\Http\Controllers\Settings\BotAliasesController;
 use App\Http\Controllers\Settings\BotExpressionsController;
 use App\Http\Controllers\Settings\BotSettingsController;
+use App\Http\Controllers\Settings\ControlUsageController;
 use App\Http\Controllers\Settings\FourthwallIntegrationController;
 use App\Http\Controllers\Settings\GpsIntegrationController;
 use App\Http\Controllers\Settings\IntegrationController;
@@ -30,6 +31,9 @@ Route::middleware('auth.redirect')->group(function () {
 
     Route::get('/settings/usage', [UsageController::class, 'index'])
         ->name('settings.usage');
+
+    Route::get('/settings/controls', [ControlUsageController::class, 'index'])
+        ->name('settings.controls');
 
     Route::patch('/settings/locale', function (Request $request) {
         $request->validate(['locale' => 'required|string|max:10']);

--- a/tests/Feature/Settings/ControlUsagePageTest.php
+++ b/tests/Feature/Settings/ControlUsagePageTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\OverlayControl;
+use App\Models\OverlayTemplate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(DatabaseTransactions::class);
+
+test('guests cannot reach the controls page', function () {
+    $this->get('/settings/controls')
+        ->assertRedirect('/login?redirect_to='.urlencode(url('/settings/controls')));
+});
+
+test('the controls page groups controls by key with scope and overlays', function () {
+    $user = User::factory()->create(['twitch_id' => (string) fake()->unique()->randomNumber(9)]);
+    $template = OverlayTemplate::factory()->create(['owner_id' => $user->id, 'fork_of_id' => null]);
+
+    OverlayControl::create([
+        'user_id' => $user->id, 'overlay_template_id' => null, 'source' => 'kofi',
+        'key' => 'donations_received', 'type' => 'counter', 'value' => '3',
+        'source_managed' => true, 'sort_order' => 0,
+    ]);
+    OverlayControl::create([
+        'user_id' => $user->id, 'overlay_template_id' => $template->id,
+        'key' => 'wins', 'type' => 'counter', 'value' => '7', 'sort_order' => 0,
+    ]);
+
+    $this->actingAs($user)
+        ->get('/settings/controls')
+        ->assertStatus(200)
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/Controls')
+            ->has('groups', 2)
+            ->has('groups.0', fn (Assert $group) => $group
+                ->has('key')
+                ->has('user_scoped')
+                ->has('overlays')
+                ->has('instances')
+                ->etc()
+            )
+        );
+});


### PR DESCRIPTION
**PR5 / follow-up** to the GPS fan-out work (#119-#122). Independent and additive; can merge any time.

## Why
Diagnosing the fan-out required SSHing into prod and running ad-hoc queries - there was no way to answer "what controls exist and where do they live" from the UI.

## What
A read-only `Settings → Controls` page listing every control you own, grouped by key:
- **Scope**: user-scoped service controls show an "All overlays" badge; template-scoped controls list the specific overlays.
- Type, source, current value.
- A "duplicated across N controls" flag when the same key lives on multiple overlays (the fan-out smell - mostly cleaned up by #122, useful going forward).

- New `ControlUsageController` (read-only), `settings/Controls.vue`, and a `Controls` nav entry.
- Additive: no schema, no migration, no change to any hot path.
- Tests: guest redirect; grouped render with scope/overlays/instances. Full suite green (854); Pint/ESLint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)