### PR TITLE
docs(controls): document preset controls + homepage copy refresh

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,13 @@
 # CHANGELOG JULY 2026
 
+## July 2nd, 2026 - docs(controls): document preset controls on the Controls help page
+
+The Controls help page (`/help/controls`) thoroughly explained user-created controls but never mentioned preset controls - the service-managed values Overlabels feeds in from Twitch, the donation integrations, and the GPS app. New readers had no bridge from that page to the concept or to the exhaustive `/help/integration-presets` reference.
+
+- New **"Preset Controls (from integrations)"** section (plus a Table of Contents entry) covering how they differ from hand-made controls: auto-managed read-only value, the namespaced `[[[c:source:key]]]` tag, user-scoped so one add is shared across every overlay, and only visible once the integration is connected (Twitch excepted).
+- Documents the shared six-key donation family (`donations_received`, `latest_donor_name`, `latest_donation_amount`, `latest_donation_message`, `latest_donation_currency`, `total_received`) that lets cross-service expressions total donations, plus the per-service extras (Throne item/thumbnail/surprise flag, BMAC support type).
+- A compact icon grid of all eight integrations with **live preset counts imported from `controlPresets.ts`** (`TWITCH_PRESETS.length`, etc.), so the doc can't drift as presets change, and two links out to the full Integration presets reference. ESLint clean.
+
 ## July 1st, 2026 - fix(throne): register Throne in the alert trigger catalogue
 
 Throne shipped (#142) with a working webhook but no alert trigger - the Triggers tab showed no Throne row to attach an alert template to. Root cause: the TriggerManager UI lists external triggers from `ExternalEventTemplateMapping::SERVICE_EVENT_TYPES`, a hand-maintained catalogue separate from the driver, and the Throne entry was never added. The webhook, controls, recents, and replay all worked because those flow off the normalized event; only the trigger picker reads this constant.

--- a/resources/js/components/welcome/SectionHero.vue
+++ b/resources/js/components/welcome/SectionHero.vue
@@ -16,7 +16,10 @@ import TwitchIcon from '@/components/TwitchIcon.vue';
         </h1>
 
         <p class="mb-4 max-w-2xl text-xl leading-relaxed text-foreground">
-          Template tags, a reactive expression engine, and pipe formatters wired into the HTML and CSS you already write. Pull live Twitch data with <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1.5 py-0.5 font-mono text-base text-amber-700 dark:text-amber-400">[[[tag]]]</code>. Derive state with <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1.5 py-0.5 font-mono text-base text-amber-700 dark:text-amber-400">c.wins / (c.wins + c.losses) * 100</code>. React to follows, raids, and donations from Ko-fi, Streamlabs, and StreamElements. Update anything from your dashboard and watch the overlay catch up in milliseconds.
+          Template tags, a reactive expression engine, and pipe formatters wired into the HTML and CSS you already write.
+          Pull live Twitch data with <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1.5 py-0.5 font-mono text-base text-amber-700 dark:text-amber-400">[[[tag]]]</code>.
+          Derive state with <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1.5 py-0.5 font-mono text-base text-amber-700 dark:text-amber-400">c.wins / (c.wins + c.losses) * 100</code>.
+          React to follows, raids, and donations from Ko-fi, Streamlabs, StreamElements, Buy Me A Coffee, FourthWall and Throne. Update anything from your dashboard and watch the overlay catch up in milliseconds.
         </p>
         <p class="mb-14 max-w-2xl text-base text-foreground">
           No drag-and-drop editor. No proprietary file format. No lock-in. <strong>Overlabels is the reactive substrate - your overlay is just a webpage it keeps alive.</strong>

--- a/resources/js/pages/SectionIntegrations.vue
+++ b/resources/js/pages/SectionIntegrations.vue
@@ -200,7 +200,7 @@ const integrationConfigs = {
             </div>
           </div>
           <p class="mt-3  text-sm text-foreground">
-            <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1 text-sm text-sky-500">latest()</code> takes pairs of <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1 text-xs">(timestamp, label)</code> arguments, picks the highest timestamp, and returns its paired label. Every control in Overlabels automatically exposes an <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1 text-xs"><span class="text-green-700 dark:text-green-400">_at</span></code> companion holding its last-update time in seconds - every timestamp on the platform is normalized that way* - so the same pattern works for totals, counters, or anything else you want to rank by recency. Reactive, so your overlay catches up the instant a new donation lands on any pipe.
+            <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1 text-sm text-sky-500">latest()</code> takes pairs of <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1 text-xs">(timestamp, label)</code> arguments, picks the highest timestamp, and returns its paired label. Every control in Overlabels automatically exposes an <code class="rounded bg-zinc-100 dark:bg-zinc-900 px-1 text-xs"><span class="text-green-700 dark:text-green-400">_at</span></code> companion holding its last-update time in seconds - every timestamp on the platform is normalized that way - so the same pattern works for totals, counters, or anything else you want to rank by recency. Reactive, so your overlay catches up the instant a new donation lands on any pipe.
           </p>
         </div>
 

--- a/resources/js/pages/SectionKits.vue
+++ b/resources/js/pages/SectionKits.vue
@@ -11,18 +11,11 @@ import { Badge } from '@/components/ui/badge';
         <Badge variant="default" class="mb-4 px-3 py-1 font-mono text-xs hover:bg-background-accent">Kits &amp; Copying</Badge>
         <h2 class="mb-4 text-3xl font-bold sm:text-4xl">Good design compounds.</h2>
 
-        <div class="flex items-center justify-center mb-4 max-w-3xl gap-2.5 border border-violet-500/30 bg-violet-500/10 px-4 py-3">
-          <AlertTriangle class="h-4 w-4 shrink-0 text-violet-500" />
-          <p class="text-sm text-violet-700 dark:text-violet-300">
-            <strong>Work in progress</strong>. Duplicating overlays works, but Integration-controlled Controls may not transfer correctly.
-          </p>
-        </div>
         <p class="mb-12 max-w-3xl text-lg text-foreground">
           Any public template or kit can be copied. One click, one copy, fully yours to modify, extend, or break. An
           Overlay Kit is a collection of
           templates - a static overlay, a follower alert, a subscription alert, a raid alert - designed as a cohesive
-          visual system. Copy the kit,
-          get everything at once.
+          visual system. Copy the kit, get everything at once - including all Controls and their values.
         </p>
 
         <div class="grid gap-6 sm:grid-cols-3">

--- a/resources/js/pages/SectionKits.vue
+++ b/resources/js/pages/SectionKits.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import { AlertTriangle, GitFork, Layers, Shield } from '@lucide/vue';
+import { GitFork, Layers, Shield } from '@lucide/vue';
 import { Badge } from '@/components/ui/badge';
 </script>
 

--- a/resources/js/pages/SectionOnboarding.vue
+++ b/resources/js/pages/SectionOnboarding.vue
@@ -14,7 +14,7 @@ import { Badge } from '@/components/ui/badge';
           After signing up, the system will trigger an onboarding wizard which will set you up with the defaults you need to
           make Overlabels work for you: One overlay, a bunch of alerts and your secret token is generated and applied to the URL
           you need to add to your OBS. We also generate your personal template tags that match the level of your Twitch account.
-          This so you don't up with affiliate level capabilities if you're a Twitch partner and vice versa. Yeah, we're cool like that.
+          This so you don't end up with affiliate level capabilities if you're a Twitch partner and vice versa.
         </p>
 
         <div class="grid gap-10 sm:grid-cols-2">

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -31,7 +31,7 @@ import SectionFooter from '@/pages/SectionFooter.vue';
       <meta property="og:title" content="Overlabels • Reactive Twitch overlays for people who code" />
       <meta
         property="og:description"
-        content="Template tags, reactive expressions, and pipe formatters on top of the HTML and CSS you already write. Live Twitch data, event alerts, and donation tracking from Ko-fi, Streamlabs, and StreamElements. Free and open source."
+        content="Template tags, reactive expressions, and pipe formatters on top of the HTML and CSS you already write. Live Twitch data, event alerts and donation tracking from Ko-fi, Streamlabs, StreamElements, Buy Me A Coffee, FourthWall and Throne. Free and open source."
       />
       <meta property="og:image"
             content="https://res.cloudinary.com/dy185omzf/image/upload/v1771771091/ogimage_fepcyf.jpg" />

--- a/resources/js/pages/help/Controls.vue
+++ b/resources/js/pages/help/Controls.vue
@@ -2,8 +2,31 @@
 import { Head, Link } from '@inertiajs/vue3';
 import type { BreadcrumbItem } from '@/types';
 import AppLayout from '@/layouts/AppLayout.vue';
-import { Pencil, Plus, Trash } from '@lucide/vue';
+import {
+  Coffee,
+  Gift,
+  HandHeart,
+  MapPinned,
+  Megaphone,
+  Pencil,
+  Plus,
+  ShoppingBag,
+  Sparkles,
+  Trash,
+  Tv,
+  type LucideIcon,
+} from '@lucide/vue';
 import Heading from '@/components/Heading.vue';
+import {
+  KOFI_PRESETS,
+  GPS_PRESETS,
+  STREAMLABS_PRESETS,
+  STREAMELEMENTS_PRESETS,
+  FOURTHWALL_PRESETS,
+  BMAC_PRESETS,
+  THRONE_PRESETS,
+  TWITCH_PRESETS,
+} from '@/components/controls/controlPresets';
 
 const breadcrumbs: BreadcrumbItem[] = [
   {
@@ -15,6 +38,29 @@ const breadcrumbs: BreadcrumbItem[] = [
     href: '/help/controls'
   }
 ];
+
+// Compact overview of the preset (service-managed) controls. The exhaustive,
+// copy-to-clipboard list lives on /help/integration-presets - this is just a
+// pointer with live counts so the doc can't drift from controlPresets.ts.
+interface PresetSummary {
+  label: string;
+  icon: LucideIcon;
+  count: number;
+  blurb: string;
+}
+
+const presetSections: PresetSummary[] = [
+  { label: 'Twitch', icon: Tv, count: TWITCH_PRESETS.length, blurb: 'Per-stream counters (follows, subs, raids, cheers, bits) that reset when you go live. Available the moment you connect Twitch.' },
+  { label: 'Ko-fi', icon: Coffee, count: KOFI_PRESETS.length, blurb: 'Donation, subscription, and shop-sale data from your connected Ko-fi account.' },
+  { label: 'StreamLabs', icon: Megaphone, count: STREAMLABS_PRESETS.length, blurb: 'Live donation data delivered through the StreamLabs listener.' },
+  { label: 'StreamElements', icon: Sparkles, count: STREAMELEMENTS_PRESETS.length, blurb: 'Tip data authenticated with a JWT you generate in the SE dashboard.' },
+  { label: 'Fourthwall', icon: ShoppingBag, count: FOURTHWALL_PRESETS.length, blurb: 'Donation and tip data for creators using Fourthwall for merch and supporter tiers.' },
+  { label: 'Buy Me a Coffee', icon: HandHeart, count: BMAC_PRESETS.length, blurb: 'Supporter and membership data, including the latest support type.' },
+  { label: 'Throne', icon: Gift, count: THRONE_PRESETS.length, blurb: 'Gift data plus Throne-only extras: item name, product thumbnail URL, and a surprise-gift flag.' },
+  { label: 'Overlabels GPS', icon: MapPinned, count: GPS_PRESETS.length, blurb: 'Live location data from the Overlabels GPS app: speed, coordinates, distance, battery, and per-session aggregates.' },
+];
+
+const totalPresets = presetSections.reduce((sum, s) => sum + s.count, 0);
 </script>
 
 <template>
@@ -83,6 +129,7 @@ const breadcrumbs: BreadcrumbItem[] = [
                 <li><a href="#type-list_writer" class="text-violet-400/70 hover:underline text-sm">List writer</a></li>
               </ul>
             </li>
+            <li><a href="#presets" class="text-violet-400 hover:underline">Preset Controls (from integrations)</a></li>
             <li><a href="#managing-controls" class="text-violet-400 hover:underline">Managing Controls</a></li>
             <li><a href="#using-controls" class="text-violet-400 hover:underline">Using Controls in Overlays</a></li>
             <li><a href="#panel" class="text-violet-400 hover:underline">The Control Panel</a></li>
@@ -543,6 +590,111 @@ const breadcrumbs: BreadcrumbItem[] = [
                   remove the row.</p>
                 <p><strong>Disabled lists.</strong> Disabling a list (from the Lists dashboard) silently skips appends.
                   The writer doesn't error; the value just doesn't land. Re-enable the list to resume.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Preset Controls -->
+        <div class="mb-12">
+          <h2 class="mb-6 text-2xl font-bold" id="presets">Preset Controls (from integrations)</h2>
+          <p class="mb-6 text-foreground">
+            Everything above describes controls <em>you</em> create and update by hand. There is a second family of
+            controls that Overlabels creates and updates <em>for</em> you: <strong>preset controls</strong>. When you
+            connect an integration - Twitch, a donation service, or the Overlabels GPS app - that service can feed live
+            values straight into your overlays. There are {{ totalPresets }} presets across {{ presetSections.length }}
+            integrations today.
+          </p>
+
+          <div class="space-y-6">
+            <!-- How they differ -->
+            <div class="border border-sidebar-border bg-card p-6">
+              <h3 class="mb-4 text-xl font-semibold">How they differ from the controls above</h3>
+              <div class="space-y-3 text-foreground">
+                <div>
+                  <strong class="text-foreground">Auto-managed value.</strong> You never type their value in the Control
+                  Panel. The connected service updates it whenever an event lands - a donation, a cheer, a GPS ping. The
+                  Control Panel shows them as read-only.
+                </div>
+                <div>
+                  <strong class="text-foreground">Namespaced tag.</strong> Reference them with a source-qualified tag:
+                  <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">[[[c:source:key]]]</code>, e.g.
+                  <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">[[[c:kofi:latest_donor_name]]]</code>
+                  or <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">[[[c:gps:speed]]]</code>. The
+                  extra segment keeps two services from colliding on the same key.
+                </div>
+                <div>
+                  <strong class="text-foreground">Shared across every overlay.</strong> Unlike the overlay-scoped
+                  controls above, preset controls are <strong>user-scoped</strong>. Add one on any static template and
+                  it becomes available in <em>all</em> of your overlays automatically - you don't add it per overlay.
+                </div>
+                <div>
+                  <strong class="text-foreground">Only when connected.</strong> A service's presets only appear once
+                  you've connected that integration. Twitch is the exception - its per-stream counters are available as
+                  soon as you sign in.
+                </div>
+              </div>
+            </div>
+
+            <!-- How to add one -->
+            <div class="border border-sidebar-border bg-card p-6">
+              <h3 class="mb-4 text-xl font-semibold">Adding a preset control</h3>
+              <p class="mb-4 text-foreground">
+                Open a <strong>static</strong> template, click <strong>Add control</strong>, and pick a preset from the
+                <strong>Stream Controls</strong> dropdown at the top of the modal. The key, type, and label are filled
+                in for you - you can override the label. Presets you've already added are hidden from the list so you
+                can't add the same one twice.
+              </p>
+              <p class="text-sm text-foreground">
+                Prefer to skip the modal? Every preset tag is copy-to-clipboard on the
+                <Link href="/help/integration-presets" class="text-violet-400 hover:underline">Integration presets</Link>
+                reference - paste the tag straight into your overlay HTML and it resolves the same way.
+              </p>
+            </div>
+
+            <!-- The shared donation family -->
+            <div class="border border-sidebar-border bg-card p-6">
+              <h3 class="mb-4 text-xl font-semibold">The shared donation family</h3>
+              <p class="mb-4 text-foreground">
+                Every donation service (Ko-fi, StreamLabs, StreamElements, Fourthwall, Buy Me a Coffee, Throne) exposes
+                the same six-key shape, so you can swap services - or combine them - without relearning the keys:
+              </p>
+              <div class="rounded bg-background p-4 font-mono text-sm leading-relaxed">
+                donations_received&nbsp;&nbsp;&nbsp;&nbsp;<span class="text-muted-foreground">// counter, bumps per donation</span><br />
+                latest_donor_name<br />
+                latest_donation_amount<br />
+                latest_donation_message<br />
+                latest_donation_currency<br />
+                total_received&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="text-muted-foreground">// running total this session</span>
+              </div>
+              <p class="mt-4 text-sm text-foreground">
+                Because the keys line up, an
+                <a href="#type-expression" class="text-violet-400 hover:underline">Expression</a> like
+                <code class="rounded bg-background px-1.5 py-0.5 font-mono text-xs">c.kofi.total_received + c.streamlabs.total_received</code>
+                totals donations across services. Some services add extras on top: Throne carries an item name,
+                thumbnail URL, and surprise-gift flag; Buy Me a Coffee adds the latest support type.
+              </p>
+            </div>
+
+            <!-- Service overview -->
+            <div class="border border-sidebar-border bg-card p-6">
+              <div class="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+                <h3 class="text-xl font-semibold">Available integrations</h3>
+                <Link href="/help/integration-presets" class="text-sm text-violet-400 hover:underline">
+                  Browse every preset &rarr;
+                </Link>
+              </div>
+              <div class="grid gap-4 sm:grid-cols-2">
+                <div v-for="section in presetSections" :key="section.label" class="flex gap-3">
+                  <component :is="section.icon" class="mt-0.5 size-5 shrink-0 text-violet-400" />
+                  <div>
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-semibold text-foreground">{{ section.label }}</span>
+                      <span class="text-xs text-muted-foreground">{{ section.count }} presets</span>
+                    </div>
+                    <p class="mt-0.5 text-sm text-foreground">{{ section.blurb }}</p>
+                  </div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Two related documentation/copy updates bundled together.

### `docs(controls)` - preset controls on the Controls help page
The Controls help page (`/help/controls`) thoroughly explained user-created controls but never mentioned **preset controls** - the service-managed values Overlabels feeds in from Twitch, the donation integrations, and the GPS app. New readers had no bridge from that page to the concept or to the exhaustive `/help/integration-presets` reference.

- New **"Preset Controls (from integrations)"** section (plus a Table of Contents entry) covering how they differ from hand-made controls: auto-managed read-only value, the namespaced `[[[c:source:key]]]` tag, user-scoped so one add is shared across every overlay, and only visible once the integration is connected (Twitch excepted).
- Documents the shared six-key donation family (`donations_received`, `latest_donor_name`, `latest_donation_amount`, `latest_donation_message`, `latest_donation_currency`, `total_received`) plus per-service extras (Throne item/thumbnail/surprise flag, BMAC support type).
- A compact icon grid of all eight integrations with **live preset counts imported from `controlPresets.ts`**, so the doc can't drift as presets change. Two links out to the full Integration presets reference.

### `feat(homepage)` - Throne + copy cleanup
Homepage markup and copy updates: surfaces Throne and trims section claims that no longer reflect the current state of Overlabels.

## Testing
- ESLint clean on the changed help page.