### PR TITLE
fix(throne): register Throne in the alert trigger catalogue

### DIFF
--- a/app/Models/ExternalEventTemplateMapping.php
+++ b/app/Models/ExternalEventTemplateMapping.php
@@ -87,6 +87,7 @@ class ExternalEventTemplateMapping extends Model
         'kofi' => ['donation'],
         'streamelements' => ['donation'],
         'streamlabs' => ['donation'],
+        'throne' => ['donation'],
     ];
 
     /**
@@ -135,6 +136,9 @@ class ExternalEventTemplateMapping extends Model
         ],
         'streamlabs' => [
             'donation' => 'Streamlabs Donation',
+        ],
+        'throne' => [
+            'donation' => 'Throne Gift or Contribution',
         ],
     ];
 

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,13 @@
 # CHANGELOG JULY 2026
 
+## July 1st, 2026 - fix(throne): register Throne in the alert trigger catalogue
+
+Throne shipped (#142) with a working webhook but no alert trigger - the Triggers tab showed no Throne row to attach an alert template to. Root cause: the TriggerManager UI lists external triggers from `ExternalEventTemplateMapping::SERVICE_EVENT_TYPES`, a hand-maintained catalogue separate from the driver, and the Throne entry was never added. The webhook, controls, recents, and replay all worked because those flow off the normalized event; only the trigger picker reads this constant.
+
+- Added `throne => ['donation' => 'Throne Gift or Contribution']` to `SERVICE_EVENT_TYPES` so the trigger appears (no frontend change - TriggerManager renders connected services dynamically).
+- Added `throne => ['donation']` to `AMOUNT_EVENT_TYPES` so Throne gifts get the same at-least / exactly variant conditions as every other donation service (a bigger gift can fire a louder alert).
+- **New guard test** (`ExternalTriggerCatalogueTest`) asserts every registered driver's `getSupportedEventTypes()` is present in `SERVICE_EVENT_TYPES`, so this drift is a red build for the next integration instead of a UI hunt. Would have caught this on the original PR.
+
 ## July 1st, 2026 - polish(throne): clearer "paste into Throne" manual step
 
 Tightened the connected-state copy on the Throne settings page so the one manual step (pasting the webhook URL into Throne) is unmissable. Replaced scattered inline "go there" links with a single prominent "Open Throne webhook settings ->" button directly below the webhook URL input, plus a helper line that reacts to the Copy button (after copying it turns violet and reads "Copied. Now open Throne and paste it into the Webhook URL field.").

--- a/tests/Unit/ExternalTriggerCatalogueTest.php
+++ b/tests/Unit/ExternalTriggerCatalogueTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\ExternalEventTemplateMapping;
+use App\Services\External\ExternalServiceRegistry;
+
+/**
+ * Guards against registry drift: the TriggerManager UI lists external alert
+ * triggers from ExternalEventTemplateMapping::SERVICE_EVENT_TYPES, which is a
+ * hand-maintained catalogue separate from the drivers. If a driver supports an
+ * event type that isn't in the catalogue, the webhook still works but there's
+ * no row to attach an alert template to - which is exactly how Throne shipped
+ * with no triggers. This test makes that omission a red build, not a UI hunt.
+ */
+test('every external driver event type is registered in the trigger catalogue', function () {
+    $missing = [];
+
+    foreach (ExternalServiceRegistry::services() as $service) {
+        $driver = ExternalServiceRegistry::driver($service);
+        $catalogue = array_keys(ExternalEventTemplateMapping::SERVICE_EVENT_TYPES[$service] ?? []);
+
+        foreach ($driver->getSupportedEventTypes() as $eventType) {
+            if (! in_array($eventType, $catalogue, true)) {
+                $missing[] = "{$service}:{$eventType}";
+            }
+        }
+    }
+
+    $this->assertSame(
+        [],
+        $missing,
+        'Driver event types missing from ExternalEventTemplateMapping::SERVICE_EVENT_TYPES '
+        .'(TriggerManager will not offer an alert trigger for them): '.implode(', ', $missing),
+    );
+});


### PR DESCRIPTION
Follow-up to #142. Throne shipped with a working webhook but **no alert trigger** - the Triggers tab showed no Throne row to attach an alert template to.

## Root cause
The TriggerManager UI lists external triggers from `ExternalEventTemplateMapping::SERVICE_EVENT_TYPES`, a hand-maintained catalogue **separate from the driver**. The Throne entry was never added. The webhook, controls, recents, and replay all worked because those flow off the normalized event; only the trigger picker reads this constant.

## Fix
- `throne => ['donation' => 'Throne Gift or Contribution']` added to `SERVICE_EVENT_TYPES`. No frontend change - `TriggerManager` already renders connected services dynamically, so the row appears once the catalogue has the entry.
- `throne => ['donation']` added to `AMOUNT_EVENT_TYPES` so Throne gifts support the same at-least / exactly variant conditions as every other donation service (a bigger gift can fire a louder alert).

## Guard test
`ExternalTriggerCatalogueTest` asserts every registered driver's `getSupportedEventTypes()` is present in `SERVICE_EVENT_TYPES`. This drift is now a red build for the next integration instead of a UI hunt - it would have failed on #142.

17 passing across the new guard test + `ExternalEventVariantsTest`. Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)