### PR TITLE
fix(dashboard): match Stream Sessions income by time window, not the session FK

### DIFF
--- a/app/Http/Controllers/StreamSessionController.php
+++ b/app/Http/Controllers/StreamSessionController.php
@@ -698,9 +698,14 @@ class StreamSessionController extends Controller
     }
 
     /**
-     * Per-session external donation income, keyed off the stream_session_id FK
-     * (external events are stamped with their session on the live transition, so
-     * this is exact rather than the time-window approach used for twitch_events).
+     * Per-session external donation income, matched by the same per-session time
+     * window every other stat on this page uses (joined on external_events.created_at).
+     *
+     * The stream_session_id FK is deliberately NOT used: it's only stamped once,
+     * retroactively, at the go-live transition, so it captures just the few seconds
+     * between session start and Helix confirmation - never the donations that arrive
+     * during the live stream. The window join keeps Income consistent with the
+     * headline Twitch numbers and surfaces in-flight donations on a live stream.
      *
      * Returns per-service/per-currency totals plus a bounded list of individual
      * donations. Currencies are never summed across each other - no FX guessing.
@@ -710,37 +715,41 @@ class StreamSessionController extends Controller
      */
     private function loadExternalIncome(int $userId): array
     {
-        $sessionIds = array_keys($this->sessionsCache);
-        if (empty($sessionIds)) {
+        $sessions = $this->sessionsCache;
+        if (empty($sessions)) {
             return [];
         }
-
-        $placeholders = implode(',', array_fill(0, count($sessionIds), '?'));
 
         // Only rows whose amount is a clean, positive numeric string. The regex
         // guard keeps Postgres from erroring on empty or non-numeric amounts
         // (subscriptions, shop orders and GPS pings carry no donation amount).
         $amountGuard = "
-            AND normalized_payload->>'event.amount' ~ '^[0-9]+(\\.[0-9]+)?$'
-            AND (normalized_payload->>'event.amount')::numeric > 0
+            AND e.normalized_payload->>'event.amount' ~ '^[0-9]+(\\.[0-9]+)?$'
+            AND (e.normalized_payload->>'event.amount')::numeric > 0
         ";
+
+        [$cte, $totalsBindings] = $this->buildWindowsCte($sessions);
 
         $totalsSql = "
+            WITH $cte
             SELECT
-                stream_session_id AS session_id,
-                service,
-                COALESCE(NULLIF(normalized_payload->>'event.currency', ''), '') AS currency,
+                w.session_id,
+                e.service,
+                COALESCE(NULLIF(e.normalized_payload->>'event.currency', ''), '') AS currency,
                 COUNT(*) AS cnt,
-                SUM((normalized_payload->>'event.amount')::numeric) AS total
-            FROM external_events
-            WHERE user_id = ?
-              AND stream_session_id IN ($placeholders)
-              $amountGuard
-            GROUP BY stream_session_id, service, currency
-            ORDER BY stream_session_id, total DESC
+                SUM((e.normalized_payload->>'event.amount')::numeric) AS total
+            FROM windows w
+            JOIN external_events e
+                ON e.user_id = ?
+                AND e.created_at >= w.window_start
+                AND e.created_at <= w.window_end
+                $amountGuard
+            GROUP BY w.session_id, e.service, currency
+            ORDER BY w.session_id, total DESC
         ";
+        $totalsBindings[] = $userId;
 
-        $totalsRows = DB::select($totalsSql, [$userId, ...$sessionIds]);
+        $totalsRows = DB::select($totalsSql, $totalsBindings);
 
         $out = [];
         foreach ($totalsRows as $r) {
@@ -757,32 +766,39 @@ class StreamSessionController extends Controller
             $out[$sid]['count'] += (int) $r->cnt;
         }
 
+        [$cte2, $donationBindings] = $this->buildWindowsCte($sessions);
+
         $donationsSql = "
-            WITH ranked AS (
+            WITH $cte2,
+            ranked AS (
                 SELECT
-                    stream_session_id AS session_id,
-                    service,
-                    normalized_payload->>'event.from_name' AS from_name,
-                    (normalized_payload->>'event.amount')::numeric AS amount,
-                    NULLIF(normalized_payload->>'event.currency', '') AS currency,
-                    NULLIF(normalized_payload->>'event.message', '') AS message,
-                    created_at,
+                    w.session_id,
+                    e.service,
+                    e.normalized_payload->>'event.from_name' AS from_name,
+                    (e.normalized_payload->>'event.amount')::numeric AS amount,
+                    NULLIF(e.normalized_payload->>'event.currency', '') AS currency,
+                    NULLIF(e.normalized_payload->>'event.message', '') AS message,
+                    e.created_at,
                     ROW_NUMBER() OVER (
-                        PARTITION BY stream_session_id
-                        ORDER BY created_at DESC
+                        PARTITION BY w.session_id
+                        ORDER BY e.created_at DESC
                     ) AS rn
-                FROM external_events
-                WHERE user_id = ?
-                  AND stream_session_id IN ($placeholders)
-                  $amountGuard
+                FROM windows w
+                JOIN external_events e
+                    ON e.user_id = ?
+                    AND e.created_at >= w.window_start
+                    AND e.created_at <= w.window_end
+                    $amountGuard
             )
             SELECT session_id, service, from_name, amount, currency, message, created_at
             FROM ranked
             WHERE rn <= ?
             ORDER BY session_id, created_at DESC
         ";
+        $donationBindings[] = $userId;
+        $donationBindings[] = self::DONATION_LIMIT;
 
-        $donationRows = DB::select($donationsSql, [$userId, ...$sessionIds, self::DONATION_LIMIT]);
+        $donationRows = DB::select($donationsSql, $donationBindings);
         foreach ($donationRows as $r) {
             $sid = (int) $r->session_id;
             if (! isset($out[$sid])) {

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,13 @@
 # CHANGELOG JUNE 2026
 
+## June 29th, 2026 - fix(dashboard): match Stream Sessions income by time window, not the session FK
+
+The new Income tab showed nothing for a live stream - a donation that landed mid-stream appeared in `/dashboard/recents` but not under the live session's Income tab. Root cause: the income query filtered on `external_events.stream_session_id`, but that FK is only stamped **once, retroactively, at the go-live transition** (`StreamStateMachineService::stampEventsWithSession`). That one-shot stamp covers just the few seconds between session start and Helix confirmation - so virtually every real donation (live or historical) inserts with a null FK and is never re-stamped. `/recents` doesn't filter by the FK, so it showed the donation; the Income tab did, so it didn't. The "exact FK" framing in the previous entry was wrong: the FK is barely populated for any session.
+
+- **`StreamSessionController::loadExternalIncome()`** now joins `external_events` on `created_at` against the same per-session `windows` CTE every other stat on the page already uses (headline counts, redemptions, goals). Income is now consistent with the headline Twitch numbers, surfaces in-flight donations on a live stream, and correctly covers historical streams. No webhook/hot-path changes - read-side query swap only.
+- **Rejected alternative:** stamping external events at insert when live. It touches the webhook hot path, wouldn't retroactively fix the nulls already stored, and the Twitch stats don't use the FK anyway - so it'd add inconsistency, not remove it.
+- **Tests:** `StreamSessionIncomeTest` updated to leave the FK null and rely on the window (as a real donation does), plus a new out-of-window donation asserted absent from the session. Both green (25 assertions). Controller lint clean.
+
 ## June 29th, 2026 - feat(dashboard): rebuild Stream Sessions as a selector + tabbed panel, add connected-service income
 
 `/dashboard/stream-sessions` was a vertical stack of expandable cards where every headline tile invented its own accent (violet/amber/cyan/rose/red/emerald top-borders) and the detail sub-blocks reassigned those same colors to different meanings - decoration pretending to be information. It was also blind to money: the controller only ever queried `twitch_events`, so Ko-fi / StreamLabs / StreamElements / Buy Me a Coffee / Fourthwall donations - already linked to their session by the `external_events.stream_session_id` FK - never appeared. Rebuilt as a focused data tool: pick one stream from a rail, read it in a tabbed panel.

--- a/tests/Feature/StreamSessionIncomeTest.php
+++ b/tests/Feature/StreamSessionIncomeTest.php
@@ -4,17 +4,22 @@ use App\Models\ExternalEvent;
 use App\Models\StreamSession;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 
 uses(RefreshDatabase::class);
 
-function makeDonation(int $userId, int $sessionId, string $service, string $amount, string $currency, string $from, ?string $message = null): void
+/**
+ * Income is matched by the session time window, NOT the stream_session_id FK -
+ * so these donations deliberately leave the FK null and rely on created_at
+ * falling inside the window, exactly as a real live donation does.
+ */
+function makeDonation(int $userId, string $service, string $amount, string $currency, string $from, Carbon $at, ?string $message = null): void
 {
-    ExternalEvent::create([
+    $event = new ExternalEvent([
         'user_id' => $userId,
         'service' => $service,
         'event_type' => 'donation',
         'message_id' => (string) fake()->unique()->uuid(),
-        'stream_session_id' => $sessionId,
         'raw_payload' => [],
         'normalized_payload' => [
             'event.from_name' => $from,
@@ -25,6 +30,10 @@ function makeDonation(int $userId, int $sessionId, string $service, string $amou
             'event.type' => 'donation',
         ],
     ]);
+    // Set created_at manually so it's "dirty" and Eloquent won't override it
+    // with now() on insert - this is what places the event inside the window.
+    $event->created_at = $at;
+    $event->save();
 }
 
 it('aggregates external donation income per session, split by service and currency', function () {
@@ -36,20 +45,26 @@ it('aggregates external donation income per session, split by service and curren
         'ended_at' => now()->subHour(),
     ]);
 
-    makeDonation($user->id, $session->id, 'kofi', '50.00', 'USD', 'alice', 'love the stream!');
-    makeDonation($user->id, $session->id, 'kofi', '9.00', 'USD', 'bob');
-    makeDonation($user->id, $session->id, 'streamelements', '25.00', 'EUR', 'chris', 'o7');
+    // All inside the window (between started_at and ended_at), FK left null.
+    $mid = now()->subHours(2);
+    makeDonation($user->id, 'kofi', '50.00', 'USD', 'alice', $mid, 'love the stream!');
+    makeDonation($user->id, 'kofi', '9.00', 'USD', 'bob', $mid);
+    makeDonation($user->id, 'streamelements', '25.00', 'EUR', 'chris', $mid, 'o7');
+
+    // Outside the window (5 hours ago) - must NOT be counted for this session.
+    makeDonation($user->id, 'kofi', '999.00', 'USD', 'ghost', now()->subHours(5));
 
     // A non-donation external event (no amount) must be ignored, not crash the cast.
-    ExternalEvent::create([
+    $sub = new ExternalEvent([
         'user_id' => $user->id,
         'service' => 'kofi',
         'event_type' => 'subscription',
         'message_id' => (string) fake()->unique()->uuid(),
-        'stream_session_id' => $session->id,
         'raw_payload' => [],
         'normalized_payload' => ['event.from_name' => 'dana', 'event.amount' => ''],
     ]);
+    $sub->created_at = $mid;
+    $sub->save();
 
     $response = $this->actingAs($user)->get('/dashboard/stream-sessions');
 


### PR DESCRIPTION
## What

The Income tab (shipped in #136) showed **nothing for a live stream**: a donation that landed mid-stream appeared in `/dashboard/recents` but not under the live session's Income tab.

## Root cause

`loadExternalIncome()` filtered on `external_events.stream_session_id`. That FK is stamped **only once - retroactively, at the go-live transition** (`StreamStateMachineService::stampEventsWithSession`), covering just the few seconds between session start and Helix confirmation. Virtually every real donation - live or historical - inserts with a **null** FK and is never re-stamped, so the FK-filtered query missed it. `/recents` doesn't filter by the FK, which is why it showed the donation and the Income tab didn't.

The "exact FK" framing in #136 was wrong: the FK is barely populated for any session.

## Fix

Join `external_events` on `created_at` against the same per-session `windows` CTE every other stat on the page already uses (headline counts, redemptions, goals). Income is now:
- consistent with the headline Twitch numbers (shared window),
- correct on a **live** stream (the window runs to `now + buffer`, so in-flight donations fall inside it),
- correct for **historical** streams (which were quietly broken the same way).

Read-side query swap only - **no webhook / hot-path changes**.

**Rejected alternative:** stamping external events at insert when live. Touches the webhook hot path, wouldn't retroactively fix the nulls already stored, and the Twitch stats don't use the FK anyway - so it'd add inconsistency, not remove it.

## Tests

`StreamSessionIncomeTest` updated to leave the FK null and rely on the window (as a real donation does), plus a new out-of-window donation asserted absent from the session. Both green (25 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)