### PR TITLE
fix(tts): honor static-overlay targeting for alert TTS

### DIFF
--- a/app/Events/TtsAudioReady.php
+++ b/app/Events/TtsAudioReady.php
@@ -20,10 +20,15 @@ class TtsAudioReady implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * @param  array<int,string>|null  $targetSlugs  Static overlay slugs this alert
+     *                                               targets; null = play on all.
+     */
     public function __construct(
         public readonly string $alertId,
         public readonly string $broadcasterId,
         public readonly string $audioUrl,
+        public readonly ?array $targetSlugs = null,
     ) {}
 
     /**
@@ -37,13 +42,16 @@ class TtsAudioReady implements ShouldBroadcast
     }
 
     /**
-     * @return array<string,string>
+     * @return array<string,mixed>
      */
     public function broadcastWith(): array
     {
         return [
             'alert_id' => $this->alertId,
             'audio_url' => $this->audioUrl,
+            // Mirror AlertTriggered so the overlay can gate TTS by target the
+            // same way it gates the visual alert. null = play on all overlays.
+            'target_overlay_slugs' => $this->targetSlugs,
         ];
     }
 

--- a/app/Http/Controllers/ExternalEventController.php
+++ b/app/Http/Controllers/ExternalEventController.php
@@ -67,7 +67,7 @@ class ExternalEventController extends Controller
         ));
 
         if ($ttsText !== null) {
-            SynthesizeAlertTts::dispatch($alertId, (string) $user->twitch_id, $ttsText);
+            SynthesizeAlertTts::dispatch($alertId, (string) $user->twitch_id, $ttsText, $targetSlugs);
         }
 
         // Optional bot chat message - queued for the bot to post. Gated on

--- a/app/Http/Controllers/TwitchEventSubController.php
+++ b/app/Http/Controllers/TwitchEventSubController.php
@@ -642,7 +642,7 @@ class TwitchEventSubController extends Controller
             // overlay correlates the resulting TtsAudioReady by alert_id and
             // schedules playback after tts_delay_ms.
             if ($ttsText !== null) {
-                SynthesizeAlertTts::dispatch($alertId, (string) $user->twitch_id, $ttsText);
+                SynthesizeAlertTts::dispatch($alertId, (string) $user->twitch_id, $ttsText, $targetSlugs);
             }
 
             // Optional bot chat message - queued for the bot to post. Gated on

--- a/app/Jobs/SynthesizeAlertTts.php
+++ b/app/Jobs/SynthesizeAlertTts.php
@@ -27,10 +27,15 @@ class SynthesizeAlertTts implements ShouldQueue
 
     public int $tries = 1;
 
+    /**
+     * @param  array<int,string>|null  $targetSlugs  Static overlay slugs this alert
+     *                                               targets; null = fire on all.
+     */
     public function __construct(
         public readonly string $alertId,
         public readonly string $broadcasterId,
         public readonly string $text,
+        public readonly ?array $targetSlugs = null,
     ) {}
 
     public function handle(TtsService $tts): void
@@ -50,6 +55,7 @@ class SynthesizeAlertTts implements ShouldQueue
             alertId: $this->alertId,
             broadcasterId: $this->broadcasterId,
             audioUrl: $audioUrl,
+            targetSlugs: $this->targetSlugs,
         ));
     }
 }

--- a/app/Services/External/ExternalAlertService.php
+++ b/app/Services/External/ExternalAlertService.php
@@ -65,7 +65,7 @@ class ExternalAlertService
             ));
 
             if ($ttsText !== null) {
-                SynthesizeAlertTts::dispatch($alertId, (string) $user->twitch_id, $ttsText);
+                SynthesizeAlertTts::dispatch($alertId, (string) $user->twitch_id, $ttsText, $targetSlugs);
             }
 
             // Optional bot chat message - queued for the bot to post. Gated on

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,13 @@
 # CHANGELOG JUNE 2026
 
+## June 25th, 2026 - fix(tts): alert TTS now honors static-overlay targeting
+
+An alert template can be "Targeted" at specific static overlays so it only renders where you want it. The visual alert respected that, but the ElevenLabs text-to-speech spoke in **every** open overlay regardless - a targeted donation alert would render in one overlay yet read aloud in all of them at once.
+
+- **Root cause.** TTS audio arrives on a second broadcast (`TtsAudioReady` -> `.tts.ready`), fired by the queued synthesis job after the visual alert. That payload never carried the target slugs - the only thing gating it was an implicit assumption that "if this overlay recorded a pending-TTS entry, it was a target." A non-targeted overlay never records one, so the renderer's "late/forgotten audio" fallback (play immediately) kicked in and spoke it anyway. "No pending entry" was ambiguous - it meant either "not a target" or "a target we forgot" - and the code assumed the latter.
+- **Fix.** `TtsAudioReady` now carries `target_overlay_slugs`, plumbed from the same `$targetSlugs` already computed for `AlertTriggered` at all three dispatch sites (Twitch EventSub, external webhook, external replay) through `SynthesizeAlertTts`. `OverlayRenderer.handleTtsAudioReady()` gates on it with the exact whitelist check the visual alert uses, so TTS honors targeting on its own merits instead of relying on the fragile pending-entry side-channel. The legitimate "late/forgotten audio" fallback stays intact for overlays that *are* targets. Empty/null slugs still means "play on all" (backward-compatible).
+- **Tests**: `AlertTtsExpressionTest` gains 4 cases (synthesis job dispatched with/without target slugs, `TtsAudioReady` payload exposes/null-defaults `target_overlay_slugs`); full TTS + targeting suites green (32 passed). ESLint + Pint clean.
+
 ## June 25th, 2026 - feat(lists): make the recent-events feed panel show its real state
 
 The first cut of the "Send these events to a list" panel had no way to tell whether a list was already an active feed - you'd pick a target, set options, save, and the form reset to blank with no confirmation, so you couldn't be sure it took. (It did: the append writes to the DB; only the live websocket push that would visibly update the list doesn't reach a dev box, which is what made it look broken locally.) The panel now states its state plainly and gives you a concrete signal that events are landing.

--- a/resources/js/components/OverlayRenderer.vue
+++ b/resources/js/components/OverlayRenderer.vue
@@ -1033,6 +1033,14 @@ function handleTtsAudioReady(event: any): void {
   const audioUrl = event?.audio_url;
   if (typeof alertId !== 'string' || typeof audioUrl !== 'string' || !audioUrl) return;
 
+  // Honor targeting independently of the visual alert. This broadcast reaches
+  // every overlay on the user's channel, and the pendingTts map can't gate it:
+  // a non-targeted overlay never records an entry, so the "forgotten audio"
+  // fallback below would otherwise play it immediately. Mirror the same
+  // whitelist check handleAlertTriggered uses.
+  const targetSlugs: string[] | null = event?.target_overlay_slugs ?? null;
+  if (targetSlugs !== null && !targetSlugs.includes(props.slug)) return;
+
   const entry = pendingTts.get(alertId);
   // Late-arriving audio for an alert we've forgotten about: play immediately.
   // No record means no scheduled SFX to wait for either.

--- a/tests/Feature/AlertTtsExpressionTest.php
+++ b/tests/Feature/AlertTtsExpressionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Events\AlertTriggered;
+use App\Events\TtsAudioReady;
 use App\Jobs\SynthesizeAlertTts;
 use App\Models\ExternalEvent;
 use App\Models\ExternalEventTemplateMapping;
@@ -409,4 +410,70 @@ test('SynthesizeAlertTts is NOT dispatched when the tts gate control is off', fu
     $this->actingAs($user)->post("/external-events/{$event->id}/replay");
 
     Bus::assertNotDispatched(SynthesizeAlertTts::class);
+});
+
+test('SynthesizeAlertTts is dispatched with the alert target slugs when set', function () {
+    Event::fake([AlertTriggered::class]);
+    Bus::fake([SynthesizeAlertTts::class]);
+
+    [$user, $alert] = makeUserWithAlertTemplate('Hello [[[event.from_name]]]');
+
+    // Target a single static overlay so the synthesis job must carry its slug.
+    $static = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => 'static',
+        'slug' => 'static-'.fake()->unique()->lexify('????????'),
+    ]);
+    $alert->targetStaticOverlays()->attach($static->id);
+
+    $event = makeKofiDonationEvent($user, ['event.from_name' => 'Sam']);
+
+    $this->actingAs($user)->post("/external-events/{$event->id}/replay");
+
+    Bus::assertDispatched(SynthesizeAlertTts::class, function (SynthesizeAlertTts $job) use ($static) {
+        return $job->targetSlugs === [$static->slug];
+    });
+});
+
+test('SynthesizeAlertTts is dispatched with null target slugs when none set', function () {
+    Event::fake([AlertTriggered::class]);
+    Bus::fake([SynthesizeAlertTts::class]);
+
+    [$user] = makeUserWithAlertTemplate('Hello [[[event.from_name]]]');
+
+    $event = makeKofiDonationEvent($user, ['event.from_name' => 'Tess']);
+
+    $this->actingAs($user)->post("/external-events/{$event->id}/replay");
+
+    Bus::assertDispatched(SynthesizeAlertTts::class, function (SynthesizeAlertTts $job) {
+        return $job->targetSlugs === null;
+    });
+});
+
+test('TtsAudioReady broadcastWith payload exposes target_overlay_slugs', function () {
+    $event = new TtsAudioReady(
+        alertId: 'alert-abc-123',
+        broadcasterId: '12345',
+        audioUrl: 'https://example.com/tts/abc.mp3',
+        targetSlugs: ['my-static-overlay'],
+    );
+
+    $payload = $event->broadcastWith();
+
+    expect($payload['alert_id'])->toBe('alert-abc-123')
+        ->and($payload['audio_url'])->toBe('https://example.com/tts/abc.mp3')
+        ->and($payload['target_overlay_slugs'])->toBe(['my-static-overlay']);
+});
+
+test('TtsAudioReady ships null target_overlay_slugs when the alert targets all overlays', function () {
+    $event = new TtsAudioReady(
+        alertId: 'alert-xyz-789',
+        broadcasterId: '12345',
+        audioUrl: 'https://example.com/tts/xyz.mp3',
+    );
+
+    $payload = $event->broadcastWith();
+
+    expect($payload['target_overlay_slugs'])->toBeNull();
 });


### PR DESCRIPTION
Alert text-to-speech ignored the "Target" whitelist and spoke in every open overlay, while the visual alert correctly fired only in targeted ones.

TTS audio rides a second broadcast (TtsAudioReady -> .tts.ready) that never carried the target slugs. Gating relied on an implicit assumption that an overlay only holds a pending-TTS entry if it was a target; a non-targeted overlay holds none, so handleTtsAudioReady's "late/forgotten audio" fallback played it immediately.

Plumb target_overlay_slugs through SynthesizeAlertTts and TtsAudioReady from the $targetSlugs already computed for AlertTriggered at all three dispatch sites, and gate handleTtsAudioReady on it with the same whitelist check the visual alert uses. The forgotten-audio fallback stays intact for genuine targets; null slugs still play on all overlays.