### PR TITLE
feat(bot): reject slash-command Bot Expressions

### DIFF
--- a/app/Services/Bot/BotExpressionValidator.php
+++ b/app/Services/Bot/BotExpressionValidator.php
@@ -42,6 +42,19 @@ class BotExpressionValidator
             'destroy_hours' => ['nullable', 'integer', 'min:0', 'max:8760'],
         ])->validate();
 
+        // Reject slash commands. The bot replies via the Send Chat Message API,
+        // which transmits literal text only - Twitch drops a leading `/timeout`
+        // (or any slash command) and posts the rest as a plain message, so the
+        // expression silently does nothing useful. We check the raw template
+        // pre-substitution, so chatter args can never inject the leading slash
+        // (the single-pass resolver guarantees this). Kept to one sentence so it
+        // reads under the form field and as a single relayed chat line.
+        if (str_starts_with(ltrim($data['expression']), '/')) {
+            throw ValidationException::withMessages([
+                'expression' => "Expressions can't start with '/'. Slash commands like /timeout only work in Twitch's own chat box; the overlabels bot sends plain text and powers your overlays, it doesn't moderate chat.",
+            ]);
+        }
+
         $command = strtolower(ltrim($data['command'], '!'));
 
         $reserved = array_column(BotCommand::DEFAULTS, 'command');

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,14 @@
 # CHANGELOG JUNE 2026
 
+## June 27th, 2026 - feat(bot): reject slash-command Bot Expressions
+
+A `!vanish` expression with the reply `/timeout [[[bot:from_user]]] 1` posted `@user 1` to chat and timed out nobody. Slash commands are a twitch.tv website convenience; the bot replies via the Send Chat Message API, which transmits literal text only, so Twitch drops the leading `/timeout` (or any slash command) and posts the rest as a plain message. Rather than reinvent moderation through the Helix API - the bot powers your overlays, it isn't a chat moderator - we now catch these at authoring time and explain why.
+
+- **`BotExpressionValidator`**: an expression whose trimmed body starts with `/` is rejected with a one-line message. The check runs on the raw template pre-substitution, so chatter args can never inject the leading slash (the single-pass resolver already guarantees this). Because the validator is shared, this covers both the web form **and** the chat-driven `!ol cmd add ...` path in one place - the chat path already relays validation errors back as a chat line, so the deny shows up there too.
+- **`Edit.vue`**: a live amber note appears the moment the expression starts with `/`, naming `/timeout`, `/ban`, `/me` and explaining that the bot sends plain chat text and isn't a chat moderator - so a web author sees it before submitting instead of bouncing off the server error.
+- No bot, DB, or scope changes - this deliberately does **not** add a moderation lane.
+- Tests: chat-admin path rejects a slashed `!vanish`; web form returns an `expression` validation error and creates nothing. Existing bot-expression/chat-admin/sweep suites green (27 passed). ESLint + Pint clean.
+
 ## June 26th, 2026 - fix(bot): stop the expression preview from jumping on refresh
 
 Each live re-render briefly swapped the resolved output for a one-line "Resolving..." placeholder, then swapped it back. On a multi-line expression that collapse-then-expand made the panel visibly jump on every keystroke - the "jumpy" complaint that prompted the pause toggle in the first place.

--- a/resources/js/pages/settings/bot/expressions/Edit.vue
+++ b/resources/js/pages/settings/bot/expressions/Edit.vue
@@ -177,6 +177,13 @@ function insertSnippet(snippet: string) {
   // Append at end if no selection.
   form.expression = (form.expression ?? '') + snippet;
 }
+
+// Slash commands never make it out of the bot: the Send Chat Message API
+// transmits literal text, so Twitch drops a leading `/timeout` (or any slash
+// command) and posts the rest as plain chat. The server validator rejects
+// these too - this just warns the author live, before they submit, rather
+// than bouncing them off a save error.
+const startsWithSlash = computed(() => (form.expression ?? '').trimStart().startsWith('/'));
 </script>
 
 <template>
@@ -241,6 +248,19 @@ function insertSnippet(snippet: string) {
               placeholder="Hi [[[bot:from_user]]], the count is [[[c:my_counter]]]"
             />
             <p v-if="form.errors.expression" class="text-sm text-rose-400">{{ form.errors.expression }}</p>
+            <div
+              v-if="startsWithSlash"
+              class="flex items-start gap-2 rounded border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200"
+            >
+              <AlertTriangle class="mt-0.5 size-4 shrink-0" />
+              <span>
+                Slash commands like <code class="text-amber-100">/timeout</code>,
+                <code class="text-amber-100">/ban</code> or <code class="text-amber-100">/me</code> don't work here.
+                The overlabels bot sends plain chat text, so Twitch drops the leading
+                <code class="text-amber-100">/</code> and posts the rest as a message. The bot powers your overlays,
+                it isn't a chat moderator - use your mod tools for that.
+              </span>
+            </div>
           </div>
 
           <!-- Preview -->

--- a/tests/Feature/BotChatAdminTest.php
+++ b/tests/Feature/BotChatAdminTest.php
@@ -105,6 +105,20 @@ it('cmd add rejects collision with a builtin', function () {
         ->toContain('built-in');
 });
 
+it('cmd add rejects an expression that starts with a slash command', function () {
+    $user = adminUser();
+
+    postManage(managePayload([
+        'name' => 'vanish',
+        'payload' => '/timeout [[[bot:from_user]]] 1',
+    ]))->assertOk();
+
+    expect(BotExpression::where('user_id', $user->id)->where('command', 'vanish')->exists())->toBeFalse();
+    expect(BotChatOutbox::where('user_id', $user->id)->latest('id')->first()?->message)
+        ->toStartWith('error:')
+        ->toContain("can't start with '/'");
+});
+
 it('cmd edit updates expression payload', function () {
     $user = adminUser();
     BotExpression::create([

--- a/tests/Feature/Settings/BotExpressionDestroyTimerTest.php
+++ b/tests/Feature/Settings/BotExpressionDestroyTimerTest.php
@@ -80,6 +80,19 @@ test('destroy_hours over the one-year cap is rejected', function () {
     expect(BotExpression::where('user_id', $user->id)->count())->toBe(0);
 });
 
+test('an expression starting with a slash command is rejected', function () {
+    $user = timerUser();
+
+    $this->actingAs($user)
+        ->post('/settings/bot/expressions', expressionPayload([
+            'command' => 'vanish',
+            'expression' => '/timeout [[[bot:from_user]]] 1',
+        ]))
+        ->assertSessionHasErrors('expression');
+
+    expect(BotExpression::where('user_id', $user->id)->count())->toBe(0);
+});
+
 test('the edit page serializes destroy_at into the payload', function () {
     $user = timerUser();
     $expr = BotExpression::create([


### PR DESCRIPTION
## Why

A `!vanish` expression with the reply `/timeout [[[bot:from_user]]] 1` posted `@user 1` to chat and timed out nobody. Slash commands are a twitch.tv website convenience; the bot replies via the Send Chat Message API, which transmits literal text only, so Twitch drops the leading `/timeout` (or any slash command) and posts the rest as a plain message.

The decision here is deliberate: **the overlabels bot powers your overlays, it isn't a chat moderator.** Rather than reinvent moderation through the Helix API (which would need a new `moderator:manage:banned_users` scope and a re-consent from every streamer), we catch these at authoring time and explain why.

## What

- **`BotExpressionValidator`**: an expression whose trimmed body starts with `/` is rejected with a one-line message. The check runs on the raw template pre-substitution, so chatter args can never inject the leading slash (the single-pass resolver already guarantees this). Because the validator is shared, this covers both the web form **and** the chat-driven `!ol cmd add ...` path - the chat path already relays validation errors back as a chat line, so the deny shows up there too.
- **`Edit.vue`**: a live amber note appears the moment the expression starts with `/`, naming `/timeout`, `/ban`, `/me` and explaining the bot sends plain chat text and isn't a chat moderator - so a web author sees it before submitting instead of bouncing off the server error.
- No bot, DB, or scope changes - this deliberately does **not** add a moderation lane.

## Testing

- Chat-admin path rejects a slashed `!vanish` (error relayed to chat).
- Web form returns an `expression` validation error and creates nothing.
- Existing bot-expression / chat-admin / sweep suites green (27 passed). ESLint + Pint clean.

To verify on prod: try `!ol cmd add vanish /timeout {user} 1` in chat - the bot should reply with the rejection line, and no expression should be created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)