### PR TITLE
feat(templates): surface "Add to OBS" on the overlay overview page

### DIFF
--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,15 @@
 # CHANGELOG JUNE 2026
 
+## June 18th, 2026 - feat(templates): surface "Add to OBS" on the overlay overview page
+
+"Add to OBS" (the dialog that mints a unique overlay URL via `generateOBSUrl()`) only lived on the edit page, buried in the code editor's tab strip. Owners had to open EDIT - and step into the code - just to grab a browser-source URL. It now lives on the overlay overview page (`templates/show`) too, right where you read the overlay.
+
+- **`show.vue`**: the read-only HEAD / BODY / CSS tab strip gains a fourth **OBS** tab that renders the existing `AddToObsButton`, mirroring the edit page's code editor. Owner-only via a new `visibleEditorTabs` computed (the access token is user-scoped). The selected tab swaps the code `<pre>` for the OBS panel; the "Copy CODE" button is hidden on the OBS tab.
+- **Inform, don't restrict.** The OBS tab is available for both static and alert overlays. Alerts are usually rendered inside a static overlay (where they inherit its CSS structure and variables), but adding an alert straight to OBS as its own browser source works fine - so on alert templates the panel shows a short "Heads up" note rather than hiding the option. Same gate change applied to the edit page's `TemplateCodeEditor` OBS panel (previously hidden for alerts).
+- **New help doc `/help/overlays-vs-alerts` ("Overlays vs Alerts").** The "Heads up" note grew into a wall of text, so it moved to its own help page (modeled on `ForDesigners.vue`, `AppLayout` + meta tags + `max-w-4xl` prose). The doc explains the two overlay kinds, shows simplified HTML examples of an alert rendering inside a static overlay's DOM (just before `</body>`, inheriting its CSS variables) vs. standalone in its own browser source, and clarifies Targeting (which static overlay an alert renders in) vs Triggers (which event fires it). Registered in `web.php` and added as a card on the help index. The OBS-tab note is now a one-liner that links to the doc (opens in a new tab).
+- **Removed the broken `a` keyboard shortcut.** On `show.vue` the shortcut called `obsButton.value?.generateOBSUrl()` but the `AddToObsButton` was never rendered there, so the ref was always null and the key did nothing. On `edit.vue` the `ref="obsButton"` was bound inside `TemplateCodeEditor`'s own scope, never the page's - so that shortcut was dead too. Dropped the registration, the orphaned `obsButton` refs, the now-unused `AddToObsButton` import on `edit.vue`, and the dangling `ref="obsButton"` in `TemplateCodeEditor.vue`.
+- No backend changes: pure reuse of the existing `AddToObsButton` component and `tokens.store` flow. Lint clean.
+
 ## June 18th, 2026 - fix(impersonation): keep admin.impersonate.stop in the Ziggy payload while impersonating
 
 Stopping an impersonation from the admin panel threw `Ziggy error: route 'admin.impersonate.stop' is not in the route list`. The role-scoped Ziggy groups pick the payload from `auth()->user()`, but during impersonation that user is the (non-admin) target - so the `user` group was emitted, which negates `admin.*` and dropped the very route the Stop button calls.

--- a/resources/js/components/templates/TemplateCodeEditor.vue
+++ b/resources/js/components/templates/TemplateCodeEditor.vue
@@ -240,7 +240,7 @@ const cssExtensions = computed(() => [css(), baseTheme, ...(isDark.value ? [oneD
 
           <!-- Add to OBS panel -->
           <div
-            v-show="codeTab === 'add-to-obs' && props.templateType === 'static'"
+            v-show="codeTab === 'add-to-obs'"
             v-if="props.template"
             class="absolute inset-0 overflow-auto p-6 text-sm text-foreground"
           >
@@ -249,12 +249,29 @@ const cssExtensions = computed(() => [css(), baseTheme, ...(isDark.value ? [oneD
                 <Video class="size-6 text-violet-500 dark:text-violet-400" />
                 <h3 class="text-lg font-semibold">Add this overlay to OBS</h3>
               </div>
-              <p v-if="props.templateType === 'static'">
+              <p>
                 Add this overlay to OBS by clicking the button below and copying the exact URL to your OBS as a browser source.
               </p>
 
+              <div
+                v-if="props.templateType === 'alert'"
+                class="space-y-2 rounded border-l-4 border-violet-500 bg-violet-500/10 p-3 text-foreground/90"
+              >
+                <p class="font-medium text-violet-700 dark:text-violet-300">Heads up: you're adding an alert directly to OBS</p>
+                <p>
+                  That works fine, but alerts are usually far more powerful rendered inside a static overlay, where they inherit its structure and styling.
+                  <a
+                    :href="route('help.overlays-vs-alerts')"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="cursor-pointer font-medium text-violet-600 underline hover:text-violet-500 dark:text-violet-300"
+                  >Read "Overlays vs Alerts"</a>
+                  so you know what you're doing.
+                </p>
+              </div>
+
               <div>
-                <AddToObsButton ref="obsButton" :template="props.template" />
+                <AddToObsButton :template="props.template" />
               </div>
             </div>
           </div>

--- a/resources/js/pages/help/Index.vue
+++ b/resources/js/pages/help/Index.vue
@@ -2,7 +2,7 @@
 import type { BreadcrumbItem } from '@/types';
 import HelpLayout from '@/layouts/HelpLayout.vue';
 import HelpCardGrid from '@/components/help/HelpCardGrid.vue';
-import { Bot, BookOpen, Brackets, FunctionSquare, Heart, FileText, Lightbulb, Library, ListChecks, Palette, Pipette, Plug, Radio, Sigma, SlidersHorizontal, Sparkles, Swords } from '@lucide/vue';
+import { Bot, BookOpen, Brackets, FunctionSquare, Heart, FileText, Layers, Lightbulb, Library, ListChecks, Palette, Pipette, Plug, Radio, Sigma, SlidersHorizontal, Sparkles, Swords } from '@lucide/vue';
 import Heading from '@/components/Heading.vue';
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -27,6 +27,12 @@ const pages = [
     description: 'A handoff guide for designers working on overlays: the two surfaces, the unknown-background problem, variable-length content, fluid layout, CSS animation, and a deliverables checklist.',
     href: '/help/for-designers',
     icon: Palette,
+  },
+  {
+    title: 'Overlays vs Alerts',
+    description: 'The two kinds of overlay and how they fit together: why alerts are most powerful rendered inside a static overlay\'s DOM, plus Targeting vs Triggers.',
+    href: '/help/overlays-vs-alerts',
+    icon: Layers,
   },
   {
     title: 'Why Ko-fi',

--- a/resources/js/pages/help/OverlaysVsAlerts.vue
+++ b/resources/js/pages/help/OverlaysVsAlerts.vue
@@ -1,0 +1,220 @@
+<script setup lang="ts">
+import { Head, Link } from '@inertiajs/vue3';
+import type { BreadcrumbItem } from '@/types';
+import AppLayout from '@/layouts/AppLayout.vue';
+import Heading from '@/components/Heading.vue';
+
+const breadcrumbs: BreadcrumbItem[] = [
+  { title: 'Help', href: '/help' },
+  { title: 'Overlays vs Alerts', href: '/help/overlays-vs-alerts' },
+];
+
+// A static overlay: always-on HTML, with its own CSS scaffolding and variables.
+const staticExample = `<style>
+  :root { --brand: #6d28ff; }
+  .avatar { border: 3px solid var(--brand); }
+</style>
+
+<body class="overlay">
+  <div class="hud">
+    <img class="avatar" src="logo.png" />
+    <span class="followers">[[[follower_count]]]</span>
+  </div>
+</body>`;
+
+// The same alert rendered INSIDE the static overlay it targets: appended to the
+// same document, just before </body>, so it inherits the static overlay's CSS.
+const insideExample = `<body class="overlay">
+  <!-- your static overlay's own HTML -->
+  <div class="hud">
+    <img class="avatar" src="logo.png" />
+    <span class="followers">1,337</span>
+  </div>
+
+  <!-- your alert is appended here, just before </body> -->
+  <div class="alert">
+    <img class="avatar" src="newsub.png" />
+    <strong>NightboticaLIVE</strong> just subscribed!
+  </div>
+</body>`;
+
+// The same alert added directly to OBS as its own browser source: it renders
+// alone, with none of the static overlay's variables or scaffolding around it.
+const standaloneExample = `<body>
+  <!-- nothing else: the alert is alone in its own browser source -->
+  <div class="alert">
+    <img class="avatar" src="newsub.png" />
+    <strong>NightboticaLIVE</strong> just subscribed!
+  </div>
+</body>`;
+</script>
+
+<template>
+  <Head>
+    <title>Overlays vs Alerts - how alerts render inside your static overlay</title>
+    <meta
+      name="description"
+      content="The difference between a static overlay and an alert in Overlabels, why alerts are most powerful rendered inside a static overlay's DOM, and how Targeting and Triggers fit together."
+    />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://overlabels.com/help/overlays-vs-alerts" />
+    <meta property="og:site_name" content="Overlabels" />
+    <meta property="og:title" content="Overlays vs Alerts - how alerts render inside your static overlay" />
+    <meta
+      property="og:description"
+      content="Why alerts are most powerful rendered inside a static overlay's DOM, and how Targeting and Triggers fit together."
+    />
+    <meta property="og:image"
+          content="https://res.cloudinary.com/dy185omzf/image/upload/v1771771091/ogimage_fepcyf.jpg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Overlabels - build Twitch overlays with HTML, CSS, and live data" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Overlays vs Alerts - how alerts render inside your static overlay" />
+    <meta
+      name="twitter:description"
+      content="Why alerts are most powerful rendered inside a static overlay's DOM, and how Targeting and Triggers fit together."
+    />
+    <meta name="twitter:image"
+          content="https://res.cloudinary.com/dy185omzf/image/upload/v1771771091/ogimage_fepcyf.jpg" />
+    <meta name="twitter:image:alt" content="Overlabels - build Twitch overlays with HTML, CSS, and live data" />
+  </Head>
+
+  <AppLayout :breadcrumbs="breadcrumbs">
+    <div class="min-h-screen bg-background">
+      <div class="mx-auto max-w-4xl p-6">
+
+        <!-- Header -->
+        <div class="mb-10">
+          <Heading
+            title="Overlays vs Alerts"
+            title-class="text-4xl font-bold mb-4"
+            description="Overlabels has two kinds of overlay: the always-on static overlay, and the one-shot alert. They look similar in the editor, but they're meant to work together - and understanding how is the difference between a uniform, polished overlay and a bunch of disconnected boxes."
+          />
+        </div>
+
+        <!-- TOC -->
+        <div class="mb-12 border border-sidebar-border bg-card p-6">
+          <h2 class="mb-4 text-xl font-bold" id="toc">Table of contents</h2>
+          <ol class="list-decimal space-y-1 pl-6 text-foreground">
+            <li><a href="#two-kinds" class="text-violet-400 hover:underline">The two kinds: static and alert</a></li>
+            <li><a href="#inside" class="text-violet-400 hover:underline">Alerts render inside your static overlay</a></li>
+            <li><a href="#standalone" class="text-violet-400 hover:underline">Adding an alert straight to OBS</a></li>
+            <li><a href="#targeting-triggers" class="text-violet-400 hover:underline">Targeting vs Triggers</a></li>
+          </ol>
+        </div>
+
+        <!-- 1. Two kinds -->
+        <section class="mb-14" id="two-kinds">
+          <h2 class="mb-4 text-2xl font-bold">1. The two kinds: static and alert</h2>
+          <div class="mb-4 border border-sidebar-border bg-card p-6">
+            <h3 class="mb-2 text-xl font-semibold">Static overlay</h3>
+            <p class="text-foreground">
+              The always-on layer you add to OBS as a browser source. Follower counters, donation goals, current game,
+              your webcam frame, a subathon timer. It sits on screen for hours, and live values mutate inside it. This
+              is also where your shared styling lives - fonts, colors, CSS variables, the scaffolding everything else
+              hangs off.
+            </p>
+          </div>
+
+          <div class="border border-sidebar-border bg-card p-6">
+            <h3 class="mb-2 text-xl font-semibold">Alert</h3>
+            <p class="text-foreground">
+              The one-shot layer. It fires when an event arrives (a follow, a sub, a raid, a Ko-fi donation), shows the
+              event data for a few seconds, and disappears. An alert is not a standalone scene - it's designed to render
+              <em>inside</em> a static overlay you've already built.
+            </p>
+          </div>
+        </section>
+
+        <!-- 2. Inside -->
+        <section class="mb-14" id="inside">
+          <h2 class="mb-4 text-2xl font-bold">2. Alerts render inside your static overlay</h2>
+          <p class="mb-4 text-foreground">
+            Here's the key idea. When an alert is targeted at a static overlay, it doesn't open its own page - it's
+            appended into the static overlay's DOM, right before the closing
+            <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">&lt;/body&gt;</code> tag. Same document,
+            same stylesheet, same everything.
+          </p>
+
+          <p class="mb-2 text-foreground">Say your static overlay defines a brand color and a styled avatar:</p>
+          <pre class="mb-6 overflow-x-auto rounded border border-sidebar-border bg-card p-4 font-mono text-sm text-foreground"><code>{{ staticExample }}</code></pre>
+
+          <p class="mb-2 text-foreground">
+            When a sub alert fires inside that static overlay, the document looks like this:
+          </p>
+          <pre class="mb-4 overflow-x-auto rounded border border-sidebar-border bg-card p-4 font-mono text-sm text-foreground"><code>{{ insideExample }}</code></pre>
+
+          <div class="rounded-lg border border-violet-400/40 bg-violet-400/5 p-5">
+            <p class="text-foreground">
+              Because the alert lives in the <strong>same document</strong>, its
+              <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">.avatar</code> picks up the exact same
+              <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">border: 3px solid var(--brand)</code>
+              you defined on the static overlay. Every CSS variable, every class, every font you set up once is
+              instantly available to your alert. That's an awesome amount of power: define your structure and styling
+              in one place, and your alerts inherit it for free. The result is a beautifully uniform overlay and alert
+              system that all rely on the same definitions.
+            </p>
+          </div>
+        </section>
+
+        <!-- 3. Standalone -->
+        <section class="mb-14" id="standalone">
+          <h2 class="mb-4 text-2xl font-bold">3. Adding an alert straight to OBS</h2>
+          <p class="mb-4 text-foreground">
+            You <em>can</em> add an alert directly to OBS as its own browser source, and it'll render perfectly fine on
+            its own whenever it fires. Who are we to judge - sometimes that's exactly what you want. But be aware of
+            what you're giving up. A standalone alert is alone in its own document:
+          </p>
+          <pre class="mb-4 overflow-x-auto rounded border border-sidebar-border bg-card p-4 font-mono text-sm text-foreground"><code>{{ standaloneExample }}</code></pre>
+          <p class="text-foreground">
+            No <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">--brand</code> variable, no
+            <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">.avatar</code> rule, none of your static
+            overlay's scaffolding. The alert still works, but you style it from scratch and it won't automatically match
+            the rest of your overlay. If you want that uniform look, render it inside a static overlay instead (see
+            above).
+          </p>
+        </section>
+
+        <!-- 4. Targeting vs Triggers -->
+        <section class="mb-14" id="targeting-triggers">
+          <h2 class="mb-4 text-2xl font-bold">4. Targeting vs Triggers</h2>
+          <p class="mb-4 text-foreground">
+            To render an alert inside a static overlay, open the alert and visit the <strong>Targeting</strong> tab,
+            then choose one or more static overlays where this alert should render.
+          </p>
+          <div class="mb-4 rounded-lg border border-yellow-500/40 bg-yellow-500/5 p-5">
+            <p class="text-foreground">
+              <strong>Heads up:</strong> if you don't set a target overlay, your alert renders in
+              <strong>ALL</strong> of your static overlays. That's usually not what you want - pick your targets
+              deliberately.
+            </p>
+          </div>
+          <p class="mb-3 text-foreground">
+            It's easy to mix up the two alert tabs, so to be clear:
+          </p>
+          <ul class="list-disc space-y-2 pl-6 text-foreground">
+            <li><strong>Triggers</strong> decide <em>on which event</em> this alert fires (a follow, a sub, a Ko-fi donation, and so on).</li>
+            <li><strong>Targeting</strong> decides <em>in which static overlay</em> this alert renders.</li>
+          </ul>
+        </section>
+
+        <!-- Bottom line -->
+        <div class="mb-14 rounded-lg border border-violet-400/40 bg-violet-400/5 p-6">
+          <p class="mb-3 text-lg font-medium text-foreground">Bottom line</p>
+          <p class="text-foreground">
+            Build your structure and styling once in a static overlay, then target your alerts at it so they render in
+            the same DOM and inherit everything. Adding an alert straight to OBS is valid too - it just renders on its
+            own, without your shared scaffolding. Either path works. This is indeed a mouthful, but hey: Overlabels is a
+            mouthful. Enjoy, whichever path you choose. When you're ready, the
+            <Link href="/help/for-designers" class="text-violet-400 hover:underline">For Designers</Link> and
+            <Link href="/help/conditionals" class="text-violet-400 hover:underline">Conditional and Event Tags</Link>
+            pages go deeper on building each surface.
+          </p>
+        </div>
+      </div>
+    </div>
+  </AppLayout>
+</template>

--- a/resources/js/pages/templates/edit.vue
+++ b/resources/js/pages/templates/edit.vue
@@ -16,7 +16,6 @@ import ForkImportWizard from '@/components/ForkImportWizard.vue';
 import IntegrationSuggestionModal from '@/components/IntegrationSuggestionModal.vue';
 import TemplateMeta from '@/components/TemplateMeta.vue';
 import TriggerManager from '@/components/TriggerManager.vue';
-import AddToObsButton from '@/components/AddToObsButton.vue';
 import BrowseFreesoundModal from '@/components/BrowseFreesoundModal.vue';
 import {
   Brackets,
@@ -208,7 +207,6 @@ const mainTabs = computed(() => {
 
 const mainTab = ref<string>('code');
 const localControls = ref<OverlayControl[]>([...(props.controls ?? [])]);
-const obsButton = ref<InstanceType<typeof AddToObsButton> | null>(null);
 
 const localTargetOverlayIds = ref<number[]>([...(props.targetStaticOverlayIds ?? [])]);
 
@@ -429,10 +427,6 @@ onMounted(() => {
     }
     if (props.template?.id) router.visit(route('templates.show', props.template.id));
   }, { description: 'Back to overlay overview' });
-
-  register('add-to-obs', 'a', () => {
-    obsButton.value?.generateOBSUrl();
-  }, { description: 'Add to OBS' });
 });
 
 </script>

--- a/resources/js/pages/templates/show.vue
+++ b/resources/js/pages/templates/show.vue
@@ -34,6 +34,7 @@ import {
   TargetIcon,
   ImageIcon,
   Zap,
+  VideoIcon,
 } from '@lucide/vue';
 import TemplateMeta from '@/components/TemplateMeta.vue';
 import { useTemplateActions } from '@/composables/useTemplateActions';
@@ -42,7 +43,6 @@ import { VisuallyHidden } from 'reka-ui';
 import { Badge } from '@/components/ui/badge';
 
 const showPreview = ref(false);
-const obsButton = ref<InstanceType<typeof AddToObsButton> | null>(null);
 
 interface OverlayOption {
   id: number;
@@ -76,8 +76,16 @@ const props = defineProps<{
 const editorTabs = [
   { key: 'head', label: 'HEAD', icon: FileCode2Icon, color: 'text-pink-500 dark:text-pink-400' },
   { key: 'html', label: 'BODY', icon: CodeIcon, color: 'text-cyan-500 dark:text-cyan-400' },
-  { key: 'css', label: 'CSS', icon: PaletteIcon, color: 'text-lime-500 dark:text-lime-400' }
+  { key: 'css', label: 'CSS', icon: PaletteIcon, color: 'text-lime-500 dark:text-lime-400' },
+  { key: 'add-to-obs', label: 'OBS', icon: VideoIcon, color: 'text-violet-500 dark:text-violet-400' }
 ];
+
+// OBS browser-source URL is owner-only (the token is user-scoped). Available for
+// both static and alert overlays - alerts are usually rendered inside a static
+// overlay, but adding one straight to OBS is valid too, so we inform rather than gate.
+const visibleEditorTabs = computed(() =>
+  editorTabs.filter((tab) => tab.key !== 'add-to-obs' || props.canEdit),
+);
 
 const mainTabs = computed(() => {
   const tabs: Array<{ key: string; label: string; icon: any }> = [
@@ -137,10 +145,6 @@ onMounted(() => {
       if (tab) mainTab.value = tab.key;
     }, { description: `Switch to tab ${i}` });
   }
-
-  register('add-to-obs', 'a', () => {
-    obsButton.value?.generateOBSUrl();
-  }, { description: 'Add to OBS' });
 });
 
 // Use the template actions composable
@@ -366,7 +370,7 @@ const breadcrumbs: BreadcrumbItem[] = [
             <!-- File tabs sidebar -->
             <div class="flex flex-col bg-sidebar text-sidebar-foreground">
               <button
-                v-for="tab in editorTabs"
+                v-for="tab in visibleEditorTabs"
                 :key="tab.key"
                 @click="activeTab = tab.key"
                 :class="[
@@ -382,14 +386,51 @@ const breadcrumbs: BreadcrumbItem[] = [
             </div>
             <!-- Code panel -->
             <div class="relative flex-1  text-gray-700 dark:text-accent-foreground">
-              <pre class="h-[50vh] overflow-auto p-4 bg-white dark:bg-[#160e21]"><code
-                class="text-sm text-muted-foreground">{{ props.template?.[activeTab] || 'No content' }}</code></pre>
-              <button
-                @click="copyToClipboard(props.template?.[activeTab], activeTab.toUpperCase())"
-                class="btn btn-sm btn-chill absolute top-4 right-8 w-30"
+              <!-- Add to OBS panel -->
+              <div
+                v-if="activeTab === 'add-to-obs'"
+                class="h-[50vh] overflow-auto p-6 text-sm text-foreground bg-white dark:bg-[#160e21]"
               >
-                Copy {{ activeTab.toUpperCase() }}
-              </button>
+                <div class="mx-auto max-w-2xl space-y-4">
+                  <div class="flex items-center gap-3">
+                    <VideoIcon class="size-6 text-violet-500 dark:text-violet-400" />
+                    <h3 class="text-lg font-semibold">Add this overlay to OBS</h3>
+                  </div>
+                  <p>
+                    Add this overlay to OBS by clicking the button below and copying the exact URL to your OBS as a browser source.
+                  </p>
+                  <div
+                    v-if="props.template?.type === 'alert'"
+                    class="space-y-2 rounded border-l-4 border-violet-500 bg-violet-500/10 p-3 text-foreground/90"
+                  >
+                    <p class="font-medium text-violet-700 dark:text-violet-300">Heads up: you're adding an alert directly to OBS</p>
+                    <p>
+                      That works fine, but alerts are usually far more powerful rendered inside a static overlay, where they inherit its structure and styling.
+                      <a
+                        :href="route('help.overlays-vs-alerts')"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="cursor-pointer font-medium text-violet-600 underline hover:text-violet-500 dark:text-violet-300"
+                      >Read "Overlays vs Alerts"</a>
+                      so you know what you're doing.
+                    </p>
+                  </div>
+                  <div>
+                    <AddToObsButton :template="props.template" />
+                  </div>
+                </div>
+              </div>
+              <!-- Read-only code view -->
+              <template v-else>
+                <pre class="h-[50vh] overflow-auto p-4 bg-white dark:bg-[#160e21]"><code
+                  class="text-sm text-muted-foreground">{{ props.template?.[activeTab] || 'No content' }}</code></pre>
+                <button
+                  @click="copyToClipboard(props.template?.[activeTab], activeTab.toUpperCase())"
+                  class="btn btn-sm btn-chill absolute top-4 right-8 w-30"
+                >
+                  Copy {{ activeTab.toUpperCase() }}
+                </button>
+              </template>
             </div>
           </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -132,6 +132,10 @@ Route::get('/help/for-designers', function () {
     return Inertia::render('help/ForDesigners');
 })->name('help.for-designers');
 
+Route::get('/help/overlays-vs-alerts', function () {
+    return Inertia::render('help/OverlaysVsAlerts');
+})->name('help.overlays-vs-alerts');
+
 Route::get('/help/formatting', function () {
     return Inertia::render('help/Formatting');
 })->name('help.formatting');


### PR DESCRIPTION
## What

\"Add to OBS\" (the dialog that mints a unique overlay browser-source URL) only lived on the **edit** page, buried in the code editor's tab strip. A user shouldn't have to open EDIT - and step into the code - just to grab a URL. It now lives on the **overlay overview** page (`templates/show`) too.

## Changes

- **`show.vue`**: the read-only HEAD / BODY / CSS tab strip gains a fourth **OBS** tab rendering the existing `AddToObsButton`, mirroring the edit page. Owner-only via a new `visibleEditorTabs` computed (the access token is user-scoped).
- **Inform, don't restrict**: the OBS tab is available for both static *and* alert overlays. Alerts are designed to render inside a static overlay (inheriting its CSS structure and variables), but adding one straight to OBS works fine - so alert templates show a short \"Heads up\" note instead of hiding the option. Same gate fix applied to the edit page's `TemplateCodeEditor` OBS panel (previously hidden for alerts).
- **New help doc** `/help/overlays-vs-alerts` (\"Overlays vs Alerts\"): explains the two overlay kinds with simplified HTML examples (alert inside a static overlay's DOM vs standalone) and clarifies **Targeting** (which static overlay an alert renders in) vs **Triggers** (which event fires it). Registered in `web.php`, added as a card on the help index. The OBS-tab note links to it (new tab).
- **Removed the broken `a` keyboard shortcut** from both `show.vue` and `edit.vue`: in both cases the `obsButton` ref was never bound to the rendered button, so the key did nothing. Dropped the orphaned refs, the dead `AddToObsButton` import on `edit.vue`, and the dangling ref on `TemplateCodeEditor`.

## Verification

- ESLint clean
- `help.overlays-vs-alerts` route registered
- Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)