### PR TITLE
feat(bot): resolve List read tags in chat replies

### DIFF
--- a/app/Http/Controllers/OverlayTemplateController.php
+++ b/app/Http/Controllers/OverlayTemplateController.php
@@ -742,31 +742,7 @@ class OverlayTemplateController extends Controller
      */
     private function sumListItems(string $slug, array $items): string
     {
-        $total = 0.0;
-        $sawNumber = false;
-
-        foreach ($items as $i => $raw) {
-            $trimmed = trim((string) $raw);
-            if ($trimmed === '') {
-                continue;
-            }
-            if (! is_numeric($trimmed)) {
-                return "ERR: list '{$slug}' has non-numeric item '{$raw}' at position {$i}";
-            }
-            $total += (float) $trimmed;
-            $sawNumber = true;
-        }
-
-        // Avoid scientific notation; let the streamer's |number pipe
-        // format if they want commas. Integer-valued sums render
-        // without trailing zeros.
-        if (! $sawNumber) {
-            return '0';
-        }
-
-        return $total == (int) $total
-            ? (string) (int) $total
-            : (string) $total;
+        return ListItems::sum($slug, $items);
     }
 
     /**

--- a/app/Services/Bot/BotExpressionResolver.php
+++ b/app/Services/Bot/BotExpressionResolver.php
@@ -2,12 +2,14 @@
 
 namespace App\Services\Bot;
 
+use App\Models\OptionSet;
 use App\Models\OverlayControl;
 use App\Models\User;
 use App\Services\Expressions\ExpressionFormatter;
 use App\Services\TemplateDataMapperService;
 use App\Services\TwitchApiService;
 use App\Services\TwitchTokenService;
+use App\Support\ListItems;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
@@ -20,10 +22,18 @@ use Throwable;
  * happens to contain something tag-shaped.
  *
  * Tag families inside [[[...]]]:
+ *   c:list:<slug>:<field> -> own List (OptionSet) read tag, snapshot at fire time
  *   c:<key>            -> own OverlayControl by key
  *   c:<service>:<key>  -> service-managed OverlayControl by broadcastKey
  *   bot:<key>          -> per-invocation context (from_user, args.0, ...)
  *   <bare>             -> Twitch Helix tag from TemplateDataMapperService
+ *
+ * List read tags mirror the overlay render projection (OverlayTemplateController),
+ * but chat is a one-shot text sink so every value is a STATIC SNAPSHOT at resolve
+ * time - nothing ticks. Supported fields: count, first, last, empty, sum, random,
+ * expires_at, countdown. Deliberately omitted: the bare c:list:<slug> (raw JSON
+ * array string) and :json (full item objects) - dumping JSON into chat is noise -
+ * plus the .N indexed scalars and foreach machinery, which aren't chat constructs.
  *
  * Pipe formatters (e.g. |number, |round:2, |distance:mi) run after lookup.
  * Unknown tags resolve to empty string per the null-over-placeholder rule.
@@ -64,16 +74,17 @@ class BotExpressionResolver
     public function resolve(User $user, string $expression, array $botContext = [], bool $dryRun = false): string
     {
         $controls = $this->loadControls($user);
+        $lists = $this->loadLists($user);
         $twitchTags = $dryRun ? [] : $this->loadTwitchTags($user);
         $locale = (string) ($user->preference('locale', 'en-US'));
 
         $resolved = preg_replace_callback(
             self::TAG_REGEX,
-            function (array $matches) use ($controls, $twitchTags, $botContext, $locale): string {
+            function (array $matches) use ($controls, $lists, $twitchTags, $botContext, $locale): string {
                 $key = $matches[1];
                 $pipe = ($matches[2] ?? '') !== '' ? $matches[2] : null;
                 $default = isset($matches[3]) ? trim($matches[3]) : null;
-                $value = $this->lookup($key, $controls, $twitchTags, $botContext);
+                $value = $this->lookup($key, $controls, $lists, $twitchTags, $botContext);
 
                 // Absence backstop: an empty value renders the literal default
                 // (verbatim, no pipe). A present value never triggers it.
@@ -99,11 +110,21 @@ class BotExpressionResolver
 
     /**
      * @param  array<string,string>  $controls
+     * @param  array<string,string>  $lists
      * @param  array<string,mixed>  $twitchTags
      * @param  array<string,mixed>  $botContext
      */
-    private function lookup(string $key, array $controls, array $twitchTags, array $botContext): string
+    private function lookup(string $key, array $controls, array $lists, array $twitchTags, array $botContext): string
     {
+        // List read tags resolve from OptionSets, not OverlayControls. Checked
+        // before the generic c: branch, which would otherwise swallow a
+        // c:list:... key into a missing-control empty string. Unsupported list
+        // tags (the bare c:list:<slug> array dump and :json) are never put in
+        // $lists, so they fall through to '' here per null-over-placeholder.
+        if (str_starts_with($key, 'c:list:')) {
+            return $lists[$key] ?? '';
+        }
+
         if (str_starts_with($key, 'c:')) {
             $controlKey = substr($key, 2);
 
@@ -140,6 +161,43 @@ class BotExpressionResolver
                 ? $control->broadcastKey()
                 : $control->key;
             $map[$identifier] = $control->resolveDisplayValue();
+        }
+
+        return $map;
+    }
+
+    /**
+     * Project the user's Lists (OptionSets) into a flat map of
+     * c:list:<slug>:<field> => value string, mirroring the overlay render
+     * projection in OverlayTemplateController. Chat is a one-shot text sink,
+     * so every field is a static snapshot at resolve time - no live ticking.
+     * countdown is computed once as max(0, expires_at - now) instead of the
+     * overlay's RAF-driven timer, since a chat line cannot tick. The bare
+     * array tag, :json, and the foreach-only .N / .count scalars are
+     * intentionally not projected here (see class docblock).
+     *
+     * @return array<string,string> Map of c:list:<slug>:<field> -> value string.
+     */
+    private function loadLists(User $user): array
+    {
+        $now = now()->timestamp;
+        $map = [];
+
+        foreach (OptionSet::where('user_id', $user->id)->get() as $list) {
+            $values = ListItems::values($list->items ?? []);
+            $count = count($values);
+            $base = 'c:list:'.$list->slug;
+
+            $map[$base.':count'] = (string) $count;
+            $map[$base.':first'] = $count > 0 ? $values[0] : '';
+            $map[$base.':last'] = $count > 0 ? $values[$count - 1] : '';
+            $map[$base.':empty'] = $count === 0 ? '1' : '0';
+            $map[$base.':sum'] = ListItems::sum($list->slug, $values);
+            $map[$base.':random'] = $count > 0 ? $values[array_rand($values)] : '';
+
+            $expiresTs = $list->expires_at?->timestamp;
+            $map[$base.':expires_at'] = $expiresTs !== null ? (string) $expiresTs : '';
+            $map[$base.':countdown'] = $expiresTs !== null ? (string) max(0, $expiresTs - $now) : '';
         }
 
         return $map;

--- a/app/Support/ListItems.php
+++ b/app/Support/ListItems.php
@@ -258,6 +258,47 @@ final class ListItems
         );
     }
 
+    /**
+     * Sum the numeric values in a List for the [[[c:list:slug:sum]]] tag.
+     * Whitespace-only / empty values are skipped (treated as 0, since
+     * empties are common as placeholders and aren't really mistakes). Any
+     * other non-numeric content fails loudly with an inline error string
+     * identifying the list slug + offending value + position, so the
+     * streamer can find and fix the broken row. The integer-valued result
+     * renders without a trailing ".0" and avoids scientific notation.
+     *
+     * The single source of truth for sum parity across the overlay render
+     * (OverlayTemplateController), the bot reply resolver
+     * (BotExpressionResolver), and the frontend renderer's computeListSum.
+     *
+     * @param  array<int, string>  $values
+     */
+    public static function sum(string $slug, array $values): string
+    {
+        $total = 0.0;
+        $sawNumber = false;
+
+        foreach (array_values($values) as $i => $raw) {
+            $trimmed = trim((string) $raw);
+            if ($trimmed === '') {
+                continue;
+            }
+            if (! is_numeric($trimmed)) {
+                return "ERR: list '{$slug}' has non-numeric item '{$raw}' at position {$i}";
+            }
+            $total += (float) $trimmed;
+            $sawNumber = true;
+        }
+
+        if (! $sawNumber) {
+            return '0';
+        }
+
+        return $total == (int) $total
+            ? (string) (int) $total
+            : (string) $total;
+    }
+
     private static function coerceValue(mixed $value): string
     {
         if (is_string($value)) {

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,17 @@
 # CHANGELOG JUNE 2026
 
+## June 29th, 2026 - feat(bot): List read tags in chat replies
+
+An append command's success reply (and any Bot Expression) can now read its list back. `[[[bot:from_user|mention]]], encounter [[[c:list:sightings:count]]] logged.` used to drop the count to empty - the bot's `BotExpressionResolver` only knew `OverlayControl`-backed `c:` tags, never Lists (`OptionSet`s), which are resolved on a separate overlay-only path. The resolver now projects the user's Lists too, so list read tags work everywhere bot text is resolved: `success_reply`, `args_empty_reply`, and generic Bot Expressions.
+
+- **`BotExpressionResolver`**: a new `loadLists()` helper mirrors the overlay render projection (`OverlayTemplateController`), and `lookup()` gains a `c:list:` branch checked **before** the generic `c:` control branch (which would otherwise swallow a `c:list:...` key into a missing-control empty). Chat is a one-shot text sink, so every field is a **static snapshot at resolve time** - nothing ticks.
+- **Supported fields:** `count`, `first`, `last`, `empty`, `sum`, `random`, `expires_at`, and `countdown` (computed once as `max(0, expires_at - now)` rather than the overlay's RAF-driven timer, since a chat line can't tick). In the append flow the reply resolves **after** the append commits, so `:count` includes the item just added - "encounter 7 logged" reads 7, not 6.
+- **Deliberately not in chat:** the bare `[[[c:list:slug]]]` (a raw JSON array string) and `[[[c:list:slug:json]]]` (full item objects) resolve to empty - dumping JSON into a chat line is noise, not output. The foreach-only `.N` / `.count` indexed scalars stay overlay-only too.
+- **Pipes and `?? default` compose** with list tags as expected: `[[[c:list:raffle:countdown|duration:mm:ss]]]`, `[[[c:list:quotes:last ?? no quotes yet]]]`.
+- **Parity refactor:** the sum logic now lives once in `ListItems::sum()` (the pure list-item chokepoint); `OverlayTemplateController::sumListItems` delegates to it, so overlay render and chat reply can't drift on the loud non-numeric error path.
+- **UI:** the Lists page's success-reply field hint now names `[[[c:list:<slug>:count]]]` and notes the count is resolved after the append.
+- **Tests:** 12 new (`BotListTagsTest`) covering every field, the empty-list and expired-deadline edges, the dropped bare/`:json` tags, pipe + `??` composition, per-user scoping, and the end-to-end `!sighting` success reply reporting the post-append count. List/bot/unit suites green (76 + 12 passed). Pint clean.
+
 ## June 27th, 2026 - feat(templates): `?? default` fallback for empty tags
 
 Tags that resolve empty left visible holes - `Hi [[[bot:args.0]]]!` with no argument rendered `Hi !`. You can now give any tag a literal fallback for when it comes out empty: `[[[bot:args.0 ?? everyone]]]`, `[[[c:donations|number ?? 0]]]`, `[[[event.user_name ?? a kind stranger]]]`. It's a new slot in the template DSL, deliberately separate from pipe formatters - pipes format a value that's present, `??` supplies literal text when one is absent. The two compose: `[[[amount|currency ?? a mystery sum]]]`.

--- a/resources/js/pages/dashboard/lists/show.vue
+++ b/resources/js/pages/dashboard/lists/show.vue
@@ -1193,7 +1193,8 @@ async function loadMeta() {
                 placeholder="@[[[bot:from_user]]], your entry has been added to the list."
               ></textarea>
               <p class="mt-1 text-xs text-muted-foreground">
-                Spoken in chat after a successful append. Same template syntax as the value template. Leave blank for silent.
+                Spoken in chat after a successful append. Same template syntax as the value template, plus this list's read tags like
+                <span class="font-mono">[[[c:list:{{ list.slug }}:count]]]</span> (resolved after the append, so the count includes it). Leave blank for silent.
               </p>
             </div>
             <div>

--- a/tests/Feature/BotAccountageTest.php
+++ b/tests/Feature/BotAccountageTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
@@ -14,6 +15,17 @@ beforeEach(function () {
         'services.twitch.client_secret' => 'test-client-secret',
     ]);
     Cache::flush();
+
+    // Freeze the clock to a mid-month date so the relative-age fixtures are
+    // deterministic. now()->subMonths(N) overflows a short month when run on
+    // a high day-of-month (e.g. on the 29th, subMonths(4) targets Feb 29 ->
+    // rolls to Mar 1), which made the "4 months" assertion fail on certain
+    // calendar dates. The 15th can't overflow any month.
+    Carbon::setTestNow(Carbon::create(2026, 6, 15, 12));
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
 });
 
 function postAccountage(array $payload): TestResponse

--- a/tests/Feature/BotListTagsTest.php
+++ b/tests/Feature/BotListTagsTest.php
@@ -1,0 +1,227 @@
+<?php
+
+use App\Models\BotChatOutbox;
+use App\Models\ListAppender;
+use App\Models\OptionSet;
+use App\Models\User;
+use App\Services\Bot\BotExpressionResolver;
+use App\Services\Lists\ListAppendService;
+use App\Services\TwitchApiService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Stub the Twitch fetch so the resolver makes no HTTP calls. List tags
+    // need no token, but resolve() still calls loadTwitchTags for bare tags.
+    $stub = new class extends TwitchApiService
+    {
+        public function __construct() {}
+
+        public function getExtendedUserData(string $accessToken, string $twitchId): array
+        {
+            return [];
+        }
+    };
+    app()->instance(TwitchApiService::class, $stub);
+});
+
+function makeListUser(string $login = 'streamer'): User
+{
+    return User::factory()->create([
+        'bot_enabled' => true,
+        'twitch_data' => ['login' => $login],
+        'twitch_id' => (string) fake()->unique()->randomNumber(9),
+    ]);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Read tags resolve the same values the overlay projection ships
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('resolves :count, :first, :last, :empty for a bot reply', function () {
+    $user = makeListUser();
+    OptionSet::create([
+        'user_id' => $user->id,
+        'slug' => 'donors',
+        'items' => ['Alice', 'Bob', 'Carol'],
+    ]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    expect($resolver->resolve($user, '[[[c:list:donors:count]]]'))->toBe('3')
+        ->and($resolver->resolve($user, '[[[c:list:donors:first]]]'))->toBe('Alice')
+        ->and($resolver->resolve($user, '[[[c:list:donors:last]]]'))->toBe('Carol')
+        ->and($resolver->resolve($user, '[[[c:list:donors:empty]]]'))->toBe('0');
+});
+
+it('resolves :empty to "1" and value tags to empty for an empty list', function () {
+    $user = makeListUser();
+    OptionSet::create(['user_id' => $user->id, 'slug' => 'nobody', 'items' => []]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    expect($resolver->resolve($user, '[[[c:list:nobody:empty]]]'))->toBe('1')
+        ->and($resolver->resolve($user, '[[[c:list:nobody:count]]]'))->toBe('0')
+        ->and($resolver->resolve($user, '[[[c:list:nobody:first]]]'))->toBe('')
+        ->and($resolver->resolve($user, '[[[c:list:nobody:random]]]'))->toBe('');
+});
+
+it('resolves :sum and surfaces its loud-failure string', function () {
+    $user = makeListUser();
+    OptionSet::create(['user_id' => $user->id, 'slug' => 'tips', 'items' => ['5', '10', '15.5']]);
+    OptionSet::create(['user_id' => $user->id, 'slug' => 'broken', 'items' => ['10', 'abc']]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    expect($resolver->resolve($user, '[[[c:list:tips:sum]]]'))->toBe('30.5')
+        ->and($resolver->resolve($user, '[[[c:list:broken:sum]]]'))
+        ->toBe("ERR: list 'broken' has non-numeric item 'abc' at position 1");
+});
+
+it('resolves :random to one of the list items', function () {
+    $user = makeListUser();
+    OptionSet::create(['user_id' => $user->id, 'slug' => 'colors', 'items' => ['red', 'green', 'blue']]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    expect($resolver->resolve($user, '[[[c:list:colors:random]]]'))->toBeIn(['red', 'green', 'blue']);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Expiry tags: static snapshot, no live ticking in chat
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('resolves :expires_at and :countdown as a static snapshot', function () {
+    $user = makeListUser();
+    OptionSet::create([
+        'user_id' => $user->id,
+        'slug' => 'raffle',
+        'items' => [],
+        'expires_at' => now()->addSeconds(90),
+    ]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    // countdown is seconds-until-expiry, clamped >= 0. now()->addSeconds(90)
+    // can land on 89 or 90 depending on sub-second timing, so allow both.
+    expect((int) $resolver->resolve($user, '[[[c:list:raffle:countdown]]]'))->toBeGreaterThanOrEqual(88)
+        ->and((int) $resolver->resolve($user, '[[[c:list:raffle:countdown]]]'))->toBeLessThanOrEqual(90)
+        ->and($resolver->resolve($user, '[[[c:list:raffle:expires_at]]]'))->not->toBe('');
+});
+
+it('clamps :countdown to 0 for an already-expired list', function () {
+    $user = makeListUser();
+    OptionSet::create([
+        'user_id' => $user->id,
+        'slug' => 'stale',
+        'items' => [],
+        'expires_at' => now()->subMinutes(5),
+    ]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    expect($resolver->resolve($user, '[[[c:list:stale:countdown]]]'))->toBe('0');
+});
+
+it('resolves expiry tags to empty when the list has no deadline', function () {
+    $user = makeListUser();
+    OptionSet::create(['user_id' => $user->id, 'slug' => 'forever', 'items' => ['x']]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    expect($resolver->resolve($user, '[[[c:list:forever:expires_at]]]'))->toBe('')
+        ->and($resolver->resolve($user, '[[[c:list:forever:countdown]]]'))->toBe('');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Deliberately unsupported in chat: bare array dump + :json
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('drops the bare c:list:<slug> array tag to empty in chat', function () {
+    $user = makeListUser();
+    OptionSet::create(['user_id' => $user->id, 'slug' => 'donors', 'items' => ['Alice', 'Bob']]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    // No raw JSON array dumped into chat.
+    expect($resolver->resolve($user, '[[[c:list:donors]]]'))->toBe('')
+        ->and($resolver->resolve($user, '[[[c:list:donors:json]]]'))->toBe('');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pipe formatters and ?? defaults compose with list tags
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('applies a pipe formatter to a list tag', function () {
+    $user = makeListUser();
+    OptionSet::create(['user_id' => $user->id, 'slug' => 'raffle', 'items' => [], 'expires_at' => now()->addSeconds(125)]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    // 125s -> mm:ss. Allow the boundary second from sub-second timing.
+    expect($resolver->resolve($user, '[[[c:list:raffle:countdown|duration:mm:ss]]]'))
+        ->toBeIn(['02:05', '02:04']);
+});
+
+it('falls back to a ?? default when a list value is empty', function () {
+    $user = makeListUser();
+    OptionSet::create(['user_id' => $user->id, 'slug' => 'quotes', 'items' => []]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    expect($resolver->resolve($user, '[[[c:list:quotes:last ?? no quotes yet]]]'))->toBe('no quotes yet');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Scoping: a list belongs to one user
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('does not resolve another user\'s list', function () {
+    $owner = makeListUser('owner');
+    $other = makeListUser('other');
+    OptionSet::create(['user_id' => $owner->id, 'slug' => 'secret', 'items' => ['a', 'b']]);
+
+    $resolver = app(BotExpressionResolver::class);
+
+    expect($resolver->resolve($other, '[[[c:list:secret:count]]]'))->toBe('');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// End-to-end: the !sighting success reply reports the post-append count
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('reports the post-append count in the success reply', function () {
+    $user = makeListUser('sighting_streamer');
+    $list = OptionSet::create([
+        'user_id' => $user->id,
+        'slug' => 'sightings',
+        'items' => ['enc 1', 'enc 2', 'enc 3', 'enc 4', 'enc 5', 'enc 6'],
+        'next_item_id' => 7,
+    ]);
+    $appender = ListAppender::create([
+        'user_id' => $user->id,
+        'target_list_id' => $list->id,
+        'command' => 'sighting',
+        'value_template' => "We've logged a sighting",
+        'dedup_policy' => ListAppender::DEDUP_NONE,
+        'success_reply' => '[[[bot:from_user|mention]]], your sighting [[[c:list:sightings:count]]] has been logged.',
+    ]);
+
+    $result = app(ListAppendService::class)->fire($appender, $user, [
+        'channel_login' => 'sighting_streamer',
+        'command' => 'sighting',
+        'chatter_id' => '99',
+        'chatter_login' => 'alice',
+        'chatter_display_name' => 'Alice',
+        'args' => '',
+    ]);
+
+    // The 7th item was just appended, so the reply must read 7 (not 6).
+    expect($result['fired'])->toBeTrue()
+        ->and($result['reply'])->toBe('@Alice, your sighting 7 has been logged.');
+
+    $outbox = BotChatOutbox::where('user_id', $user->id)->first();
+    expect($outbox)->not->toBeNull()
+        ->and($outbox->message)->toBe('@Alice, your sighting 7 has been logged.');
+});


### PR DESCRIPTION
## The bug

An Append command's **success reply** (and any Bot Expression) silently dropped `[[[c:list:slug:count]]]` and friends to empty. The bot's `BotExpressionResolver` only knew `c:` tags backed by `OverlayControl` rows; Lists (`OptionSet`s) are projected into flat tag keys on a **separate, overlay-only path** (`OverlayTemplateController` server-side + `OverlayRenderer.vue` live) that the bot reply path never ran. So `c:list:slug:count` fell into the generic `c:` branch, found no matching control, and resolved to empty - while the same tag worked fine in overlays.

## The fix

- **`BotExpressionResolver`**: new `loadLists()` projection mirroring the overlay render, plus a `c:list:` branch in `lookup()` checked **before** the generic `c:` control branch (which would otherwise swallow the key into a missing-control empty). Works everywhere bot text is resolved: `success_reply`, `args_empty_reply`, and generic Bot Expressions.
- **Supported fields** (static snapshot at resolve time - chat is a one-shot text sink, nothing ticks): `count`, `first`, `last`, `empty`, `sum`, `random`, `expires_at`, `countdown` (computed once as `max(0, expires_at - now)`, not the overlay's RAF timer).
- **Deliberately dropped to empty in chat:** the bare `[[[c:list:slug]]]` (raw JSON array string) and `[[[c:list:slug:json]]]` (full item objects) - no JSON dumps in a chat line.
- In the append flow the reply resolves **after** the append commits, so `:count` includes the just-added item ("encounter 7", not 6).
- **Parity refactor:** sum logic extracted to `ListItems::sum()`; `OverlayTemplateController::sumListItems` now delegates to it, so overlay render and chat reply can't drift on the loud non-numeric error path.
- **UI:** the Lists page success-reply field hint now names `[[[c:list:<slug>:count]]]` and notes the count is resolved after the append.
- Pipes and `?? default` compose with list tags as expected.

## Tests

12 new in `BotListTagsTest`: every field, empty-list and expired-deadline edges, the dropped bare/`:json` tags, pipe + `??` composition, per-user scoping, and an end-to-end success reply reporting the post-append count. Related list/bot/unit suites green (138 passed across the footprint). Pint + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)