### PR TITLE
feat(alerts): variant conditions + collision warning on the event overview

### DIFF
--- a/app/Http/Controllers/EventTemplateMappingController.php
+++ b/app/Http/Controllers/EventTemplateMappingController.php
@@ -5,7 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\EventTemplateMapping;
 use App\Models\ExternalEventTemplateMapping;
 use App\Models\ExternalIntegration;
-use App\Models\OverlayTemplate;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 
@@ -20,20 +21,30 @@ class EventTemplateMappingController extends Controller
     {
         $user = Auth::user();
 
-        $twitchMappings = EventTemplateMapping::with('template:id,name,slug')
+        $twitchRows = EventTemplateMapping::with('template:id,name,slug')
             ->where('user_id', $user->id)
             ->where('enabled', true)
             ->whereNotNull('template_id')
-            ->get()
+            ->orderBy('event_type')
+            ->orderBy('template_id')
+            ->get();
+
+        $twitchShadow = $this->shadowedBy($twitchRows, fn (EventTemplateMapping $m) => $m->event_type);
+
+        $twitchMappings = $twitchRows
             ->map(fn (EventTemplateMapping $m) => [
                 'event_type' => $m->event_type,
                 'event_label' => EventTemplateMapping::EVENT_TYPES[$m->event_type] ?? $m->event_type,
+                'condition_type' => $m->condition_type,
+                'condition_value' => $m->condition_value,
+                'condition_unit' => EventTemplateMapping::AMOUNT_FIELDS[$m->event_type]['unit'] ?? null,
                 'duration_ms' => $m->duration_ms,
                 'template' => $m->template ? [
                     'id' => $m->template->id,
                     'name' => $m->template->name,
                     'slug' => $m->template->slug,
                 ] : null,
+                'shadowed_by' => $twitchShadow[$m->id] ?? null,
             ])
             ->values();
 
@@ -42,22 +53,33 @@ class EventTemplateMappingController extends Controller
             ->pluck('service')
             ->toArray();
 
-        $externalMappings = ExternalEventTemplateMapping::with('template:id,name,slug')
+        $externalRows = ExternalEventTemplateMapping::with('template:id,name,slug')
             ->where('user_id', $user->id)
             ->where('enabled', true)
             ->whereNotNull('overlay_template_id')
-            ->get()
+            ->orderBy('service')
+            ->orderBy('event_type')
+            ->orderBy('overlay_template_id')
+            ->get();
+
+        $externalShadow = $this->shadowedBy($externalRows, fn (ExternalEventTemplateMapping $m) => $m->service.':'.$m->event_type);
+
+        $externalMappings = $externalRows
             ->map(fn (ExternalEventTemplateMapping $m) => [
                 'service' => $m->service,
                 'event_type' => $m->event_type,
                 'event_label' => ExternalEventTemplateMapping::SERVICE_EVENT_TYPES[$m->service][$m->event_type]
                     ?? $m->event_type,
+                'condition_type' => $m->condition_type,
+                'condition_value' => $m->condition_value,
+                'condition_unit' => ExternalEventTemplateMapping::supportsCondition($m->service, $m->event_type) ? 'amount' : null,
                 'duration_ms' => $m->duration_ms,
                 'template' => $m->template ? [
                     'id' => $m->template->id,
                     'name' => $m->template->name,
                     'slug' => $m->template->slug,
                 ] : null,
+                'shadowed_by' => $externalShadow[$m->id] ?? null,
             ])
             ->values();
 
@@ -75,6 +97,46 @@ class EventTemplateMappingController extends Controller
             'connectedServices' => $connectedServices,
             'unassignedEventTypes' => $unassignedEventTypes,
         ]);
+    }
+
+    /**
+     * Map [mapping_id => winning template name] for every "shadowed" mapping:
+     * one that shares an identical trigger condition with an earlier-assigned
+     * mapping (same event scope + condition_type + condition_value). The
+     * resolver breaks such ties on the lowest template id, so the winner always
+     * fires and every other member never does. Only EXACT-condition duplicates
+     * are flagged - an `at_least 100` is not shadowed by an `exactly 100`,
+     * because it still fires at other amounts.
+     *
+     * The collection MUST already be ordered by the tie-break id ascending, so
+     * the group's first element is the winner.
+     *
+     * @param  Collection<int, Model>  $mappings
+     * @param  callable(Model): string  $scopeKey
+     * @return array<int, string>
+     */
+    private function shadowedBy(Collection $mappings, callable $scopeKey): array
+    {
+        $shadowed = [];
+
+        $groups = $mappings->groupBy(
+            fn ($m) => $scopeKey($m).'|'.($m->condition_type ?? '').'|'.($m->condition_value ?? '')
+        );
+
+        foreach ($groups as $group) {
+            if ($group->count() < 2) {
+                continue;
+            }
+
+            $winner = $group->first();
+            foreach ($group as $m) {
+                if ($m->getKey() !== $winner->getKey()) {
+                    $shadowed[$m->getKey()] = $winner->template?->name ?? 'another alert';
+                }
+            }
+        }
+
+        return $shadowed;
     }
 
     /**

--- a/docs/changelog/changelog-2026-06.md
+++ b/docs/changelog/changelog-2026-06.md
@@ -1,5 +1,15 @@
 # CHANGELOG JUNE 2026
 
+## June 30th, 2026 - feat(alerts): surface variant condition + collision warning on the event overview
+
+The `/alerts` overview was built before variants - it listed "Bits Cheer -> some template" with no hint of the condition, so two cheer variants pointing at different templates looked identical, and a genuine collision (two alerts on the exact same condition) was invisible. When variants tie, the resolver deterministically fires the lowest-template-id (first-assigned) one and silently skips the rest; nothing told you the others were dead. This makes the one cross-template view honest about both.
+
+- **Conditions are now shown** on each overview row: `Big Cheer · At least 1000 bits · 5s`, `Nice · Exactly 69 bits · 5s`, base rows read `Any amount`. Non-amount events (follow, raid-with-no-threshold, etc.) show nothing extra. External donation rows drop the unit word (`At least 50`, since the amount is currency-naive).
+- **Collision warning** - rows that share an identical trigger (same event + `condition_type` + `condition_value`) with an earlier-assigned alert get an amber border and a one-line "Never fires - \"First Cheer\" wins this exact trigger. Change or remove this condition." Only TRUE always-shadowed duplicates are flagged: an `exactly 100` does not flag an `at_least 100`, because the latter still fires at other amounts. Disabled duplicates are ignored (the resolver skips them too).
+- **No blocking, by design** - the per-template Triggers editor stays dumb and never denies a save; the overview (the only view that sees all templates at once) is where cross-template conflicts surface. Visibility over prohibition - the config isn't broken, it was just invisible.
+- **Backend** - `EventTemplateMappingController::index()` now orders by the tie-break id and runs a small `shadowedBy()` grouping helper (shared shape for Twitch and external), returning `condition_type/value/unit` + `shadowed_by` (winning template name) per row. Fixed a latent duplicate-`:key` in the Vue list now that one event type can have multiple rows. Fully responsive (flex-wrap, warning wraps under the row on mobile).
+- **Tests:** 5 new (`AlertOverviewCollisionTest`) covering the flagged duplicate, the non-colliding different-conditions case, the exactly-vs-at-least non-collision, the external donation collision, and the disabled-duplicate skip. Full suite **963 passed**; Pint + ESLint + vite build clean.
+
 ## June 30th, 2026 - feat(triggers): donation amount variants (Phase 2 - Ko-fi / StreamLabs / StreamElements / BMAC / Fourthwall)
 
 Phase 2 of alert variants extends the same machinery to external donations: a bigger Ko-fi donation can now fire a louder alert than a small one, the same way cheer bits do. Built directly on the Phase 1 frontend - the Triggers tab condition picker now appears on donation rows too, no new UI component.

--- a/resources/js/pages/events/index.vue
+++ b/resources/js/pages/events/index.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 import { Head, Link } from '@inertiajs/vue3';
 import AppLayout from '@/layouts/AppLayout.vue';
 import Heading from '@/components/Heading.vue';
-import { ExternalLink, Megaphone } from '@lucide/vue';
+import { AlertTriangle, ExternalLink, Megaphone } from '@lucide/vue';
 import type { BreadcrumbItem } from '@/types';
 import { SERVICE_LABELS } from '@/utils/services';
 
@@ -13,14 +13,24 @@ interface AssignedTemplate {
   slug: string;
 }
 
-interface TwitchMapping {
+/** Fields shared by every mapping row that carries a variant condition. */
+interface ConditionFields {
+  condition_type: string | null;
+  condition_value: number | null;
+  /** Unit label when the event supports a condition (e.g. "bits"), else null. */
+  condition_unit: string | null;
+  /** Name of the alert that wins this exact trigger, if this row is shadowed. */
+  shadowed_by: string | null;
+}
+
+interface TwitchMapping extends ConditionFields {
   event_type: string;
   event_label: string;
   duration_ms: number;
   template: AssignedTemplate | null;
 }
 
-interface ExternalMapping {
+interface ExternalMapping extends ConditionFields {
   service: string;
   event_type: string;
   event_label: string;
@@ -53,6 +63,20 @@ const externalByService = computed(() => {
 });
 
 const totalAssigned = computed(() => props.twitchMappings.length + props.externalMappings.length);
+
+/**
+ * Human label for a row's variant condition, or null when the event has no
+ * amount to condition on (so no condition text is shown). "amount" is the
+ * unitless external/donation case - we drop the word so it doesn't read
+ * "At least 50 amount".
+ */
+function conditionLabel(row: ConditionFields): string | null {
+  if (!row.condition_unit) return null;
+  const unit = row.condition_unit === 'amount' ? '' : ` ${row.condition_unit}`;
+  if (row.condition_type === 'at_least') return `At least ${row.condition_value}${unit}`;
+  if (row.condition_type === 'exactly') return `Exactly ${row.condition_value}${unit}`;
+  return 'Any amount';
+}
 </script>
 
 <template>
@@ -85,9 +109,10 @@ const totalAssigned = computed(() => props.twitchMappings.length + props.externa
         <div v-else class="space-y-2">
           <Link
             v-for="row in twitchMappings"
-            :key="row.event_type"
+            :key="`${row.event_type}:${row.template?.id}`"
             :href="row.template ? route('templates.show', row.template.id) : '#'"
-            class="flex flex-wrap items-center gap-3 rounded-sm border border-sidebar-border bg-card p-4 transition-colors hover:border-violet-400 hover:bg-sidebar cursor-pointer"
+            class="flex flex-wrap items-center gap-3 rounded-sm border bg-card p-4 transition-colors hover:border-violet-400 hover:bg-sidebar cursor-pointer"
+            :class="row.shadowed_by ? 'border-amber-400/50' : 'border-sidebar-border'"
           >
             <div class="min-w-0 flex-1">
               <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -100,10 +125,18 @@ const totalAssigned = computed(() => props.twitchMappings.length + props.externa
               </div>
               <div v-if="row.template" class="mt-1 text-sm text-foreground">
                 {{ row.template.name }}
+                <span v-if="conditionLabel(row)" class="text-muted-foreground"> · {{ conditionLabel(row) }}</span>
                 <span class="text-muted-foreground"> · {{ row.duration_ms / 1000 }}s</span>
               </div>
+              <div
+                v-if="row.shadowed_by"
+                class="mt-1.5 flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400"
+              >
+                <AlertTriangle class="mt-px h-3.5 w-3.5 shrink-0" />
+                <span>Never fires - "{{ row.shadowed_by }}" wins this exact trigger. Change or remove this condition.</span>
+              </div>
             </div>
-            <ExternalLink class="h-4 w-4 text-muted-foreground" />
+            <ExternalLink class="h-4 w-4 shrink-0 text-muted-foreground" />
           </Link>
         </div>
       </section>
@@ -125,9 +158,10 @@ const totalAssigned = computed(() => props.twitchMappings.length + props.externa
         <div v-else class="space-y-2">
           <Link
             v-for="row in externalByService[service]"
-            :key="`${row.service}:${row.event_type}`"
+            :key="`${row.service}:${row.event_type}:${row.template?.id}`"
             :href="row.template ? route('templates.show', row.template.id) : '#'"
-            class="flex flex-wrap items-center gap-3 rounded-sm border border-sidebar-border bg-card p-4 transition-colors hover:border-violet-400 hover:bg-sidebar cursor-pointer"
+            class="flex flex-wrap items-center gap-3 rounded-sm border bg-card p-4 transition-colors hover:border-violet-400 hover:bg-sidebar cursor-pointer"
+            :class="row.shadowed_by ? 'border-amber-400/50' : 'border-sidebar-border'"
           >
             <div class="min-w-0 flex-1">
               <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -140,10 +174,18 @@ const totalAssigned = computed(() => props.twitchMappings.length + props.externa
               </div>
               <div v-if="row.template" class="mt-1 text-sm text-foreground">
                 {{ row.template.name }}
+                <span v-if="conditionLabel(row)" class="text-muted-foreground"> · {{ conditionLabel(row) }}</span>
                 <span class="text-muted-foreground"> · {{ row.duration_ms / 1000 }}s</span>
               </div>
+              <div
+                v-if="row.shadowed_by"
+                class="mt-1.5 flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400"
+              >
+                <AlertTriangle class="mt-px h-3.5 w-3.5 shrink-0" />
+                <span>Never fires - "{{ row.shadowed_by }}" wins this exact trigger. Change or remove this condition.</span>
+              </div>
             </div>
-            <ExternalLink class="h-4 w-4 text-muted-foreground" />
+            <ExternalLink class="h-4 w-4 shrink-0 text-muted-foreground" />
           </Link>
         </div>
       </section>

--- a/tests/Feature/AlertOverviewCollisionTest.php
+++ b/tests/Feature/AlertOverviewCollisionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use App\Models\EventTemplateMapping;
+use App\Models\ExternalEventTemplateMapping;
+use App\Models\OverlayTemplate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(DatabaseTransactions::class);
+
+function makeOverviewUser(): User
+{
+    return User::factory()->create(['twitch_id' => (string) fake()->unique()->randomNumber(9)]);
+}
+
+function makeNamedAlert(User $user, string $name): OverlayTemplate
+{
+    return OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => 'alert',
+        'name' => $name,
+        'slug' => 'alert-'.fake()->unique()->lexify('????????'),
+    ]);
+}
+
+test('two identical cheer conditions flag the later template as shadowed', function () {
+    $user = makeOverviewUser();
+    $winner = makeNamedAlert($user, 'First Cheer'); // lower id wins the tie
+    $loser = makeNamedAlert($user, 'Second Cheer');
+
+    foreach ([$winner, $loser] as $t) {
+        EventTemplateMapping::create([
+            'user_id' => $user->id, 'event_type' => 'channel.cheer',
+            'condition_type' => 'exactly', 'condition_value' => 100,
+            'template_id' => $t->id, 'duration_ms' => 5000, 'enabled' => true,
+        ]);
+    }
+
+    $this->actingAs($user)
+        ->get('/alerts')
+        ->assertStatus(200)
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('events/index')
+            ->has('twitchMappings', 2)
+            ->where('twitchMappings.0.condition_type', 'exactly')
+            ->where('twitchMappings.0.condition_value', 100)
+            ->where('twitchMappings.0.condition_unit', 'bits')
+            ->where('twitchMappings.0.shadowed_by', null)
+            ->where('twitchMappings.1.shadowed_by', 'First Cheer')
+        );
+});
+
+test('different cheer conditions never collide', function () {
+    $user = makeOverviewUser();
+    $base = makeNamedAlert($user, 'Base Cheer');
+    $big = makeNamedAlert($user, 'Big Cheer');
+
+    EventTemplateMapping::create([
+        'user_id' => $user->id, 'event_type' => 'channel.cheer',
+        'condition_type' => null, 'condition_value' => null,
+        'template_id' => $base->id, 'duration_ms' => 5000, 'enabled' => true,
+    ]);
+    EventTemplateMapping::create([
+        'user_id' => $user->id, 'event_type' => 'channel.cheer',
+        'condition_type' => 'at_least', 'condition_value' => 1000,
+        'template_id' => $big->id, 'duration_ms' => 5000, 'enabled' => true,
+    ]);
+
+    $this->actingAs($user)
+        ->get('/alerts')
+        ->assertStatus(200)
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('events/index')
+            ->has('twitchMappings', 2)
+            ->where('twitchMappings.0.shadowed_by', null)
+            ->where('twitchMappings.1.shadowed_by', null)
+        );
+});
+
+test('an exactly 100 does not shadow an at_least 100 (it still fires at other amounts)', function () {
+    $user = makeOverviewUser();
+    $exact = makeNamedAlert($user, 'Exact 100');
+    $atLeast = makeNamedAlert($user, 'At Least 100');
+
+    EventTemplateMapping::create([
+        'user_id' => $user->id, 'event_type' => 'channel.cheer',
+        'condition_type' => 'exactly', 'condition_value' => 100,
+        'template_id' => $exact->id, 'duration_ms' => 5000, 'enabled' => true,
+    ]);
+    EventTemplateMapping::create([
+        'user_id' => $user->id, 'event_type' => 'channel.cheer',
+        'condition_type' => 'at_least', 'condition_value' => 100,
+        'template_id' => $atLeast->id, 'duration_ms' => 5000, 'enabled' => true,
+    ]);
+
+    $this->actingAs($user)
+        ->get('/alerts')
+        ->assertStatus(200)
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('twitchMappings.0.shadowed_by', null)
+            ->where('twitchMappings.1.shadowed_by', null)
+        );
+});
+
+test('identical donation conditions flag the shadowed external row', function () {
+    $user = makeOverviewUser();
+    $winner = makeNamedAlert($user, 'First Donation');
+    $loser = makeNamedAlert($user, 'Second Donation');
+
+    foreach ([$winner, $loser] as $t) {
+        ExternalEventTemplateMapping::create([
+            'user_id' => $user->id, 'service' => 'kofi', 'event_type' => 'donation',
+            'condition_type' => 'at_least', 'condition_value' => 50,
+            'overlay_template_id' => $t->id, 'duration_ms' => 5000, 'enabled' => true,
+        ]);
+    }
+
+    $this->actingAs($user)
+        ->get('/alerts')
+        ->assertStatus(200)
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('externalMappings', 2)
+            ->where('externalMappings.0.condition_unit', 'amount')
+            ->where('externalMappings.0.shadowed_by', null)
+            ->where('externalMappings.1.shadowed_by', 'First Donation')
+        );
+});
+
+test('a disabled duplicate does not shadow the enabled one', function () {
+    $user = makeOverviewUser();
+    $live = makeNamedAlert($user, 'Live Cheer');
+    $off = makeNamedAlert($user, 'Disabled Cheer');
+
+    EventTemplateMapping::create([
+        'user_id' => $user->id, 'event_type' => 'channel.cheer',
+        'condition_type' => 'exactly', 'condition_value' => 100,
+        'template_id' => $live->id, 'duration_ms' => 5000, 'enabled' => true,
+    ]);
+    EventTemplateMapping::create([
+        'user_id' => $user->id, 'event_type' => 'channel.cheer',
+        'condition_type' => 'exactly', 'condition_value' => 100,
+        'template_id' => $off->id, 'duration_ms' => 5000, 'enabled' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->get('/alerts')
+        ->assertStatus(200)
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('twitchMappings', 1)
+            ->where('twitchMappings.0.shadowed_by', null)
+        );
+});


### PR DESCRIPTION
Follow-up to the alert-variants work (#139, #140). Makes the `/alerts` overview honest about variant conditions and flags genuine collisions. **Option B** from the design discussion: surface conflicts in the one cross-template view rather than blocking them in the per-template editor.

## Why

The overview predates variants. It listed "Bits Cheer -> some template" with no condition shown, so two cheer variants pointing at different templates looked identical. Worse, a real collision (two alerts on the *exact* same condition) was invisible: on a tie the resolver deterministically fires the lowest-template-id (first-assigned) alert and silently skips the rest. Nothing told you the others were dead rows.

## What

- **Conditions are now visible** per row: `Big Cheer · At least 1000 bits · 5s`, `Nice · Exactly 69 bits · 5s`; base rows read `Any amount`. Non-amount events show nothing extra. External donation rows drop the unit word (`At least 50`) since the amount is currency-naive.
- **Collision warning** - a row sharing an identical trigger (same event + `condition_type` + `condition_value`) with an earlier-assigned alert gets an amber border and a one-line note: *Never fires - "First Cheer" wins this exact trigger. Change or remove this condition.* Clicking the row deep-links to that shadowed template so you can fix it.
- **Only true always-shadowed duplicates are flagged.** An `exactly 100` does **not** flag an `at_least 100` - the latter still fires at every other amount. Disabled duplicates are ignored (the resolver skips them too).
- **Non-blocking by design.** The per-template Triggers editor stays dumb and never denies a save; the overview is the only view that sees all templates at once, so that is where conflicts surface. Visibility over prohibition - the config was never broken, just invisible.

## Implementation

- `EventTemplateMappingController::index()` orders by the resolver tie-break id and runs a small `shadowedBy()` grouping helper (same shape for Twitch and external), returning `condition_type` / `condition_value` / `condition_unit` + `shadowed_by` (winning template name) per row.
- Fixed a latent duplicate Vue `:key` (one event type can now produce multiple rows).
- Fully responsive: existing flex-wrap row, the warning wraps underneath on mobile; shadowed rows get a single amber border, no new columns.

## Tests

5 new in `AlertOverviewCollisionTest`: flagged duplicate, non-colliding different-conditions, exactly-vs-at-least non-collision, external donation collision, disabled-duplicate skip. Full suite **963 passed**; Pint + ESLint + vite build clean.

## Deliberately not done

- No save-time block or live frontend deny (options C/D) - they add friction and editor/global coupling to prevent a deterministic, harmless outcome.
- No `sort_order` priority field (option E) - that is a separate "let users intentionally stack variants" product question, not "warn about the mess".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
