### PR TITLE
Dependency refresh + Bot Expression self-destruct timer + redirect/impersonation fixes

### DIFF
--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,12 @@
 # CHANGELOG JUNE 2026
 
+## June 18th, 2026 - fix(impersonation): keep admin.impersonate.stop in the Ziggy payload while impersonating
+
+Stopping an impersonation from the admin panel threw `Ziggy error: route 'admin.impersonate.stop' is not in the route list`. The role-scoped Ziggy groups pick the payload from `auth()->user()`, but during impersonation that user is the (non-admin) target - so the `user` group was emitted, which negates `admin.*` and dropped the very route the Stop button calls.
+
+- **`app.blade.php`**: the `@routes` group now resolves to `admin` when the session is impersonating (`impersonating_user_id` + `real_admin_id` present), not just when `auth()->user()->isAdmin()`. The real operator is a verified admin - `HandleImpersonation` confirms `real_admin_id` is an admin before swapping the auth user - so shipping the admin group leaks nothing to a non-admin: they would receive it normally anyway.
+- Why not a surgical "user group + just admin.impersonate.stop" group: Ziggy keeps a route only if no negation pattern matches it, so the `user` group's `!admin.*` rejects `admin.impersonate.stop` regardless of order. Re-allowing one admin route would mean enumerating every other admin subtree as a negation - brittle, and new admin routes would leak. Selecting the existing `admin` group for a verified admin is both simpler and safer.
+
 ## June 18th, 2026 - fix(public-preview): bounce "Log in to copy" back to the public overlay
 
 On a public overlay preview (`/overlay/{slug}/public`), the "Log in to copy" button shown to logged-out visitors linked straight to `/auth/redirect/twitch`, which skipped the step that records where the user came from - so after connecting they always landed on `/dashboard` instead of the overlay they were viewing.

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,12 @@
 # CHANGELOG JUNE 2026
 
+## June 18th, 2026 - fix(public-preview): bounce "Log in to copy" back to the public overlay
+
+On a public overlay preview (`/overlay/{slug}/public`), the "Log in to copy" button shown to logged-out visitors linked straight to `/auth/redirect/twitch`, which skipped the step that records where the user came from - so after connecting they always landed on `/dashboard` instead of the overlay they were viewing.
+
+- **`public-preview.vue`**: the link now points at the login route with `?redirect_to=<current url>`, mirroring how `RedirectIfUnauthenticated` builds its login URL. The login page (`AuthenticatedSessionController@create`) stores `redirect_to` as `url.intended`, which the Twitch OAuth callback already pulls and honours - so the user is returned to the exact public preview after connecting.
+- No backend changes: pure reuse of the existing `?redirect_to=` flow. The callback's safety check only rejects `/onboarding/` and `/api/` paths, so the public overlay URL redirects cleanly.
+
 ## June 18th, 2026 - feat(bot): self-destruct timer for temporary Bot Expressions
 
 A new `destroy` option on `!ol cmd options` lets a streamer set a temporary command that removes itself after a fixed number of hours - set-and-forget, no live countdown to manage. `!ol cmd options <name> destroy 12` schedules `!<name>` for deletion 12 hours from now; `destroy 0` cancels a pending timer, and re-running just overwrites it (free extend/shorten).

--- a/resources/js/pages/overlay/public-preview.vue
+++ b/resources/js/pages/overlay/public-preview.vue
@@ -51,6 +51,11 @@ const props = defineProps<{
 const page = usePage<AppPageProps>();
 const isAuthed = computed(() => !!page.props.auth?.user);
 
+// Bounce unauthenticated users through the login flow and back to this public
+// preview once they connect. Mirrors RedirectIfUnauthenticated: the login page
+// stores redirect_to as url.intended, which the Twitch OAuth callback honours.
+const loginUrl = computed(() => `${route('login')}?redirect_to=${encodeURIComponent(window.location.href)}`);
+
 const csrf = computed(() => {
   return (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '';
 });
@@ -247,7 +252,7 @@ const activeSource = computed(() => {
             <input type="hidden" name="_token" :value="csrf" />
             <button type="submit" class="ovl-btn-copy cursor-pointer">Copy</button>
           </form>
-          <a v-else href="/auth/redirect/twitch" class="ovl-btn-copy cursor-pointer">Log in to copy</a>
+          <a v-else :href="loginUrl" class="ovl-btn-copy cursor-pointer">Log in to copy</a>
         </div>
       </div>
 

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -68,9 +68,15 @@
         <meta name="twitter:image:alt" content="{{ $ogData['image_alt'] }}" />
 
         @php
+            // During impersonation auth()->user() is the (non-admin) target, so
+            // isAdmin() is false and the 'user' group would drop every admin.*
+            // route - including admin.impersonate.stop that the Stop button calls.
+            // The real operator is a verified admin (HandleImpersonation checks
+            // real_admin_id before swapping), so ship the admin group instead.
+            $isImpersonating = session()->has('impersonating_user_id') && session()->has('real_admin_id');
             $ziggyGroup = ! auth()->check()
                 ? 'guest'
-                : (auth()->user()->isAdmin() ? 'admin' : 'user');
+                : ((auth()->user()->isAdmin() || $isImpersonating) ? 'admin' : 'user');
         @endphp
         @routes($ziggyGroup)
         @vite(['resources/js/app.ts', "resources/js/pages/{$page['component']}.vue"])


### PR DESCRIPTION
Branch bundles four related-but-distinct changes landed since the last merge to main.

## Changes

- **chore(deps): refresh dependencies, close phpseclib SSRF advisory** (`538dfe9`) - Composer + npm in-range updates; bumps `phpseclib` 3.0.53 -> 3.0.55 to close GHSA-m557-wrgg-6rp4 (medium SSRF), `laravel/framework`, `laravel/socialite`, ESLint 9 -> 10, drops a dead rollup optional dep. `composer audit` / `npm audit` clean.
- **feat(bot): self-destruct timer for temporary Bot Expressions** (`b4c0884`, `420f936`) - `!ol cmd options <name> destroy <hours>` schedules a temporary command to remove itself; `destroy 0` cancels. DB-backed `destroy_at` column + `bot:sweep-destroyed` scheduled command (cascades to dependent aliases). Settings page shows a countdown badge. No bot changes.
- **fix(public-preview): return "Log in to copy" to the public overlay** (`be48c1f`) - the logged-out copy button on `/overlay/{slug}/public` now routes through login with `?redirect_to=<current url>` so users land back on the overlay after connecting, instead of `/dashboard`.
- **fix(impersonation): keep admin.impersonate.stop in Ziggy while impersonating** (`3e81f8c`) - the role-scoped Ziggy groups dropped `admin.*` during impersonation (auth user is the non-admin target), breaking the Stop button. Now emits the `admin` group for impersonating sessions (operator is a verified admin).

## Testing

- Full PHP suite green at the deps commit (871 passed); new bot timer tests added.
- Both fixes verified locally.
- Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)