### PR TITLE
feat(triggers): donation amount variants for external services (Phase 2)

### DIFF
--- a/app/Http/Controllers/ExternalEventController.php
+++ b/app/Http/Controllers/ExternalEventController.php
@@ -26,19 +26,21 @@ class ExternalEventController extends Controller
             return back()->with('message', 'You do not own this event.')->with('type', 'error');
         }
 
-        $mapping = ExternalEventTemplateMapping::with(['template', 'template.targetStaticOverlays'])
-            ->where('user_id', $user->id)
-            ->where('service', $externalEvent->service)
-            ->where('event_type', $externalEvent->event_type)
-            ->where('enabled', true)
-            ->first();
+        $data = $externalEvent->normalized_payload ?? [];
+
+        $mapping = ExternalEventTemplateMapping::resolveForEvent(
+            $user->id,
+            $externalEvent->service,
+            $externalEvent->event_type,
+            $data['event.amount'] ?? null,
+        );
 
         if (! $mapping || ! $mapping->template) {
             return back()->with('message', 'No active alert mapping found for this event type.')->with('type', 'error');
         }
 
         $template = $mapping->template;
-        $data = $externalEvent->normalized_payload ?? [];
+        $template->loadMissing('targetStaticOverlays');
 
         $targetSlugs = $template->targetStaticOverlays->isNotEmpty()
             ? $template->targetStaticOverlays->pluck('slug')->all()

--- a/app/Http/Controllers/OverlayTemplateController.php
+++ b/app/Http/Controllers/OverlayTemplateController.php
@@ -870,10 +870,12 @@ class OverlayTemplateController extends Controller
 
         $assignedExternal = ExternalEventTemplateMapping::where('user_id', $userId)
             ->where('overlay_template_id', $template->id)
-            ->get(['service', 'event_type', 'duration_ms', 'enabled'])
+            ->get(['service', 'event_type', 'condition_type', 'condition_value', 'duration_ms', 'enabled'])
             ->map(fn (ExternalEventTemplateMapping $m) => [
                 'service' => $m->service,
                 'event_type' => $m->event_type,
+                'condition_type' => $m->condition_type,
+                'condition_value' => $m->condition_value,
                 'duration_ms' => $m->duration_ms,
                 'enabled' => (bool) $m->enabled,
             ])
@@ -890,6 +892,9 @@ class OverlayTemplateController extends Controller
             // Which Twitch event types support a variant condition, and the
             // unit label for each (drives the per-row condition picker).
             'amountFields' => EventTemplateMapping::AMOUNT_FIELDS,
+            // Which external (service => event types) support an amount
+            // condition (donation variants). Same picker, "amount" unit.
+            'externalAmountEventTypes' => ExternalEventTemplateMapping::AMOUNT_EVENT_TYPES,
             'connectedServices' => $connectedServices,
             'assigned' => [
                 'twitch' => $assignedTwitch,
@@ -923,6 +928,8 @@ class OverlayTemplateController extends Controller
             'external' => ['nullable', 'array'],
             'external.*.service' => ['required', 'string', 'in:'.implode(',', array_keys(ExternalEventTemplateMapping::SERVICE_EVENT_TYPES))],
             'external.*.event_type' => ['required', 'string'],
+            'external.*.condition_type' => ['nullable', 'string', 'in:'.ExternalEventTemplateMapping::CONDITION_AT_LEAST.','.ExternalEventTemplateMapping::CONDITION_EXACTLY],
+            'external.*.condition_value' => ['nullable', 'integer', 'min:1', 'max:100000000', 'required_with:external.*.condition_type'],
             'external.*.duration_ms' => ['required', 'integer', 'min:1000', 'max:999000'],
             'external.*.enabled' => ['required', 'boolean'],
         ]);
@@ -995,18 +1002,42 @@ class OverlayTemplateController extends Controller
             });
 
         foreach ($external as $row) {
+            // A condition only means something for amount-bearing events
+            // (donations). Strip it otherwise so a stale picker value can't
+            // smuggle a non-matchable row in.
+            $supportsCondition = ExternalEventTemplateMapping::supportsCondition($row['service'], $row['event_type']);
+            $conditionType = $supportsCondition ? ($row['condition_type'] ?? null) : null;
+            $conditionValue = $conditionType !== null ? ($row['condition_value'] ?? null) : null;
+
+            // Key on (user, template, service, event_type): each template owns
+            // one row per external event type, but many templates can map the
+            // same donation with different conditions - the variant ladder.
             ExternalEventTemplateMapping::updateOrCreate(
                 [
                     'user_id' => $userId,
+                    'overlay_template_id' => $template->id,
                     'service' => $row['service'],
                     'event_type' => $row['event_type'],
                 ],
                 [
-                    'overlay_template_id' => $template->id,
+                    'condition_type' => $conditionType,
+                    'condition_value' => $conditionValue,
                     'duration_ms' => $row['duration_ms'],
                     'enabled' => $row['enabled'],
                 ]
             );
+
+            // Non-amount events keep the one-template-per-event invariant:
+            // there is no condition to tell two rows apart, so claiming the
+            // event for this template releases it from any other. Amount-bearing
+            // events skip this - multiple templates coexisting IS the variant set.
+            if (! $supportsCondition) {
+                ExternalEventTemplateMapping::where('user_id', $userId)
+                    ->where('service', $row['service'])
+                    ->where('event_type', $row['event_type'])
+                    ->where('overlay_template_id', '!=', $template->id)
+                    ->delete();
+            }
         }
 
         return back()->with('message', 'Triggers saved.')->with('type', 'success');

--- a/app/Models/ExternalEventTemplateMapping.php
+++ b/app/Models/ExternalEventTemplateMapping.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Carbon;
  * @property int $user_id
  * @property string $service
  * @property string $event_type
+ * @property string|null $condition_type
+ * @property int|null $condition_value
  * @property int|null $overlay_template_id
  * @property bool $enabled
  * @property Carbon|null $created_at
@@ -21,6 +23,7 @@ use Illuminate\Support\Carbon;
  * @property array<array-key, mixed>|null $settings
  * @property-read OverlayTemplate|null $template
  * @property-read User|null $user
+ *
  * @method static Builder<static>|ExternalEventTemplateMapping newModelQuery()
  * @method static Builder<static>|ExternalEventTemplateMapping newQuery()
  * @method static Builder<static>|ExternalEventTemplateMapping query()
@@ -34,6 +37,7 @@ use Illuminate\Support\Carbon;
  * @method static Builder<static>|ExternalEventTemplateMapping whereSettings($value)
  * @method static Builder<static>|ExternalEventTemplateMapping whereUpdatedAt($value)
  * @method static Builder<static>|ExternalEventTemplateMapping whereUserId($value)
+ *
  * @mixin Eloquent
  * @mixin IdeHelperExternalEventTemplateMapping
  */
@@ -43,6 +47,8 @@ class ExternalEventTemplateMapping extends Model
         'user_id',
         'service',
         'event_type',
+        'condition_type',
+        'condition_value',
         'overlay_template_id',
         'enabled',
         'duration_ms',
@@ -52,8 +58,44 @@ class ExternalEventTemplateMapping extends Model
     protected $casts = [
         'enabled' => 'boolean',
         'duration_ms' => 'integer',
+        'condition_value' => 'integer',
         'settings' => 'array',
     ];
+
+    /** Variant condition: fire only when amount >= condition_value. */
+    public const string CONDITION_AT_LEAST = 'at_least';
+
+    /** Variant condition: fire only when amount === condition_value. */
+    public const string CONDITION_EXACTLY = 'exactly';
+
+    /**
+     * External (service => event types) that carry a monetary amount a variant
+     * condition can compare against. Scoped to the donation event of each
+     * donation service - the headline "alerts by amount" case. Other monetary
+     * types (Ko-fi shop orders, BMAC extras) can be added here later; events
+     * absent here always resolve to their base row.
+     *
+     * The threshold is a whole currency unit and is currency-naive (no FX) -
+     * it compares the raw numeric amount, matching the no-exchange-rate stance
+     * the Stream Sessions income view already takes.
+     *
+     * @var array<string, array<int, string>>
+     */
+    public const array AMOUNT_EVENT_TYPES = [
+        'bmac' => ['donation'],
+        'fourthwall' => ['donation'],
+        'kofi' => ['donation'],
+        'streamelements' => ['donation'],
+        'streamlabs' => ['donation'],
+    ];
+
+    /**
+     * Whether a (service, event_type) pair supports a variant condition.
+     */
+    public static function supportsCondition(string $service, string $eventType): bool
+    {
+        return in_array($eventType, self::AMOUNT_EVENT_TYPES[$service] ?? [], true);
+    }
 
     /**
      * Event types per external service (service key => [event_type => display label]).
@@ -104,5 +146,69 @@ class ExternalEventTemplateMapping extends Model
     public function template(): BelongsTo
     {
         return $this->belongsTo(OverlayTemplate::class, 'overlay_template_id');
+    }
+
+    /**
+     * Pick the winning mapping for an incoming external event, honoring variant
+     * conditions on the donated amount. Replaces the bare `->first()` lookup at
+     * both firing sites (live webhook dispatch, replay) so selection can't drift.
+     *
+     * Ladder (most specific first):
+     *   1. `exactly N`  where amount === N
+     *   2. `at_least N` where amount >= N - highest N wins
+     *   3. base row (no condition) - the catch-all fallback
+     *
+     * Ties at the same threshold break on lowest overlay_template_id. Event
+     * types without a monetary amount skip the ladder and resolve to their base
+     * row, which is exactly the original behavior. A null/blank amount is read
+     * as 0, so a conditioned-only set with no base falls through to null.
+     */
+    public static function resolveForEvent(int $userId, string $service, string $eventType, ?string $amount): ?self
+    {
+        $mappings = self::with('template')
+            ->where('user_id', $userId)
+            ->where('service', $service)
+            ->where('event_type', $eventType)
+            ->where('enabled', true)
+            ->get()
+            ->filter(fn (self $m) => $m->template !== null);
+
+        if ($mappings->isEmpty()) {
+            return null;
+        }
+
+        // No monetary field to condition on - there is only ever a base row.
+        if (! self::supportsCondition($service, $eventType)) {
+            return $mappings->sortBy('overlay_template_id')->first();
+        }
+
+        $value = (float) ($amount ?? 0);
+
+        $exact = $mappings
+            ->filter(fn (self $m) => $m->condition_type === self::CONDITION_EXACTLY
+                && $m->condition_value !== null
+                && abs($value - $m->condition_value) < 0.001)
+            ->sortBy('overlay_template_id')
+            ->first();
+        if ($exact !== null) {
+            return $exact;
+        }
+
+        $atLeast = $mappings
+            ->filter(fn (self $m) => $m->condition_type === self::CONDITION_AT_LEAST
+                && $m->condition_value !== null
+                && $value >= $m->condition_value)
+            // Highest threshold first; lowest template id breaks ties.
+            ->sort(fn (self $a, self $b) => [$b->condition_value, $a->overlay_template_id]
+                <=> [$a->condition_value, $b->overlay_template_id])
+            ->first();
+        if ($atLeast !== null) {
+            return $atLeast;
+        }
+
+        return $mappings
+            ->filter(fn (self $m) => $m->condition_type === null)
+            ->sortBy('overlay_template_id')
+            ->first();
     }
 }

--- a/app/Services/External/ExternalAlertService.php
+++ b/app/Services/External/ExternalAlertService.php
@@ -19,12 +19,14 @@ class ExternalAlertService
      */
     public function dispatch(NormalizedExternalEvent $event, User $user): bool
     {
-        $mapping = ExternalEventTemplateMapping::where('user_id', $user->id)
-            ->where('service', $event->getService())
-            ->where('event_type', $event->getEventType())
-            ->where('enabled', true)
-            ->with('template')
-            ->first();
+        // Pick the alert template, honoring variant conditions on the donated
+        // amount (e.g. a louder alert for a bigger Ko-fi donation).
+        $mapping = ExternalEventTemplateMapping::resolveForEvent(
+            $user->id,
+            $event->getService(),
+            $event->getEventType(),
+            $event->getAmount(),
+        );
 
         if (! $mapping || ! $mapping->template) {
             return false;

--- a/database/migrations/2026_06_30_000002_add_conditions_to_external_event_template_mappings.php
+++ b/database/migrations/2026_06_30_000002_add_conditions_to_external_event_template_mappings.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Phase 2 of alert variants: external donation amounts. Mirrors the Twitch
+     * side (event_template_mappings) - a single donation event type can now
+     * resolve to different alert templates depending on the donated amount.
+     *
+     * The old unique(user_id, service, event_type) enforced one template per
+     * external event type. We re-key it to include overlay_template_id so many
+     * templates can map the same (service, donation) with different conditions,
+     * which is what makes the variant ladder.
+     */
+    public function up(): void
+    {
+        Schema::table('external_event_template_mappings', function (Blueprint $table) {
+            // null = base/catch-all (today's behavior); 'at_least' / 'exactly'
+            $table->string('condition_type')->nullable()->after('event_type');
+            // null for base rows; the amount threshold (whole currency units)
+            $table->unsignedInteger('condition_value')->nullable()->after('condition_type');
+
+            $table->dropUnique(['user_id', 'service', 'event_type']);
+            $table->unique(['user_id', 'overlay_template_id', 'service', 'event_type'], 'ext_mapping_user_tpl_service_event_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('external_event_template_mappings', function (Blueprint $table) {
+            $table->dropUnique('ext_mapping_user_tpl_service_event_unique');
+            $table->unique(['user_id', 'service', 'event_type']);
+
+            $table->dropColumn(['condition_type', 'condition_value']);
+        });
+    }
+};

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,16 @@
 # CHANGELOG JUNE 2026
 
+## June 30th, 2026 - feat(triggers): donation amount variants (Phase 2 - Ko-fi / StreamLabs / StreamElements / BMAC / Fourthwall)
+
+Phase 2 of alert variants extends the same machinery to external donations: a bigger Ko-fi donation can now fire a louder alert than a small one, the same way cheer bits do. Built directly on the Phase 1 frontend - the Triggers tab condition picker now appears on donation rows too, no new UI component.
+
+- **Conditions on donations** - `At least N` / `Exactly N` on the `donation` event of each donation service (Ko-fi, StreamLabs, StreamElements, Buy Me a Coffee, Fourthwall), listed in the new `ExternalEventTemplateMapping::AMOUNT_EVENT_TYPES` registry. Every other external event type (subscriptions, shop orders, GPS pings) keeps its single base row.
+- **One resolver, both firing sites** - `ExternalEventTemplateMapping::resolveForEvent()` replaces the bare `->first()` in `ExternalAlertService::dispatch` (live webhook, amount from `NormalizedExternalEvent::getAmount()`) and `ExternalEventController::replay` (amount from the stored `normalized_payload['event.amount']`). Same ladder as Twitch: `exactly == amount` -> highest matching `at_least` -> base -> nothing; ties break on lowest `overlay_template_id`.
+- **Whole-unit, currency-naive thresholds** - the threshold is an integer (e.g. "at least 5"); the donated amount is parsed as a float and compared raw, with **no FX conversion** (matching the no-exchange-rate stance the Stream Sessions income view already takes). A 4.99 donation falls below an "at least 5" tier; 5.00 meets it. `exactly` uses a small epsilon so 5.00 matches a threshold of 5. A null/blank amount reads as 0.
+- **Schema** - `2026_06_30_000002_add_conditions_to_external_event_template_mappings` adds `condition_type` + `condition_value` and re-keys `unique(user_id, service, event_type)` to `unique(user_id, overlay_template_id, service, event_type)` so many templates can map the same donation. Non-amount external events keep one-template-per-event (ownership moves on reassign), mirroring Twitch.
+- **Write-path guards** - a condition is stripped server-side for non-amount external events, `condition_value` is `required_with` its `condition_type`, and an unknown `condition_type` is rejected.
+- **Tests:** 16 new (`ExternalEventVariantsTest`) covering the ladder, the decimal-below/at-threshold edges, null/blank-as-zero, tie-break, disabled skip, the non-amount-type passthrough, two-templates-coexist, the non-amount strip + ownership-move, and both validation rejections. Full suite **958 passed**; Pint + ESLint + vite build clean.
+
 ## June 30th, 2026 - feat(triggers): alert variants by amount (cheer bits, gift count, raid viewers)
 
 One alert template per event type was a hard limit baked into the schema: `event_template_mappings` carried a `unique(user_id, event_type)`, so a single `channel.cheer` could only ever fire one alert no matter how many bits were thrown. Streamers wanted what Twitch Alerts calls "variants" - a 5000-bit cheer deserving a louder alert than a 100-bit one. You can now give an amount-bearing event a condition per template, and the matching variant wins. The look/sound/TTS/controls already live on the template, so a "variant" is just **a template plus a condition** - no new alert plumbing.

--- a/resources/js/components/TriggerManager.vue
+++ b/resources/js/components/TriggerManager.vue
@@ -17,6 +17,8 @@ interface TwitchAssignment {
 interface ExternalAssignment {
   service: string;
   event_type: string;
+  condition_type: string | null;
+  condition_value: number | null;
   duration_ms: number;
   enabled: boolean;
 }
@@ -26,6 +28,8 @@ interface TriggerData {
   externalEventTypes: Record<string, Record<string, string>>;
   /** Event types that support a variant condition, mapped to their unit label. */
   amountFields: Record<string, { path: string; unit: string }>;
+  /** External (service -> event types) that support an amount condition. */
+  externalAmountEventTypes: Record<string, string[]>;
   connectedServices: string[];
   assigned: {
     twitch: TwitchAssignment[];
@@ -83,9 +87,8 @@ const externalRowsByService = ref<Record<string, Row[]>>(
         return {
           event_type: eventType,
           event_label: label,
-          // External donation variants land in Phase 2; no condition here yet.
-          condition_type: null,
-          condition_value: null,
+          condition_type: existing?.condition_type ?? null,
+          condition_value: existing?.condition_value ?? null,
           duration_ms: existing?.duration_ms ?? DEFAULT_DURATION_MS,
           enabled: existing?.enabled ?? false,
           service,
@@ -130,6 +133,14 @@ function rowSearchText(row: Row): string {
   return `${row.event_label} ${row.event_type} ${row.service} ${rowKeyText(row)}`;
 }
 
+/** Unit label for the condition picker, or undefined if the row has no amount. */
+function amountUnitFor(row: Row): string | undefined {
+  if (!row.service) {
+    return props.triggers.amountFields[row.event_type]?.unit;
+  }
+  return props.triggers.externalAmountEventTypes[row.service]?.includes(row.event_type) ? 'amount' : undefined;
+}
+
 const isSaving = ref(false);
 
 function save() {
@@ -152,6 +163,8 @@ function save() {
       .map((r) => ({
         service: r.service,
         event_type: r.event_type,
+        condition_type: r.condition_type,
+        condition_value: r.condition_value,
         duration_ms: r.duration_ms,
         enabled: r.enabled,
       })),
@@ -206,7 +219,7 @@ function save() {
         v-model:duration-ms="item.duration_ms"
         v-model:condition-type="item.condition_type"
         v-model:condition-value="item.condition_value"
-        :amount-unit="group.key === TWITCH_GROUP_KEY ? triggers.amountFields[item.event_type]?.unit : undefined"
+        :amount-unit="amountUnitFor(item)"
         :label="item.event_label"
         :key-text="rowKeyText(item)"
         :toggle-checked-class="

--- a/tests/Feature/ExternalEventVariantsTest.php
+++ b/tests/Feature/ExternalEventVariantsTest.php
@@ -1,0 +1,240 @@
+<?php
+
+use App\Models\ExternalEventTemplateMapping;
+use App\Models\OverlayTemplate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+uses(DatabaseTransactions::class);
+
+/**
+ * @return array{0: User, 1: array<int, OverlayTemplate>}
+ */
+function makeUserWithAlertTemplates(int $count = 1): array
+{
+    $user = User::factory()->create(['twitch_id' => (string) fake()->unique()->randomNumber(9)]);
+
+    $templates = [];
+    for ($i = 0; $i < $count; $i++) {
+        $templates[] = OverlayTemplate::factory()->create([
+            'owner_id' => $user->id,
+            'fork_of_id' => null,
+            'type' => 'alert',
+            'slug' => 'alert-'.fake()->unique()->lexify('????????'),
+        ]);
+    }
+
+    return [$user, $templates];
+}
+
+function makeDonationMapping(User $user, OverlayTemplate $template, ?string $type, ?int $value, string $service = 'kofi'): ExternalEventTemplateMapping
+{
+    return ExternalEventTemplateMapping::create([
+        'user_id' => $user->id,
+        'service' => $service,
+        'event_type' => 'donation',
+        'condition_type' => $type,
+        'condition_value' => $value,
+        'overlay_template_id' => $template->id,
+        'duration_ms' => 5000,
+        'enabled' => true,
+    ]);
+}
+
+test('exactly match beats at_least and base', function () {
+    [$user, $t] = makeUserWithAlertTemplates(3);
+    makeDonationMapping($user, $t[0], null, null);
+    makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 5);
+    $exact = makeDonationMapping($user, $t[2], ExternalEventTemplateMapping::CONDITION_EXACTLY, 10);
+
+    $winner = ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '10.00');
+
+    expect($winner?->id)->toBe($exact->id);
+});
+
+test('highest matching at_least threshold wins', function () {
+    [$user, $t] = makeUserWithAlertTemplates(3);
+    makeDonationMapping($user, $t[0], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 1);
+    makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 5);
+    $big = makeDonationMapping($user, $t[2], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 50);
+
+    $winner = ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '100.00');
+
+    expect($winner?->id)->toBe($big->id);
+});
+
+test('at_least falls through to a lower tier below the top threshold', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    $small = makeDonationMapping($user, $t[0], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 1);
+    makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 50);
+
+    $winner = ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '20.00');
+
+    expect($winner?->id)->toBe($small->id);
+});
+
+test('decimal amount below a whole-unit threshold does not match it', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    $base = makeDonationMapping($user, $t[0], null, null);
+    makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 5);
+
+    // 4.99 is below the "at least 5" tier - falls to base.
+    expect(ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '4.99')?->id)->toBe($base->id);
+});
+
+test('decimal amount at or above a whole-unit threshold matches it', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    makeDonationMapping($user, $t[0], null, null);
+    $tier = makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 5);
+
+    expect(ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '5.00')?->id)->toBe($tier->id);
+});
+
+test('base row is the fallback when no condition matches', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    $base = makeDonationMapping($user, $t[0], null, null);
+    makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 50);
+
+    $winner = ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '5.00');
+
+    expect($winner?->id)->toBe($base->id);
+});
+
+test('no match and no base row resolves to null', function () {
+    [$user, $t] = makeUserWithAlertTemplates(1);
+    makeDonationMapping($user, $t[0], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 50);
+
+    expect(ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '5.00'))->toBeNull();
+});
+
+test('null or blank amount is treated as zero', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    $base = makeDonationMapping($user, $t[0], null, null);
+    makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 1);
+
+    expect(ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', null)?->id)->toBe($base->id);
+    expect(ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '')?->id)->toBe($base->id);
+});
+
+test('equal at_least thresholds break the tie on lowest template id', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    $first = makeDonationMapping($user, $t[0], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 5);
+    makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_AT_LEAST, 5);
+
+    $winner = ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '20.00');
+
+    expect($winner?->id)->toBe($first->id);
+});
+
+test('disabled variants are ignored by the resolver', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    $base = makeDonationMapping($user, $t[0], null, null);
+    $disabled = makeDonationMapping($user, $t[1], ExternalEventTemplateMapping::CONDITION_EXACTLY, 10);
+    $disabled->update(['enabled' => false]);
+
+    expect(ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'donation', '10.00')?->id)->toBe($base->id);
+});
+
+test('a non-amount external event type ignores conditions and returns its base', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    // Ko-fi 'subscription' is not in AMOUNT_EVENT_TYPES.
+    $base = ExternalEventTemplateMapping::create([
+        'user_id' => $user->id, 'service' => 'kofi', 'event_type' => 'subscription',
+        'overlay_template_id' => $t[0]->id, 'duration_ms' => 5000, 'enabled' => true,
+    ]);
+
+    expect(ExternalEventTemplateMapping::supportsCondition('kofi', 'subscription'))->toBeFalse();
+    expect(ExternalEventTemplateMapping::resolveForEvent($user->id, 'kofi', 'subscription', '99.00')?->id)->toBe($base->id);
+});
+
+test('updateTriggers lets two templates own kofi donation with different conditions', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    [$small, $big] = $t;
+    $this->actingAs($user);
+
+    $this->put("/templates/{$small->id}/triggers", [
+        'twitch' => [],
+        'external' => [
+            ['service' => 'kofi', 'event_type' => 'donation', 'condition_type' => null, 'condition_value' => null, 'duration_ms' => 5000, 'enabled' => true],
+        ],
+    ])->assertRedirect();
+
+    $this->put("/templates/{$big->id}/triggers", [
+        'twitch' => [],
+        'external' => [
+            ['service' => 'kofi', 'event_type' => 'donation', 'condition_type' => 'at_least', 'condition_value' => 50, 'duration_ms' => 5000, 'enabled' => true],
+        ],
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('external_event_template_mappings', [
+        'service' => 'kofi', 'event_type' => 'donation', 'overlay_template_id' => $small->id, 'condition_type' => null,
+    ]);
+    $this->assertDatabaseHas('external_event_template_mappings', [
+        'service' => 'kofi', 'event_type' => 'donation', 'overlay_template_id' => $big->id, 'condition_type' => 'at_least', 'condition_value' => 50,
+    ]);
+});
+
+test('updateTriggers strips a condition smuggled onto a non-amount external event', function () {
+    [$user, $t] = makeUserWithAlertTemplates(1);
+    $this->actingAs($user);
+
+    $this->put("/templates/{$t[0]->id}/triggers", [
+        'twitch' => [],
+        'external' => [
+            ['service' => 'kofi', 'event_type' => 'subscription', 'condition_type' => 'at_least', 'condition_value' => 50, 'duration_ms' => 5000, 'enabled' => true],
+        ],
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('external_event_template_mappings', [
+        'service' => 'kofi', 'event_type' => 'subscription', 'overlay_template_id' => $t[0]->id, 'condition_type' => null, 'condition_value' => null,
+    ]);
+});
+
+test('updateTriggers reassigning a non-amount external event moves ownership', function () {
+    [$user, $t] = makeUserWithAlertTemplates(2);
+    [$a, $b] = $t;
+
+    ExternalEventTemplateMapping::create([
+        'user_id' => $user->id, 'service' => 'kofi', 'event_type' => 'subscription',
+        'overlay_template_id' => $b->id, 'duration_ms' => 5000, 'enabled' => true,
+    ]);
+
+    $this->actingAs($user);
+    $this->put("/templates/{$a->id}/triggers", [
+        'twitch' => [],
+        'external' => [
+            ['service' => 'kofi', 'event_type' => 'subscription', 'condition_type' => null, 'condition_value' => null, 'duration_ms' => 5000, 'enabled' => true],
+        ],
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('external_event_template_mappings', [
+        'service' => 'kofi', 'event_type' => 'subscription', 'overlay_template_id' => $a->id,
+    ]);
+    $this->assertDatabaseMissing('external_event_template_mappings', [
+        'service' => 'kofi', 'event_type' => 'subscription', 'overlay_template_id' => $b->id,
+    ]);
+});
+
+test('updateTriggers rejects an invalid external condition_type', function () {
+    [$user, $t] = makeUserWithAlertTemplates(1);
+    $this->actingAs($user);
+
+    $this->put("/templates/{$t[0]->id}/triggers", [
+        'twitch' => [],
+        'external' => [
+            ['service' => 'kofi', 'event_type' => 'donation', 'condition_type' => 'more_than', 'condition_value' => 5, 'duration_ms' => 5000, 'enabled' => true],
+        ],
+    ])->assertSessionHasErrors('external.0.condition_type');
+});
+
+test('updateTriggers requires a condition_value when an external condition_type is set', function () {
+    [$user, $t] = makeUserWithAlertTemplates(1);
+    $this->actingAs($user);
+
+    $this->put("/templates/{$t[0]->id}/triggers", [
+        'twitch' => [],
+        'external' => [
+            ['service' => 'kofi', 'event_type' => 'donation', 'condition_type' => 'at_least', 'condition_value' => null, 'duration_ms' => 5000, 'enabled' => true],
+        ],
+    ])->assertSessionHasErrors('external.0.condition_value');
+});


### PR DESCRIPTION
## Why

Phase 1 gave Twitch events (cheer/gift/raid) alert variants by amount. Phase 2 finishes the original request by extending the **exact same machinery** to external donations - a bigger Ko-fi donation can fire a louder alert than a small one. Because the Triggers-tab condition picker already exists from Phase 1, this is almost entirely backend.

## What

- **Conditions on donations** - `At least N` / `Exactly N` on the `donation` event of each donation service (**Ko-fi, StreamLabs, StreamElements, Buy Me a Coffee, Fourthwall**), listed in the new `ExternalEventTemplateMapping::AMOUNT_EVENT_TYPES` registry. Every other external event type (subscriptions, shop orders, GPS pings) keeps its single base row.
- **One resolver, both firing sites** - `ExternalEventTemplateMapping::resolveForEvent()` replaces the bare `->first()` in `ExternalAlertService::dispatch` (live webhook; amount from `NormalizedExternalEvent::getAmount()`) and `ExternalEventController::replay` (amount from the stored `normalized_payload['event.amount']`). Ladder matches Twitch: `exactly == amount` -> highest matching `at_least` -> base -> nothing; ties break on lowest `overlay_template_id`.
- **Whole-unit, currency-naive thresholds** - threshold is an integer (e.g. "at least 5"); the donated amount parses as a float and compares raw, with **no FX conversion** (same no-exchange-rate stance as the Stream Sessions income view). `4.99` falls below an "at least 5" tier; `5.00` meets it. `exactly` uses a small epsilon so `5.00` matches a threshold of `5`. Null/blank amount reads as `0`.
- **Write-path guards** - condition stripped server-side for non-amount external events; `condition_value` `required_with` its `condition_type`; unknown `condition_type` rejected. Non-amount external events keep one-template-per-event (ownership moves on reassign), mirroring Twitch.

## Migration

`2026_06_30_000002_add_conditions_to_external_event_template_mappings` - adds `condition_type` + `condition_value`, swaps `unique(user_id, service, event_type)` for `unique(user_id, overlay_template_id, service, event_type)`. Reversible.

## How to use

1. "Big Donation" alert template -> Triggers tab -> enable Ko-fi Donation -> `At least 50`.
2. "Small Donation" template -> enable Ko-fi Donation -> leave `Any amount` (base).
3. A 75-dollar Ko-fi donation fires Big; a 5-dollar one fires Small.

## Tests

16 new in `ExternalEventVariantsTest`: full ladder, decimal-below/at-threshold edges, null/blank-as-zero, tie-break, disabled skip, non-amount-type passthrough, two-templates-coexist write path, non-amount strip + ownership-move, both validation rejections. Existing external/alert/trigger suites green. Full suite **958 passed**; Pint + ESLint + vite build clean.

## Scope notes

- Only the `donation` event type carries a condition for v1 (the headline "donation amounts" case). Other monetary types (Ko-fi shop orders, BMAC extras) are a one-line registry addition later.
- Currency-naive by design - a threshold compares the raw number regardless of currency, no FX guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
