### PR TITLE
feat(events): token-authed events feed + one-click global alert mute

### DIFF
--- a/app/Http/Controllers/AlertMuteController.php
+++ b/app/Http/Controllers/AlertMuteController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\AlertMuteService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class AlertMuteController extends Controller
+{
+    /**
+     * Session-authed mute toggle for the dashboard events page. The
+     * token-authed sibling lives in Api\EventFeedController::mute().
+     */
+    public function update(Request $request, AlertMuteService $alertMute): RedirectResponse
+    {
+        $validated = $request->validate([
+            'muted' => 'required|boolean',
+        ]);
+
+        $muted = $alertMute->setMuted($request->user(), (bool) $validated['muted']);
+
+        return back()
+            ->with('message', $muted ? 'All alerts muted.' : 'Alerts unmuted.')
+            ->with('type', $muted ? 'warning' : 'success');
+    }
+}

--- a/app/Http/Controllers/Api/EventFeedController.php
+++ b/app/Http/Controllers/Api/EventFeedController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\OverlayAccessToken;
+use App\Services\AlertMuteService;
+use App\Services\UnifiedEventFeedService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Token-authed events feed, the phone-friendly sibling of /dashboard/events.
+ * Authenticated by the same OverlayAccessToken overlays use, so a streamer who
+ * is not logged in to Twitch on their phone can still watch their events and
+ * mute their alerts. Serves /events/feed, which reads the token from the URL
+ * fragment client-side (the fragment never reaches the server).
+ *
+ * First consumers of token abilities: reading the feed requires `read`, the
+ * mute toggle requires `write` (tokens with no abilities set are unrestricted,
+ * matching hasAbility(), so existing overlay tokens keep working). The mute
+ * toggle is deliberately the only write an overlay token can perform.
+ */
+class EventFeedController extends Controller
+{
+    public function index(Request $request, UnifiedEventFeedService $eventFeed, AlertMuteService $alertMute): JsonResponse
+    {
+        $accessToken = $this->resolveToken($request, 'read');
+        if ($accessToken instanceof JsonResponse) {
+            return $accessToken;
+        }
+
+        $filters = $eventFeed->normalizeFilters($request);
+        $paginator = $eventFeed->paginate($accessToken->user_id, $filters, 25);
+        $user = $accessToken->user;
+
+        // Lean paginator shape: no links array, so the token in the request
+        // query is never echoed back inside pagination URLs.
+        return response()->json([
+            'events' => [
+                'data' => $paginator->items(),
+                'current_page' => $paginator->currentPage(),
+                'last_page' => $paginator->lastPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'from' => $paginator->firstItem(),
+                'to' => $paginator->lastItem(),
+            ],
+            'filters' => $filters,
+            'facets' => $eventFeed->facets($accessToken->user_id),
+            'alerts_muted' => $alertMute->isMuted($user),
+            // For subscribing to the owner's private channels via the overlay
+            // broadcasting auth endpoint, which only ever signs the token
+            // owner's own channels.
+            'twitch_id' => $user->twitch_id,
+            'ts' => now()->timestamp,
+        ]);
+    }
+
+    public function mute(Request $request, AlertMuteService $alertMute): JsonResponse
+    {
+        $accessToken = $this->resolveToken($request, 'write');
+        if ($accessToken instanceof JsonResponse) {
+            return $accessToken;
+        }
+
+        $validated = $request->validate([
+            'muted' => 'required|boolean',
+        ]);
+
+        $muted = $alertMute->setMuted($accessToken->user, (bool) $validated['muted']);
+
+        // Writes leave a trail in the token's access log.
+        $accessToken->recordAccess($request->ip(), $request->userAgent(), 'events-feed:mute');
+
+        return response()->json(['alerts_muted' => $muted]);
+    }
+
+    private function resolveToken(Request $request, string $ability): OverlayAccessToken|JsonResponse
+    {
+        $token = (string) $request->input('token', '');
+        if (strlen($token) !== 64) {
+            return response()->json([
+                'error' => 'A valid 64-character overlay token is required.',
+            ], 401);
+        }
+
+        $accessToken = OverlayAccessToken::findByToken($token, $request->ip());
+        if (! $accessToken || ! $accessToken->user) {
+            return response()->json(['error' => 'Invalid or expired token.'], 401);
+        }
+
+        if (! $accessToken->hasAbility($ability)) {
+            return response()->json(['error' => "This token does not have the '$ability' ability."], 403);
+        }
+
+        return $accessToken;
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -8,13 +8,11 @@ use App\Models\OptionSet;
 use App\Models\OverlayTemplate;
 use App\Models\TwitchEvent;
 use App\Models\Update;
+use App\Services\AlertMuteService;
 use App\Services\BroadcastMeter;
 use App\Services\EventMeter;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Database\Query\Builder as QueryBuilder;
+use App\Services\UnifiedEventFeedService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -67,7 +65,7 @@ class DashboardController extends Controller
         ]);
     }
 
-    public function recentActivity(Request $request): Response
+    public function recentActivity(Request $request, UnifiedEventFeedService $eventFeed): Response
     {
         $user = $request->user();
 
@@ -77,9 +75,9 @@ class DashboardController extends Controller
             ->limit(20)
             ->get();
 
-        $filters = $this->normalizeEventFilters($request);
-        $paginator = $this->paginateUnifiedEvents($user->id, $filters, 20);
-        $facets = $this->eventFilterFacets($user->id);
+        $filters = $eventFeed->normalizeFilters($request);
+        $paginator = $eventFeed->paginate($user->id, $filters, 20)->withQueryString();
+        $facets = $eventFeed->facets($user->id);
 
         return Inertia::render('dashboard/recents', [
             'recentTemplates' => $recentTemplates,
@@ -145,153 +143,20 @@ class DashboardController extends Controller
         ]);
     }
 
-    public function recentEvents(Request $request): Response
+    public function recentEvents(Request $request, UnifiedEventFeedService $eventFeed): Response
     {
         $user = $request->user();
 
-        $filters = $this->normalizeEventFilters($request);
-        $paginator = $this->paginateUnifiedEvents($user->id, $filters, 25);
-        $facets = $this->eventFilterFacets($user->id);
+        $filters = $eventFeed->normalizeFilters($request);
+        $paginator = $eventFeed->paginate($user->id, $filters, 25)->withQueryString();
+        $facets = $eventFeed->facets($user->id);
 
         return Inertia::render('dashboard/events', [
             'events' => $paginator,
             'filters' => $filters,
             'facets' => $facets,
+            'alertsMuted' => app(AlertMuteService::class)->isMuted($user),
         ]);
-    }
-
-    /**
-     * @return array{search: string, source: string, event_type: string, range: string}
-     */
-    private function normalizeEventFilters(Request $request): array
-    {
-        $allowedRanges = ['all', 'hour', '24h', '7d', '30d'];
-        $range = (string) $request->query('range', 'all');
-        if (! in_array($range, $allowedRanges, true)) {
-            $range = 'all';
-        }
-
-        return [
-            'search' => trim((string) $request->query('search', '')),
-            'source' => trim((string) $request->query('source', '')),
-            'event_type' => trim((string) $request->query('event_type', '')),
-            'range' => $range,
-        ];
-    }
-
-    /**
-     * @param  array{search: string, source: string, event_type: string, range: string}  $filters
-     */
-    private function paginateUnifiedEvents(int $userId, array $filters, int $perPage): LengthAwarePaginator
-    {
-        $twitch = DB::table('twitch_events')
-            ->where('user_id', $userId)
-            ->selectRaw("id, 'twitch' AS source, event_type, created_at, event_data::text AS event_data_json, NULL::text AS normalized_payload_json");
-
-        $external = DB::table('external_events')
-            ->where('user_id', $userId)
-            ->where('service', '!=', 'gps')
-            ->selectRaw('id, service AS source, event_type, created_at, NULL::text AS event_data_json, normalized_payload::text AS normalized_payload_json');
-
-        $this->applyEventFilters($twitch, $external, $filters);
-
-        $combined = DB::query()
-            ->fromSub($twitch->unionAll($external), 'events')
-            ->orderByDesc('created_at')
-            ->orderByDesc('id');
-
-        $paginator = $combined->paginate($perPage)->withQueryString();
-
-        $paginator->getCollection()->transform(function (object $row): array {
-            return [
-                'id' => (int) $row->id,
-                'source' => $row->source,
-                'event_type' => $row->event_type,
-                'label' => $row->source === 'twitch'
-                    ? (EventTemplateMapping::EVENT_TYPES[$row->event_type] ?? $row->event_type)
-                    : $row->event_type,
-                'created_at' => Carbon::parse($row->created_at)->toIso8601String(),
-                'event_data' => $row->event_data_json ? json_decode($row->event_data_json, true) : null,
-                'normalized_payload' => $row->normalized_payload_json ? json_decode($row->normalized_payload_json, true) : null,
-            ];
-        });
-
-        return $paginator;
-    }
-
-    /**
-     * @param  array{search: string, source: string, event_type: string, range: string}  $filters
-     */
-    private function applyEventFilters(QueryBuilder $twitch, QueryBuilder $external, array $filters): void
-    {
-        if ($filters['source'] !== '') {
-            if ($filters['source'] === 'twitch') {
-                $external->whereRaw('1 = 0');
-            } else {
-                $twitch->whereRaw('1 = 0');
-                $external->where('service', $filters['source']);
-            }
-        }
-
-        if ($filters['event_type'] !== '') {
-            $twitch->where('event_type', $filters['event_type']);
-            $external->where('event_type', $filters['event_type']);
-        }
-
-        $since = match ($filters['range']) {
-            'hour' => Carbon::now()->subHour(),
-            '24h' => Carbon::now()->subDay(),
-            '7d' => Carbon::now()->subDays(7),
-            '30d' => Carbon::now()->subDays(30),
-            default => null,
-        };
-        if ($since !== null) {
-            $twitch->where('created_at', '>=', $since);
-            $external->where('created_at', '>=', $since);
-        }
-
-        if ($filters['search'] !== '') {
-            $like = '%'.addcslashes($filters['search'], '%_\\').'%';
-            $twitch->whereRaw('event_data::text ILIKE ?', [$like]);
-            $external->whereRaw('normalized_payload::text ILIKE ?', [$like]);
-        }
-    }
-
-    /**
-     * Distinct sources + event types available to this user for populating filter dropdowns.
-     *
-     * @return array{sources: array<int, string>, event_types: array<int, string>}
-     */
-    private function eventFilterFacets(int $userId): array
-    {
-        $externalSources = ExternalEvent::where('user_id', $userId)
-            ->where('service', '!=', 'gps')
-            ->distinct()
-            ->pluck('service')
-            ->all();
-
-        $hasTwitch = TwitchEvent::where('user_id', $userId)->exists();
-
-        $sources = $externalSources;
-        if ($hasTwitch) {
-            array_unshift($sources, 'twitch');
-        }
-        $sources = array_values(array_unique($sources));
-        sort($sources);
-
-        $twitchTypes = TwitchEvent::where('user_id', $userId)->distinct()->pluck('event_type')->all();
-        $externalTypes = ExternalEvent::where('user_id', $userId)
-            ->where('service', '!=', 'gps')
-            ->distinct()
-            ->pluck('event_type')
-            ->all();
-        $eventTypes = array_values(array_unique(array_merge($twitchTypes, $externalTypes)));
-        sort($eventTypes);
-
-        return [
-            'sources' => $sources,
-            'event_types' => $eventTypes,
-        ];
     }
 
     /**

--- a/app/Http/Controllers/ExternalEventController.php
+++ b/app/Http/Controllers/ExternalEventController.php
@@ -7,6 +7,7 @@ use App\Jobs\SynthesizeAlertTts;
 use App\Models\BotChatOutbox;
 use App\Models\ExternalEvent;
 use App\Models\ExternalEventTemplateMapping;
+use App\Services\AlertMuteService;
 use App\Services\Expressions\AlertExpressionRenderer;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -24,6 +25,10 @@ class ExternalEventController extends Controller
 
         if ($externalEvent->user_id !== $user->id) {
             return back()->with('message', 'You do not own this event.')->with('type', 'error');
+        }
+
+        if (app(AlertMuteService::class)->isMuted($user)) {
+            return back()->with('message', 'Alerts are muted. Unmute alerts to replay events.')->with('type', 'warning');
         }
 
         $data = $externalEvent->normalized_payload ?? [];

--- a/app/Http/Controllers/OverlayControlController.php
+++ b/app/Http/Controllers/OverlayControlController.php
@@ -6,6 +6,7 @@ use App\Events\ControlValueUpdated;
 use App\Models\OptionSet;
 use App\Models\OverlayControl;
 use App\Models\OverlayTemplate;
+use App\Services\AlertMuteService;
 use App\Services\External\ExternalServiceRegistry;
 use App\Services\StreamSessionService;
 use Carbon\Carbon;
@@ -72,9 +73,12 @@ class OverlayControlController extends Controller
         if (! empty($validated['source'])) {
             $source = $validated['source'];
 
-            // Resolve presets from either Twitch stream controls or external service drivers
+            // Resolve presets from Twitch stream controls, the system alerts
+            // namespace, or external service drivers
             if ($source === 'twitch') {
                 $provisionedDefs = collect(StreamSessionService::CONTROL_PRESETS)->keyBy('key');
+            } elseif ($source === AlertMuteService::SOURCE) {
+                $provisionedDefs = collect(AlertMuteService::CONTROL_PRESETS)->keyBy('key');
             } elseif (ExternalServiceRegistry::has($source)) {
                 $driver = ExternalServiceRegistry::driver($source);
                 $provisionedDefs = collect($driver->getAutoProvisionedControls())->keyBy('key');

--- a/app/Http/Controllers/TwitchEventSubController.php
+++ b/app/Http/Controllers/TwitchEventSubController.php
@@ -12,6 +12,7 @@ use App\Models\StreamState;
 use App\Models\TwitchEvent;
 use App\Models\User;
 use App\Models\UserEventsubSubscription;
+use App\Services\AlertMuteService;
 use App\Services\EventMeter;
 use App\Services\Expressions\AlertExpressionRenderer;
 use App\Services\LockdownService;
@@ -591,6 +592,13 @@ class TwitchEventSubController extends Controller
      */
     private function renderEventAlert(User $user, EventTemplateMapping $mapping, array $eventData): void
     {
+        // Global mute: muted is muted - no broadcast, no TTS synthesis, no
+        // bot message. Guarded here so the live webhook path, replay, and
+        // test cheer are all covered by one check.
+        if (app(AlertMuteService::class)->isMuted($user)) {
+            return;
+        }
+
         try {
             // Get user's Twitch data for static template tags
             $twitchData = $this->twitchService->getExtendedUserData(
@@ -682,6 +690,10 @@ class TwitchEventSubController extends Controller
             return back()->with('message', 'You do not own this event.')->with('type', 'error');
         }
 
+        if (app(AlertMuteService::class)->isMuted($user)) {
+            return back()->with('message', 'Alerts are muted. Unmute alerts to replay events.')->with('type', 'warning');
+        }
+
         $mapping = EventTemplateMapping::resolveForEvent(
             $user->id,
             $twitchEvent->event_type,
@@ -759,8 +771,10 @@ class TwitchEventSubController extends Controller
 
         $mapping = EventTemplateMapping::resolveForEvent($user->id, 'channel.cheer', $event);
 
+        $muted = app(AlertMuteService::class)->isMuted($user);
+
         $alertFired = false;
-        if ($mapping && $mapping->template) {
+        if (! $muted && $mapping && $mapping->template) {
             $this->renderEventAlert($user, $mapping, $data);
             $alertFired = true;
         }
@@ -772,6 +786,7 @@ class TwitchEventSubController extends Controller
             'bits' => $bits,
             'cheerer_name' => $cheererName,
             'alert_fired' => $alertFired,
+            'alerts_muted' => $muted,
             'controls_updated' => $wasLive,
             'is_live' => $wasLive,
         ]);

--- a/app/Models/OverlayControl.php
+++ b/app/Models/OverlayControl.php
@@ -78,7 +78,7 @@ class OverlayControl extends Model
     const array TYPES = ['text', 'number', 'counter', 'timer', 'datetime', 'boolean', 'expression', 'list_writer'];
 
     /** Service source names that cannot be used as control keys (to avoid namespace collisions in expressions). */
-    const array RESERVED_KEYS = ['kofi', 'streamlabs', 'twitch', 'streamelements', 'gps'];
+    const array RESERVED_KEYS = ['kofi', 'streamlabs', 'twitch', 'streamelements', 'gps', 'alerts', 'fourthwall', 'bmac', 'throne'];
 
     const string KEY_PATTERN = '/^[a-z][a-z0-9_]{0,49}$/';
 

--- a/app/Services/AlertMuteService.php
+++ b/app/Services/AlertMuteService.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services;
+
+use App\Events\ControlValueUpdated;
+use App\Models\OverlayControl;
+use App\Models\User;
+
+/**
+ * Global alert mute: one switch that silences every alert output (visual,
+ * sound, TTS synthesis, bot chat message) at the dispatch sites.
+ *
+ * State lives in a single service-managed boolean control (source `alerts`,
+ * key `muted`) - the same control templates read via [[[if:c:alerts:muted]]] -
+ * so the guard, the toggle button, and the overlay banner all share one source
+ * of truth. Absent control = not muted. The control is user-scoped
+ * (overlay_template_id NULL) and source_managed, so the toggle endpoints are
+ * its only writers; the sibling of AlertExpressionRenderer's `tts` gate.
+ */
+class AlertMuteService
+{
+    public const string SOURCE = 'alerts';
+
+    public const string KEY = 'muted';
+
+    /** Preset defs for the "add preset control" flow, mirrors StreamSessionService::CONTROL_PRESETS. */
+    public const array CONTROL_PRESETS = [
+        ['key' => self::KEY, 'type' => 'boolean', 'label' => 'Alerts Muted', 'value' => '0'],
+    ];
+
+    public function isMuted(User $user): bool
+    {
+        return OverlayControl::where('user_id', $user->id)
+            ->where('source', self::SOURCE)
+            ->where('key', self::KEY)
+            ->where('source_managed', true)
+            ->where('value', '1')
+            ->exists();
+    }
+
+    /**
+     * Set the mute state, provisioning the control on first use, and
+     * broadcast the change so overlays and feed pages update live.
+     */
+    public function setMuted(User $user, bool $muted): bool
+    {
+        $control = OverlayControl::provisionServiceControl($user, self::SOURCE, self::CONTROL_PRESETS[0]);
+
+        $newValue = $muted ? '1' : '0';
+
+        if ($control->value !== $newValue) {
+            $control->update(['value' => $newValue]);
+
+            ControlValueUpdated::dispatch(
+                '',
+                $control->broadcastKey(),
+                $control->type,
+                $newValue,
+                $user->twitch_id,
+            );
+        }
+
+        return $muted;
+    }
+}

--- a/app/Services/External/ExternalAlertService.php
+++ b/app/Services/External/ExternalAlertService.php
@@ -7,6 +7,7 @@ use App\Jobs\SynthesizeAlertTts;
 use App\Models\BotChatOutbox;
 use App\Models\ExternalEventTemplateMapping;
 use App\Models\User;
+use App\Services\AlertMuteService;
 use App\Services\Expressions\AlertExpressionRenderer;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -19,6 +20,12 @@ class ExternalAlertService
      */
     public function dispatch(NormalizedExternalEvent $event, User $user): bool
     {
+        // Global mute: muted is muted - no broadcast, no TTS synthesis, no
+        // bot message. Control updates still flow; only alert output stops.
+        if (app(AlertMuteService::class)->isMuted($user)) {
+            return false;
+        }
+
         // Pick the alert template, honoring variant conditions on the donated
         // amount (e.g. a louder alert for a bigger Ko-fi donation).
         $mapping = ExternalEventTemplateMapping::resolveForEvent(

--- a/app/Services/UnifiedEventFeedService.php
+++ b/app/Services/UnifiedEventFeedService.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\EventTemplateMapping;
+use App\Models\ExternalEvent;
+use App\Models\TwitchEvent;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Unified twitch_events + external_events feed: filter normalization, facets
+ * and pagination. Extracted from DashboardController so the session dashboard
+ * pages and the token-authed /api/events feed serve identical data from one
+ * query path, keyed by an explicit user id.
+ */
+class UnifiedEventFeedService
+{
+    /**
+     * @return array{search: string, source: string, event_type: string, range: string}
+     */
+    public function normalizeFilters(Request $request): array
+    {
+        $allowedRanges = ['all', 'hour', '24h', '7d', '30d'];
+        $range = (string) $request->query('range', 'all');
+        if (! in_array($range, $allowedRanges, true)) {
+            $range = 'all';
+        }
+
+        return [
+            'search' => trim((string) $request->query('search', '')),
+            'source' => trim((string) $request->query('source', '')),
+            'event_type' => trim((string) $request->query('event_type', '')),
+            'range' => $range,
+        ];
+    }
+
+    /**
+     * @param  array{search: string, source: string, event_type: string, range: string}  $filters
+     */
+    public function paginate(int $userId, array $filters, int $perPage): LengthAwarePaginator
+    {
+        $twitch = DB::table('twitch_events')
+            ->where('user_id', $userId)
+            ->selectRaw("id, 'twitch' AS source, event_type, created_at, event_data::text AS event_data_json, NULL::text AS normalized_payload_json");
+
+        $external = DB::table('external_events')
+            ->where('user_id', $userId)
+            ->where('service', '!=', 'gps')
+            ->selectRaw('id, service AS source, event_type, created_at, NULL::text AS event_data_json, normalized_payload::text AS normalized_payload_json');
+
+        $this->applyFilters($twitch, $external, $filters);
+
+        $combined = DB::query()
+            ->fromSub($twitch->unionAll($external), 'events')
+            ->orderByDesc('created_at')
+            ->orderByDesc('id');
+
+        $paginator = $combined->paginate($perPage);
+
+        $paginator->getCollection()->transform(function (object $row): array {
+            return [
+                'id' => (int) $row->id,
+                'source' => $row->source,
+                'event_type' => $row->event_type,
+                'label' => $row->source === 'twitch'
+                    ? (EventTemplateMapping::EVENT_TYPES[$row->event_type] ?? $row->event_type)
+                    : $row->event_type,
+                'created_at' => Carbon::parse($row->created_at)->toIso8601String(),
+                'event_data' => $row->event_data_json ? json_decode($row->event_data_json, true) : null,
+                'normalized_payload' => $row->normalized_payload_json ? json_decode($row->normalized_payload_json, true) : null,
+            ];
+        });
+
+        return $paginator;
+    }
+
+    /**
+     * Distinct sources + event types available to this user for populating filter dropdowns.
+     *
+     * @return array{sources: array<int, string>, event_types: array<int, string>}
+     */
+    public function facets(int $userId): array
+    {
+        $externalSources = ExternalEvent::where('user_id', $userId)
+            ->where('service', '!=', 'gps')
+            ->distinct()
+            ->pluck('service')
+            ->all();
+
+        $hasTwitch = TwitchEvent::where('user_id', $userId)->exists();
+
+        $sources = $externalSources;
+        if ($hasTwitch) {
+            array_unshift($sources, 'twitch');
+        }
+        $sources = array_values(array_unique($sources));
+        sort($sources);
+
+        $twitchTypes = TwitchEvent::where('user_id', $userId)->distinct()->pluck('event_type')->all();
+        $externalTypes = ExternalEvent::where('user_id', $userId)
+            ->where('service', '!=', 'gps')
+            ->distinct()
+            ->pluck('event_type')
+            ->all();
+        $eventTypes = array_values(array_unique(array_merge($twitchTypes, $externalTypes)));
+        sort($eventTypes);
+
+        return [
+            'sources' => $sources,
+            'event_types' => $eventTypes,
+        ];
+    }
+
+    /**
+     * @param  array{search: string, source: string, event_type: string, range: string}  $filters
+     */
+    private function applyFilters(QueryBuilder $twitch, QueryBuilder $external, array $filters): void
+    {
+        if ($filters['source'] !== '') {
+            if ($filters['source'] === 'twitch') {
+                $external->whereRaw('1 = 0');
+            } else {
+                $twitch->whereRaw('1 = 0');
+                $external->where('service', $filters['source']);
+            }
+        }
+
+        if ($filters['event_type'] !== '') {
+            $twitch->where('event_type', $filters['event_type']);
+            $external->where('event_type', $filters['event_type']);
+        }
+
+        $since = match ($filters['range']) {
+            'hour' => Carbon::now()->subHour(),
+            '24h' => Carbon::now()->subDay(),
+            '7d' => Carbon::now()->subDays(7),
+            '30d' => Carbon::now()->subDays(30),
+            default => null,
+        };
+        if ($since !== null) {
+            $twitch->where('created_at', '>=', $since);
+            $external->where('created_at', '>=', $since);
+        }
+
+        if ($filters['search'] !== '') {
+            $like = '%'.addcslashes($filters['search'], '%_\\').'%';
+            $twitch->whereRaw('event_data::text ILIKE ?', [$like]);
+            $external->whereRaw('normalized_payload::text ILIKE ?', [$like]);
+        }
+    }
+}

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,26 @@
 # CHANGELOG JULY 2026
 
+## July 3rd, 2026 - feat(events): token-authed events feed + one-click global alert mute
+
+Two user-requested pieces that make the events page usable mid-stream from a phone. First: `/dashboard/events` required a full Twitch login, painful on mobile where you're usually not logged in to Twitch. Second: there was no way to silence every alert at once (StreamElements has this; now so do we).
+
+**Token-authed events feed (`/events/feed#<token>`)**
+
+- New standalone page (own Vite entry, `resources/js/events-feed/`) authenticated by the same `OverlayAccessToken` overlays use: token in the URL fragment, read client-side, never sent to the server in a URL. Mirrors the overlay shell + the `/api/lists/{slug}?token=` precedent.
+- New stateless endpoints: `GET /api/events` (filters, facets, pagination - same query as the dashboard page, extracted into `UnifiedEventFeedService`) and `POST /api/events/mute`. Both `throttle:overlay` + `lockdown`, Sanctum-stateful shed.
+- **Token abilities are now enforced for the first time**: the feed requires `read`, the mute toggle requires `write`. Tokens with no abilities set remain unrestricted (matches `hasAbility()`), so every existing overlay token keeps working. The mute toggle is deliberately the only write an overlay token can perform, and each mute write lands in the token's access log.
+- Live updates via the existing overlay broadcasting auth endpoint (it already signs `twitch-events`/`alerts` channels for a token): new events refresh page 1 debounced; the mute state flips live no matter where it was toggled from.
+- `EventsTable` gained a `readonly` prop - replay stays a logged-in dashboard action.
+
+**Global alert mute (muted is muted)**
+
+- State lives in ONE place: a service-managed boolean control `alerts:muted` (user-scoped, source_managed, provisioned lazily on first toggle). The same control templates read - `[[[if:c:alerts:muted]]]ALERTS ARE MUTED[[[endif]]]` shows/hides live in overlays with zero engine changes, and `[[[c:alerts:muted_at]]]` ("muted since") comes free from the client-side `_at` companion. Conceptual sibling of the `tts` gate control.
+- `AlertMuteService`: `isMuted()` (one indexed exists() query, absent control = not muted) + `setMuted()` (provision, flip `'0'`/`'1'`, broadcast `ControlValueUpdated` with empty overlay_slug = all overlays).
+- Guarded at all three alert build-sites BEFORE any output: `TwitchEventSubController::renderEventAlert` (covers live webhooks, replay, test cheer), `ExternalAlertService::dispatch`, `ExternalEventController::replay`. Muting stops the visual broadcast, the alert sound, the ElevenLabs TTS synthesis (no credits burned), and the bot chat message. Events keep recording and controls keep updating - only alert output stops.
+- No replay bypass: replaying while muted returns a "Alerts are muted" warning instead; test cheer reports `alerts_muted` in its response.
+- Mute/unmute button + amber muted banner on both `/dashboard/events` (session, `POST /dashboard/events/mute`) and the token feed.
+- `alerts:muted` is in the Add-Control preset picker (new "Overlabels - Alerts" group, no integration required) so the overlay banner pattern is one click to add. `alerts` reserved as a control key; drive-by: `fourthwall`, `bmac`, `throne` added to `RESERVED_KEYS` too (they were missing, same collision class).
+
 ## July 2nd, 2026 - docs(controls): document preset controls on the Controls help page
 
 The Controls help page (`/help/controls`) thoroughly explained user-created controls but never mentioned preset controls - the service-managed values Overlabels feeds in from Twitch, the donation integrations, and the GPS app. New readers had no bridge from that page to the concept or to the exhaustive `/help/integration-presets` reference.

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,13 @@
 # CHANGELOG JULY 2026
 
+## July 3rd, 2026 - feat(events): one-click feed link + QR from the recents page
+
+Closes the "how do I even get the feed URL onto my phone" gap from the feed feature: plaintext tokens are shown once, so no page could reconstruct the link after the fact. Now the recents page mints it for you.
+
+- **`TokenUrlDialog`** - the token-URL machinery extracted from `AddToObsButton` (link warning, `tokens.store` POST, fragment URL assembly, copy-to-clipboard box, QR code) into one shared dialog with `instructions`/`footer` slots. `AddToObsButton` is now a thin wrapper around it with identical behavior and copy.
+- **`EventsFeedLinkButton`** - replaces the "Embed view" link on `/dashboard/recents` (which pointed at the session-locked `/dashboard/events`). One click mints a fresh token **scoped to `read,write`** (tighter than the unrestricted default), named "Events feed" so it's recognizable on the Tokens page, and shows `/events/feed#<token>` with the QR code open by default - the phone is the whole point. Copy warns that the link reads your history and can mute your alerts, and points at token revocation if it leaks.
+- ESLint + vite build clean; no backend changes.
+
 ## July 3rd, 2026 - feat(events): token-authed events feed + one-click global alert mute
 
 Two user-requested pieces that make the events page usable mid-stream from a phone. First: `/dashboard/events` required a full Twitch login, painful on mobile where you're usually not logged in to Twitch. Second: there was no way to silence every alert at once (StreamElements has this; now so do we).

--- a/resources/js/components/AddToObsButton.vue
+++ b/resources/js/components/AddToObsButton.vue
@@ -1,88 +1,25 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-import QRCode from 'qrcode';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ref } from 'vue';
+import TokenUrlDialog from '@/components/TokenUrlDialog.vue';
+import { Dialog, DialogContent, DialogFooter, DialogTitle } from '@/components/ui/dialog';
 import { VisuallyHidden } from 'reka-ui';
-import { useLinkWarning } from '@/composables/useLinkWarning';
-import { CheckIcon, CopyIcon, Loader2, QrCodeIcon } from '@lucide/vue';
 
 const props = defineProps<{
   template: { id: number; name: string; slug: string };
 }>();
 
-const { triggerLinkWarning } = useLinkWarning();
-
-const showOBSHelp = ref(false);
+const dialogRef = ref<InstanceType<typeof TokenUrlDialog> | null>(null);
 const showObsScreenshot = ref(false);
-const obsGenerating = ref(false);
-const obsGeneratedUrl = ref<string | null>(null);
-const obsUrlCopied = ref(false);
 const obsConfirmedCopied = ref(false);
-const obsError = ref('');
-const showQrCode = ref(false);
-const qrDataUrl = ref<string | null>(null);
 
-// Render the QR only after a URL is confirmed; clear it when the URL is reset.
-watch(obsGeneratedUrl, async (url) => {
-  if (!url) {
-    qrDataUrl.value = null;
-    return;
-  }
-  qrDataUrl.value = await QRCode.toDataURL(url, {
-    width: 240,
-    margin: 2,
-    color: { dark: '#000000', light: '#ffffff' },
-  });
-});
+const obsWarning =
+  'The next screen shows your personal token and you should NOT show this on stream.\n\nIf you are currently streaming, move this screen away from your stream before continuing.';
 
 const obsIconSVG = '<svg role="img" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12,24C5.383,24,0,18.617,0,12S5.383,0,12,0s12,5.383,12,12S18.617,24,12,24z M12,1.109 C5.995,1.109,1.11,5.995,1.11,12C1.11,18.005,5.995,22.89,12,22.89S22.89,18.005,22.89,12C22.89,5.995,18.005,1.109,12,1.109z M6.182,5.99c0.352-1.698,1.503-3.229,3.05-3.996c-0.269,0.273-0.595,0.483-0.844,0.78c-1.02,1.1-1.48,2.692-1.199,4.156 c0.355,2.235,2.455,4.06,4.732,4.028c1.765,0.079,3.485-0.937,4.348-2.468c1.848,0.063,3.645,1.017,4.7,2.548 c0.54,0.799,0.962,1.736,0.991,2.711c-0.342-1.295-1.202-2.446-2.375-3.095c-1.135-0.639-2.529-0.802-3.772-0.425 c-1.56,0.448-2.849,1.723-3.293,3.293c-0.377,1.25-0.216,2.628,0.377,3.772c-0.825,1.429-2.315,2.449-3.932,2.756 c-1.244,0.261-2.551,0.059-3.709-0.464c1.036,0.302,2.161,0.355,3.191-0.011c1.381-0.457,2.522-1.567,3.024-2.935 c0.556-1.49,0.345-3.261-0.591-4.54c-0.7-1.007-1.803-1.717-3.002-1.969c-0.38-0.068-0.764-0.098-1.148-0.134 c-0.611-1.231-0.834-2.66-0.528-3.996L6.182,5.99z"/></svg>';
 
 function generateOBSUrl() {
-  triggerLinkWarning(async () => {
-    showOBSHelp.value = true;
-    obsGenerating.value = true;
-    obsGeneratedUrl.value = null;
-    obsUrlCopied.value = false;
-    obsConfirmedCopied.value = false;
-    obsError.value = '';
-    showQrCode.value = false;
-    try {
-      const url = route('tokens.store');
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-          'X-CSRF-TOKEN': document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '',
-        },
-        body: JSON.stringify({ name: `OBS - ${props.template?.name ?? 'Overlay'}` }),
-      });
-
-      if (!response.ok) {
-        const errorBody = await response.text();
-        console.error('[OBS URL] Token generation failed', { status: response.status, body: errorBody, url });
-        obsError.value = 'Failed to generate a token. Please try again.';
-        return;
-      }
-
-      const data = await response.json();
-      obsGeneratedUrl.value = `${window.location.origin}/overlay/${props.template?.slug}/#${data.plain_token}`;
-    } catch (e) {
-      console.error('[OBS URL]', e);
-      obsError.value = 'Failed to generate a token. Please try again.';
-    } finally {
-      obsGenerating.value = false;
-    }
-  }, 'The next screen shows your personal token and you should NOT show this on stream.\n\nIf you are currently streaming, move this screen away from your stream before continuing.');
-}
-
-function copyOBSUrl() {
-  if (!obsGeneratedUrl.value) return;
-  navigator.clipboard.writeText(obsGeneratedUrl.value);
-  obsUrlCopied.value = true;
-  setTimeout(() => {
-    obsUrlCopied.value = false;
-  }, 5000);
+  obsConfirmedCopied.value = false;
+  dialogRef.value?.generate();
 }
 
 defineExpose({ generateOBSUrl });
@@ -101,94 +38,46 @@ defineExpose({ generateOBSUrl });
   </button>
 
   <!-- OBS URL Dialog -->
-  <Dialog :open="showOBSHelp">
-    <DialogContent class="max-w-lg" @escape-key-down.prevent @pointer-down-outside.prevent @interact-outside.prevent>
-      <DialogHeader>
-        <DialogTitle>Add this overlay to OBS</DialogTitle>
-      </DialogHeader>
-
-      <!-- Loading state -->
-      <div v-if="obsGenerating" class="flex items-center justify-center gap-3 py-8">
-        <Loader2 class="h-5 w-5 animate-spin text-violet-400" />
-        <span class="text-sm">Generating your secure URL...</span>
+  <TokenUrlDialog
+    ref="dialogRef"
+    title="Add this overlay to OBS"
+    :token-name="`OBS - ${props.template?.name ?? 'Overlay'}`"
+    :url-base="`/overlay/${props.template?.slug}/`"
+    :warning="obsWarning"
+    copy-hint='Easy: Just drag the box below in your OBS and click "Yes" to confirm.'
+    qr-hint="Scan with your phone to open this overlay. This code contains your secret token, so do not show it on stream."
+  >
+    <template #instructions>
+      <div>
+        <ol class="list-decimal space-y-1.5 pl-4 text-foreground">
+          <li><strong>Drag the box above</strong> directly on to OBS.</li>
+          <li>In OBS, this will automatically create a new <strong>Browser Source</strong>.</li>
+          <li>Alternatively, you can click the green box above to copy the link and create the browser source manually. Be sure to set it to fullscreen (right click > transform > Fit to screen)</li>
+          <li>Your OBS Browser Source settings should look like
+            <button type="button" class="underline text-violet-400 hover:text-violet-300 cursor-pointer" @click="showObsScreenshot = true">this example</button>.
+          </li>
+        </ol>
       </div>
+    </template>
 
-      <!-- Error state -->
-      <div v-else-if="obsError" class="space-y-4 text-sm">
-        <div class="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-red-600 dark:text-red-400">
-          <p>{{ obsError }}</p>
-        </div>
-      </div>
+    <template #footer="{ close }">
+      <div class="flex flex-col bg-violet-600/10 p-2 border rounded-sm border-violet-500/50 gap-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input v-model="obsConfirmedCopied" type="checkbox" />
+          <span class="text-sm text-foreground">I have copied this overlay to my OBS as a Browser Source</span>
+        </label>
 
-      <!-- URL generated -->
-      <div v-else-if="obsGeneratedUrl" class="space-y-4 text-sm">
-        <p class="text-green-400" v-if="obsUrlCopied">URL Copied to clipboard</p>
-        <p class="text-foreground" v-else>Easy: Just drag the box below in your OBS and click "Yes" to confirm.</p>
-
-        <a
-          class="flex items-center cursor-pointer gap-2 rounded-lg border border-green-500/20 bg-green-400/10 dark:bg-green-950/10 p-3 font-mono text-xs break-all transition-colors hover:bg-green-400/20 active:ring active:ring-green-500 select-all"
-          :class="obsUrlCopied ? 'border-green-500/40 ring ring-green-500/80' : 'border-green-500/20'"
-          :href="obsGeneratedUrl"
-          @click.prevent="copyOBSUrl"
+        <button
+          v-if="obsConfirmedCopied"
+          type="button"
+          class="btn btn-primary mt-2"
+          @click="close()"
         >
-          <span class="flex-1 text-green-600 dark:text-green-300/80">{{ obsGeneratedUrl }}</span>
-          <span class="shrink-0 rounded-md p-2 transition hover:bg-green-500/10" title="Copy URL">
-            <CheckIcon v-if="obsUrlCopied" class="h-4 w-4 text-green-400" />
-            <CopyIcon v-else class="h-4 w-4 text-green-400" />
-          </span>
-        </a>
-
-        <div>
-          <ol class="list-decimal space-y-1.5 pl-4 text-foreground">
-            <li><strong>Drag the box above</strong> directly on to OBS.</li>
-            <li>In OBS, this will automatically create a new <strong>Browser Source</strong>.</li>
-            <li>Alternatively, you can click the green box above to copy the link and create the browser source manually. Be sure to set it to fullscreen (right click > transform > Fit to screen)</li>
-            <li>Your OBS Browser Source settings should look like
-              <button type="button" class="underline text-violet-400 hover:text-violet-300 cursor-pointer" @click="showObsScreenshot = true">this example</button>.
-            </li>
-          </ol>
-        </div>
-
-        <!-- QR code for getting the overlay URL onto a phone -->
-        <div class="rounded-lg border border-violet-500/30 bg-violet-600/5">
-          <button
-            type="button"
-            class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left cursor-pointer"
-            @click="showQrCode = !showQrCode"
-          >
-            <span class="flex items-center gap-2 text-sm text-foreground">
-              <QrCodeIcon class="h-4 w-4 text-violet-400" />
-              Show QR code to open on your phone
-            </span>
-            <span class="text-xs text-violet-400">{{ showQrCode ? 'Hide' : 'Show' }}</span>
-          </button>
-
-          <div v-if="showQrCode && qrDataUrl" class="flex flex-col items-center gap-2 px-3 pb-3">
-            <img :src="qrDataUrl" alt="QR code for this overlay URL" class="rounded bg-white p-2" width="240" height="240" />
-            <p class="text-center text-xs text-foreground">Scan with your phone to open this overlay. This code contains your secret token, so do not show it on stream.</p>
-          </div>
-        </div>
-
-        <div class="h-px bg-violet-300"></div>
-
-        <div class="flex flex-col bg-violet-600/10 p-2 border rounded-sm border-violet-500/50 gap-2">
-          <label class="flex items-center gap-2 cursor-pointer">
-            <input v-model="obsConfirmedCopied" type="checkbox" />
-            <span class="text-sm text-foreground">I have copied this overlay to my OBS as a Browser Source</span>
-          </label>
-
-          <button
-            v-if="obsConfirmedCopied"
-            type="button"
-            class="btn btn-primary mt-2"
-            @click="showOBSHelp = false"
-          >
-            Close this screen and continue
-          </button>
-        </div>
+          Close this screen and continue
+        </button>
       </div>
-    </DialogContent>
-  </Dialog>
+    </template>
+  </TokenUrlDialog>
 
   <!-- OBS Settings Screenshot Modal -->
   <Dialog :open="showObsScreenshot" @update:open="showObsScreenshot = $event">

--- a/resources/js/components/ControlFormModal.vue
+++ b/resources/js/components/ControlFormModal.vue
@@ -23,6 +23,7 @@ import {
 import { ChevronsUpDownIcon } from '@lucide/vue';
 import ExpressionBuilder from '@/components/controls/ExpressionBuilder.vue';
 import {
+  ALERTS_PRESETS,
   KOFI_PRESETS,
   GPS_PRESETS,
   STREAMLABS_PRESETS,
@@ -121,6 +122,11 @@ const showThronePresets = computed(
 const showTwitchPresets = computed(
   () => !isEditing.value && !isCopying.value && props.template?.type === 'static',
 );
+// System presets (alerts:muted): no integration required, so same visibility
+// rule as the Twitch presets.
+const showAlertsPresets = computed(
+  () => !isEditing.value && !isCopying.value && props.template?.type === 'static',
+);
 
 // Filter out presets that already exist as controls on this template
 function isPresetAlreadyAdded(source: string, key: string): boolean {
@@ -141,6 +147,9 @@ function matchesPresetSearch(source: string, preset: ServicePreset): boolean {
 
 const availableTwitchPresets = computed(() =>
   TWITCH_PRESETS.filter((p) => !isPresetAlreadyAdded('twitch', p.key) && matchesPresetSearch('twitch', p)),
+);
+const availableAlertsPresets = computed(() =>
+  ALERTS_PRESETS.filter((p) => !isPresetAlreadyAdded('alerts', p.key) && matchesPresetSearch('alerts', p)),
 );
 const availableKofiPresets = computed(() =>
   KOFI_PRESETS.filter((p) => !isPresetAlreadyAdded('kofi', p.key) && matchesPresetSearch('kofi', p)),
@@ -511,7 +520,7 @@ async function save() {
           <p v-if="errors.general" class="text-sm text-destructive">{{ errors.general }}</p>
 
           <!-- Service Presets -->
-          <div v-if="showTwitchPresets || showKofiPresets || showGpsPresets || showStreamLabsPresets || showStreamElementsPresets || showFourthwallPresets || showBmacPresets || showThronePresets" class="space-y-2 border border-violet-400/30 bg-violet-400/5 p-3">
+          <div v-if="showTwitchPresets || showAlertsPresets || showKofiPresets || showGpsPresets || showStreamLabsPresets || showStreamElementsPresets || showFourthwallPresets || showBmacPresets || showThronePresets" class="space-y-2 border border-violet-400/30 bg-violet-400/5 p-3">
             <div class="flex items-center justify-between gap-2">
               <p class="text-sm font-medium text-violet-500 dark:text-violet-400">Stream Controls</p>
               <a
@@ -546,6 +555,16 @@ async function save() {
                     v-for="preset in availableTwitchPresets"
                     :key="'twitch:' + preset.key"
                     :value="'twitch:' + preset.key"
+                  >
+                    {{ preset.label }} ({{ preset.type }})
+                  </ComboboxItem>
+                </ComboboxGroup>
+                <ComboboxGroup v-if="showAlertsPresets && availableAlertsPresets.length">
+                  <ComboboxLabel>Overlabels - Alerts</ComboboxLabel>
+                  <ComboboxItem
+                    v-for="preset in availableAlertsPresets"
+                    :key="'alerts:' + preset.key"
+                    :value="'alerts:' + preset.key"
                   >
                     {{ preset.label }} ({{ preset.type }})
                   </ComboboxItem>

--- a/resources/js/components/EventsFeedLinkButton.vue
+++ b/resources/js/components/EventsFeedLinkButton.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import TokenUrlDialog from '@/components/TokenUrlDialog.vue';
+import { Smartphone } from '@lucide/vue';
+
+// Mints a read+write scoped token and hands out the /events/feed#<token> URL,
+// QR-first: the whole point of the feed is opening it on a phone without a
+// Twitch login. Reuses the same dialog machinery as AddToObsButton.
+const dialogRef = ref<InstanceType<typeof TokenUrlDialog> | null>(null);
+
+const feedWarning =
+  'The next screen shows a link containing your personal token and you should NOT show it on stream.\n\nIf you are currently streaming, move this screen away from your stream before continuing.';
+
+function generateFeedUrl() {
+  dialogRef.value?.generate();
+}
+
+defineExpose({ generateFeedUrl });
+</script>
+
+<template>
+  <button
+    @click="generateFeedUrl()"
+    class="btn btn-primary cursor-pointer"
+    title="Open your events feed on your phone"
+  >
+    <Smartphone class="mr-2 h-4 w-4" />
+    Events feed
+  </button>
+
+  <TokenUrlDialog
+    ref="dialogRef"
+    title="Your events feed, on your phone"
+    token-name="Events feed"
+    :abilities="['read', 'write']"
+    url-base="/events/feed"
+    :warning="feedWarning"
+    copy-hint="Scan the QR code below with your phone, or copy the link."
+    qr-hint="Scan with your phone to open your events feed. This code contains your secret token, so do not show it on stream."
+    qr-default-open
+  >
+    <template #instructions>
+      <p class="text-foreground">
+        The link opens your live events feed with the mute-all-alerts button - no login needed.
+        Anyone with the link can read your event history and mute or unmute your alerts, so treat
+        it like a password. If it ever leaks, revoke the "Events feed" token on the Tokens page
+        and generate a new link here.
+      </p>
+    </template>
+
+    <template #footer="{ close }">
+      <div class="flex justify-end">
+        <button type="button" class="btn btn-chill" @click="close()">Close</button>
+      </div>
+    </template>
+  </TokenUrlDialog>
+</template>

--- a/resources/js/components/EventsTable.vue
+++ b/resources/js/components/EventsTable.vue
@@ -8,8 +8,11 @@ import type { UnifiedEvent } from '@/composables/useEventColors';
 
 const { eventDotClass, eventHoverBorderClass } = useEventColors();
 
-defineProps<{
+const props = defineProps<{
   events: UnifiedEvent[];
+  // Hides the replay affordance; used by the token-authed events feed, which
+  // is view-only (replay stays a logged-in dashboard action).
+  readonly?: boolean;
 }>();
 
 const replayingId = ref<number | null>(null);
@@ -35,6 +38,7 @@ function confirmAndReplay(event: UnifiedEvent) {
 const nonReplayableTypes = ['stream.online', 'stream.offline', 'channel.channel_points_custom_reward_redemption.update'];
 
 function canReplay(event: UnifiedEvent): boolean {
+  if (props.readonly) return false;
   if (event.source !== 'twitch') return true;
   return !nonReplayableTypes.includes(event.event_type);
 }

--- a/resources/js/components/TokenUrlDialog.vue
+++ b/resources/js/components/TokenUrlDialog.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import QRCode from 'qrcode';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useLinkWarning } from '@/composables/useLinkWarning';
+import { CheckIcon, CopyIcon, Loader2, QrCodeIcon } from '@lucide/vue';
+
+// Shared "generate a tokened URL" dialog: mints a fresh OverlayAccessToken via
+// tokens.store, appends it as a URL fragment, and offers copy-to-clipboard and
+// a QR code. Wrapped by AddToObsButton (overlay browser-source URLs) and
+// EventsFeedLinkButton (phone events feed); the wrapper renders its own
+// trigger button, provides the surrounding copy via slots, and calls the
+// exposed generate().
+const props = defineProps<{
+  title: string;
+  // Name stored on the minted token, so it's recognizable on the Tokens page.
+  tokenName: string;
+  // Path the fragment is appended to, e.g. `/overlay/my-slug/` or `/events/feed`.
+  urlBase: string;
+  // Abilities for the minted token; omitted = unrestricted (legacy behavior).
+  abilities?: string[];
+  // Shown by the pre-open link warning (the "don't show this on stream" gate).
+  warning: string;
+  // Line above the URL box before/after copying.
+  copyHint: string;
+  copiedHint?: string;
+  // Line under the QR image.
+  qrHint: string;
+  // Open the QR section as soon as the URL exists (phone-first flows).
+  qrDefaultOpen?: boolean;
+}>();
+
+defineSlots<{
+  instructions?: () => unknown;
+  footer?: (props: { close: () => void }) => unknown;
+}>();
+
+const { triggerLinkWarning } = useLinkWarning();
+
+const showDialog = ref(false);
+const generating = ref(false);
+const generatedUrl = ref<string | null>(null);
+const urlCopied = ref(false);
+const error = ref('');
+const showQrCode = ref(false);
+const qrDataUrl = ref<string | null>(null);
+
+// Render the QR only after a URL is confirmed; clear it when the URL is reset.
+watch(generatedUrl, async (url) => {
+  if (!url) {
+    qrDataUrl.value = null;
+    return;
+  }
+  qrDataUrl.value = await QRCode.toDataURL(url, {
+    width: 240,
+    margin: 2,
+    color: { dark: '#000000', light: '#ffffff' },
+  });
+});
+
+function generate() {
+  triggerLinkWarning(async () => {
+    showDialog.value = true;
+    generating.value = true;
+    generatedUrl.value = null;
+    urlCopied.value = false;
+    error.value = '';
+    showQrCode.value = props.qrDefaultOpen ?? false;
+    try {
+      const url = route('tokens.store');
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'X-CSRF-TOKEN': document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '',
+        },
+        body: JSON.stringify({
+          name: props.tokenName,
+          ...(props.abilities ? { abilities: props.abilities } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error('[Token URL] Token generation failed', { status: response.status, body: errorBody, url });
+        error.value = 'Failed to generate a token. Please try again.';
+        return;
+      }
+
+      const data = await response.json();
+      generatedUrl.value = `${window.location.origin}${props.urlBase}#${data.plain_token}`;
+    } catch (e) {
+      console.error('[Token URL]', e);
+      error.value = 'Failed to generate a token. Please try again.';
+    } finally {
+      generating.value = false;
+    }
+  }, props.warning);
+}
+
+function copyUrl() {
+  if (!generatedUrl.value) return;
+  navigator.clipboard.writeText(generatedUrl.value);
+  urlCopied.value = true;
+  setTimeout(() => {
+    urlCopied.value = false;
+  }, 5000);
+}
+
+function close() {
+  showDialog.value = false;
+}
+
+defineExpose({ generate });
+</script>
+
+<template>
+  <Dialog :open="showDialog">
+    <DialogContent class="max-w-lg" @escape-key-down.prevent @pointer-down-outside.prevent @interact-outside.prevent>
+      <DialogHeader>
+        <DialogTitle>{{ title }}</DialogTitle>
+      </DialogHeader>
+
+      <!-- Loading state -->
+      <div v-if="generating" class="flex items-center justify-center gap-3 py-8">
+        <Loader2 class="h-5 w-5 animate-spin text-violet-400" />
+        <span class="text-sm">Generating your secure URL...</span>
+      </div>
+
+      <!-- Error state -->
+      <div v-else-if="error" class="space-y-4 text-sm">
+        <div class="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-red-600 dark:text-red-400">
+          <p>{{ error }}</p>
+        </div>
+      </div>
+
+      <!-- URL generated -->
+      <div v-else-if="generatedUrl" class="space-y-4 text-sm">
+        <p class="text-green-400" v-if="urlCopied">{{ copiedHint ?? 'URL Copied to clipboard' }}</p>
+        <p class="text-foreground" v-else>{{ copyHint }}</p>
+
+        <a
+          class="flex items-center cursor-pointer gap-2 rounded-lg border border-green-500/20 bg-green-400/10 dark:bg-green-950/10 p-3 font-mono text-xs break-all transition-colors hover:bg-green-400/20 active:ring active:ring-green-500 select-all"
+          :class="urlCopied ? 'border-green-500/40 ring ring-green-500/80' : 'border-green-500/20'"
+          :href="generatedUrl"
+          @click.prevent="copyUrl"
+        >
+          <span class="flex-1 text-green-600 dark:text-green-300/80">{{ generatedUrl }}</span>
+          <span class="shrink-0 rounded-md p-2 transition hover:bg-green-500/10" title="Copy URL">
+            <CheckIcon v-if="urlCopied" class="h-4 w-4 text-green-400" />
+            <CopyIcon v-else class="h-4 w-4 text-green-400" />
+          </span>
+        </a>
+
+        <slot name="instructions" />
+
+        <!-- QR code for getting the URL onto a phone -->
+        <div class="rounded-lg border border-violet-500/30 bg-violet-600/5">
+          <button
+            type="button"
+            class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left cursor-pointer"
+            @click="showQrCode = !showQrCode"
+          >
+            <span class="flex items-center gap-2 text-sm text-foreground">
+              <QrCodeIcon class="h-4 w-4 text-violet-400" />
+              {{ showQrCode ? 'QR code to open on your phone' : 'Show QR code to open on your phone' }}
+            </span>
+            <span class="text-xs text-violet-400">{{ showQrCode ? 'Hide' : 'Show' }}</span>
+          </button>
+
+          <div v-if="showQrCode && qrDataUrl" class="flex flex-col items-center gap-2 px-3 pb-3">
+            <img :src="qrDataUrl" alt="QR code for this URL" class="rounded bg-white p-2" width="240" height="240" />
+            <p class="text-center text-xs text-foreground">{{ qrHint }}</p>
+          </div>
+        </div>
+
+        <div class="h-px bg-violet-300"></div>
+
+        <slot name="footer" :close="close" />
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/resources/js/components/controls/controlPresets.ts
+++ b/resources/js/components/controls/controlPresets.ts
@@ -80,6 +80,13 @@ export const TWITCH_PRESETS: ServicePreset[] = [
   { key: 'latest_cheer_message', label: 'Latest Cheer Message', type: 'text' },
 ];
 
+// System namespace, not an integration: alerts:muted mirrors the global
+// alert mute state (events page / feed page button). Read-only in overlays,
+// flips live: [[[if:c:alerts:muted]]]ALERTS ARE MUTED[[[endif]]]
+export const ALERTS_PRESETS: ServicePreset[] = [
+  { key: 'muted', label: 'Alerts Muted', type: 'boolean' },
+];
+
 export const GPS_PRESETS: ServicePreset[] = [
   { key: 'speed', label: 'GPS Speed', type: 'number' },
   { key: 'lat', label: 'GPS Latitude', type: 'text' },
@@ -99,6 +106,7 @@ export const GPS_PRESETS: ServicePreset[] = [
 export function getPresetsForSource(source: string): ServicePreset[] {
   switch (source) {
     case 'twitch': return TWITCH_PRESETS;
+    case 'alerts': return ALERTS_PRESETS;
     case 'kofi': return KOFI_PRESETS;
     case 'gps': return GPS_PRESETS;
     case 'streamlabs': return STREAMLABS_PRESETS;

--- a/resources/js/events-feed/EventsFeed.vue
+++ b/resources/js/events-feed/EventsFeed.vue
@@ -1,0 +1,365 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import EventsTable from '@/components/EventsTable.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, RefreshCw, SlidersHorizontal, Volume2, VolumeX } from '@lucide/vue';
+import debounce from 'lodash/debounce';
+import { EVENT_TYPE_LABELS } from '@/composables/useEventColors';
+import type { UnifiedEvent } from '@/composables/useEventColors';
+
+const props = defineProps<{
+  token: string;
+}>();
+
+interface PageMeta {
+  current_page: number;
+  last_page: number;
+  total: number;
+  from: number | null;
+  to: number | null;
+}
+
+interface FilterFacets {
+  sources: string[];
+  event_types: string[];
+}
+
+const events = ref<UnifiedEvent[]>([]);
+const meta = ref<PageMeta>({ current_page: 1, last_page: 1, total: 0, from: null, to: null });
+const facets = ref<FilterFacets>({ sources: [], event_types: [] });
+const filters = ref({ search: '', source: '', event_type: '', range: 'all' });
+const page = ref(1);
+
+const alertsMuted = ref(false);
+const twitchId = ref('');
+
+const refreshing = ref(false);
+const muting = ref(false);
+const filtersOpen = ref(false);
+const showInfo = ref(false);
+const initialized = ref(false);
+const fatalError = ref<string | null>(null);
+const loadError = ref<string | null>(null);
+const muteError = ref<string | null>(null);
+
+async function load(showSpinner = true) {
+  if (showSpinner) refreshing.value = true;
+  try {
+    const params = new URLSearchParams({ token: props.token });
+    if (filters.value.search) params.set('search', filters.value.search);
+    if (filters.value.source) params.set('source', filters.value.source);
+    if (filters.value.event_type) params.set('event_type', filters.value.event_type);
+    if (filters.value.range !== 'all') params.set('range', filters.value.range);
+    if (page.value > 1) params.set('page', String(page.value));
+
+    const res = await fetch(`/api/events?${params}`, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    });
+
+    if (res.status === 401) {
+      fatalError.value = 'This feed link is invalid or expired. Copy a fresh events feed link from the Events page on Overlabels.';
+      return;
+    }
+    if (res.status === 403) {
+      fatalError.value = 'This token is not allowed to read the events feed.';
+      return;
+    }
+    if (!res.ok) throw new Error(String(res.status));
+
+    const json = await res.json();
+    events.value = json.events.data;
+    meta.value = {
+      current_page: json.events.current_page,
+      last_page: json.events.last_page,
+      total: json.events.total,
+      from: json.events.from,
+      to: json.events.to,
+    };
+    facets.value = json.facets;
+    alertsMuted.value = json.alerts_muted;
+    loadError.value = null;
+    initialized.value = true;
+
+    if (!twitchId.value && json.twitch_id) {
+      twitchId.value = String(json.twitch_id);
+      subscribe();
+    }
+  } catch {
+    loadError.value = 'Could not load events. Check your connection and try again.';
+  } finally {
+    setTimeout(() => {
+      refreshing.value = false;
+    }, 300);
+  }
+}
+
+async function toggleMute() {
+  if (muting.value) return;
+  muting.value = true;
+  muteError.value = null;
+  try {
+    const res = await fetch('/api/events/mute', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: JSON.stringify({ token: props.token, muted: !alertsMuted.value }),
+    });
+
+    if (res.status === 403) {
+      muteError.value = 'This token is not allowed to change alert settings.';
+      return;
+    }
+    if (!res.ok) throw new Error(String(res.status));
+
+    const json = await res.json();
+    alertsMuted.value = json.alerts_muted;
+  } catch {
+    muteError.value = 'Could not update alert settings. Try again.';
+  } finally {
+    muting.value = false;
+  }
+}
+
+function applyFilter() {
+  page.value = 1;
+  void load();
+}
+
+const debounceSearch = debounce(() => {
+  applyFilter();
+}, 300);
+
+function goToPage(target: number) {
+  if (target < 1 || target > meta.value.last_page || target === page.value) return;
+  page.value = target;
+  void load();
+}
+
+// Live updates: refetch page 1 (debounced) when new events land. Only the
+// first page auto-refreshes; deeper pages would shift rows underneath you.
+const refreshSoon = debounce(() => {
+  if (page.value === 1) void load(false);
+}, 1200);
+
+function subscribe() {
+  const echo = (window as any).Echo;
+  if (!echo || !twitchId.value) return;
+
+  echo.private(`twitch-events.${twitchId.value}`).listen('.twitch.event', () => refreshSoon());
+
+  echo
+    .private(`alerts.${twitchId.value}`)
+    .listen('.control.updated', (e: { key?: string; value?: string }) => {
+      // Mute state flips live no matter where it was toggled from.
+      if (e.key === 'alerts:muted') {
+        alertsMuted.value = e.value === '1';
+      }
+    })
+    .listen('.alert.triggered', () => refreshSoon());
+}
+
+onMounted(() => {
+  void load();
+});
+
+onBeforeUnmount(() => {
+  const echo = (window as any).Echo;
+  if (echo && twitchId.value) {
+    echo.leave(`twitch-events.${twitchId.value}`);
+    echo.leave(`alerts.${twitchId.value}`);
+  }
+});
+
+function sourceLabel(source: string): string {
+  const map: Record<string, string> = {
+    twitch: 'Twitch',
+    kofi: 'Ko-fi',
+    streamlabs: 'StreamLabs',
+    streamelements: 'StreamElements',
+    bmac: 'Buy Me a Coffee',
+    fourthwall: 'Fourthwall',
+  };
+  return map[source] ?? source;
+}
+
+function eventTypeLabel(type: string): string {
+  return EVENT_TYPE_LABELS[type] ?? type;
+}
+</script>
+
+<template>
+  <div v-if="fatalError" class="flex min-h-screen items-center justify-center px-6">
+    <p class="max-w-md text-center text-sm text-foreground">{{ fatalError }}</p>
+  </div>
+
+  <div v-else class="mx-auto max-w-3xl px-2 py-2">
+    <div class="mb-2 flex flex-wrap items-center gap-2">
+      <button class="btn btn-chill btn-xs gap-1.5 cursor-pointer" :disabled="refreshing" @click="page = 1; load()">
+        <RefreshCw class="h-3 w-3" :class="{ 'animate-spin': refreshing }" />
+        {{ refreshing ? 'Working' : 'Refresh' }}
+      </button>
+
+      <button
+        class="btn btn-chill btn-xs gap-1.5 cursor-pointer"
+        :aria-expanded="filtersOpen"
+        aria-controls="feed-filters"
+        @click="filtersOpen = !filtersOpen"
+      >
+        <SlidersHorizontal class="h-3 w-3" />
+        Filters
+        <ChevronUp v-if="filtersOpen" class="h-3 w-3" />
+        <ChevronDown v-else class="h-3 w-3" />
+      </button>
+
+      <button
+        class="btn btn-xs ml-auto gap-1.5 cursor-pointer"
+        :class="alertsMuted ? 'border-amber-400/60 text-amber-400 hover:bg-amber-400/10' : 'btn-chill'"
+        :disabled="muting || !initialized"
+        :aria-pressed="alertsMuted"
+        @click="toggleMute"
+      >
+        <VolumeX v-if="alertsMuted" class="h-3 w-3" />
+        <Volume2 v-else class="h-3 w-3" />
+        {{ alertsMuted ? 'Unmute alerts' : 'Mute all alerts' }}
+      </button>
+
+      <button
+        class="grid h-7 w-7 cursor-pointer place-items-center rounded-full border border-violet-400/40 text-violet-400 transition hover:bg-violet-400/10"
+        type="button"
+        aria-label="Show info"
+        @click="showInfo = true"
+      >
+        ?
+      </button>
+    </div>
+
+    <div
+      v-if="alertsMuted"
+      class="mb-2 flex items-center gap-2 border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-sm text-foreground"
+    >
+      <VolumeX class="h-4 w-4 shrink-0 text-amber-400" />
+      <span>All alerts are muted. Events keep recording; unmute to fire alerts again.</span>
+    </div>
+
+    <div v-if="muteError" class="mb-2 border border-red-400/40 bg-red-400/10 px-3 py-2 text-sm text-foreground">
+      {{ muteError }}
+    </div>
+
+    <!-- Collapsible Filters -->
+    <div v-show="filtersOpen" id="feed-filters" class="mb-2 border border-sidebar-border bg-sidebar-accent p-3">
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div class="flex flex-col gap-1">
+          <label for="feed-filter-search" class="text-xs">Search</label>
+          <input
+            v-model="filters.search"
+            @input="debounceSearch"
+            type="text"
+            placeholder="Search event payload..."
+            class="input-border h-9 w-full text-sm"
+            id="feed-filter-search"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <label for="feed-filter-source" class="text-xs">Source</label>
+          <select
+            v-model="filters.source"
+            @change="applyFilter"
+            class="input-border h-9 w-full cursor-pointer text-sm"
+            id="feed-filter-source"
+          >
+            <option value="">All sources</option>
+            <option v-for="src in facets.sources" :key="src" :value="src">
+              {{ sourceLabel(src) }}
+            </option>
+          </select>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <label for="feed-filter-event-type" class="text-xs">Event type</label>
+          <select
+            v-model="filters.event_type"
+            @change="applyFilter"
+            class="input-border h-9 w-full cursor-pointer text-sm"
+            id="feed-filter-event-type"
+          >
+            <option value="">All event types</option>
+            <option v-for="type in facets.event_types" :key="type" :value="type">
+              {{ eventTypeLabel(type) }}
+            </option>
+          </select>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <label for="feed-filter-range" class="text-xs">Time range</label>
+          <select
+            v-model="filters.range"
+            @change="applyFilter"
+            class="input-border h-9 w-full cursor-pointer text-sm"
+            id="feed-filter-range"
+          >
+            <option value="all">All time</option>
+            <option value="hour">Last hour</option>
+            <option value="24h">Last 24 hours</option>
+            <option value="7d">Last 7 days</option>
+            <option value="30d">Last 30 days</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="loadError" class="border border-red-400/40 bg-red-400/10 px-3 py-2 text-sm text-foreground">
+      {{ loadError }}
+    </div>
+
+    <div v-else-if="initialized" class="bg-card px-2 py-1 transition-opacity duration-300" :class="refreshing ? 'opacity-40' : 'opacity-100'">
+      <EventsTable v-if="events.length > 0" :events="events" readonly />
+
+      <EmptyState v-else message="No events match your filters. Try widening the time range or clearing search." />
+
+      <div v-if="meta.last_page > 1" class="mt-4 flex items-center justify-between gap-2 pb-2 text-sm">
+        <button
+          class="btn btn-chill btn-xs gap-1 cursor-pointer"
+          :disabled="meta.current_page <= 1 || refreshing"
+          @click="goToPage(meta.current_page - 1)"
+        >
+          <ChevronLeft class="h-3 w-3" />
+          Newer
+        </button>
+        <span class="tabular-nums text-foreground">Page {{ meta.current_page }} of {{ meta.last_page }}</span>
+        <button
+          class="btn btn-chill btn-xs gap-1 cursor-pointer"
+          :disabled="meta.current_page >= meta.last_page || refreshing"
+          @click="goToPage(meta.current_page + 1)"
+        >
+          Older
+          <ChevronRight class="h-3 w-3" />
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div
+    v-if="showInfo"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
+    @click.self="showInfo = false"
+  >
+    <div class="w-full max-w-md rounded-xl bg-background p-5 shadow-xl">
+      <div class="flex items-start justify-between gap-3">
+        <p class="text-sm font-medium leading-6">
+          Your recent events, live. Use the mute button to silence every alert in one tap - visuals, sounds, TTS and bot messages. Events keep recording while muted. Replaying events is available on the dashboard when you are logged in.
+        </p>
+
+        <button
+          class="cursor-pointer text-lg leading-none text-base-content/60 hover:text-base-content"
+          type="button"
+          @click="showInfo = false"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/events-feed/app.ts
+++ b/resources/js/events-feed/app.ts
@@ -1,0 +1,68 @@
+import '../../css/app.css';
+
+import { createApp } from 'vue';
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+import EventsFeed from './EventsFeed.vue';
+import { initializeTheme } from '@/composables/useAppearance';
+
+// Echo/Reverb for live feed updates (Reverb uses the Pusher protocol)
+(window as any).Pusher = Pusher;
+
+// The feed page is session-less like an overlay, so the default
+// `/broadcasting/auth` (which requires a logged-in session) can't sign its
+// subscriptions. POST the URL-fragment token to the overlay auth endpoint
+// instead; it only ever signs the token owner's own private channels.
+function feedAuthorizer(channel: { name: string }) {
+  return {
+    authorize: (socketId: string, callback: (err: Error | null, data: unknown) => void) => {
+      const feed = (window as any).__EVENTS_FEED__ || {};
+      if (!feed.token) {
+        callback(new Error('Feed token unavailable for channel auth'), null);
+        return;
+      }
+      fetch('/api/overlay/broadcasting/auth', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({
+          slug: 'events-feed',
+          token: feed.token,
+          socket_id: socketId,
+          channel_name: channel.name,
+        }),
+      })
+        .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+        .then((data) => callback(null, data))
+        .catch((err) => callback(err, null));
+    },
+  };
+}
+
+try {
+  (window as any).Echo = new Echo({
+    broadcaster: 'reverb',
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
+    wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+    authorizer: feedAuthorizer,
+  });
+} catch (err) {
+  console.error('Failed to initialize Echo:', err);
+  (window as any).Echo = null;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initializeTheme();
+
+  const mount = document.getElementById('events-feed-root');
+  const feed = (window as any).__EVENTS_FEED__;
+  if (!mount || !feed) return;
+
+  createApp(EventsFeed, { token: feed.token }).mount(mount);
+});

--- a/resources/js/pages/dashboard/events.vue
+++ b/resources/js/pages/dashboard/events.vue
@@ -5,7 +5,7 @@ import EventsTable from '@/components/EventsTable.vue';
 import Pagination from '@/components/Pagination.vue';
 import RekaToast from '@/components/RekaToast.vue';
 import EmptyState from '@/components/EmptyState.vue';
-import { ChevronDown, ChevronUp, RefreshCw, SlidersHorizontal } from '@lucide/vue';
+import { ChevronDown, ChevronUp, RefreshCw, SlidersHorizontal, Volume2, VolumeX } from '@lucide/vue';
 import debounce from 'lodash/debounce';
 import { EVENT_TYPE_LABELS } from '@/composables/useEventColors';
 import type { AppPageProps } from '@/types';
@@ -53,6 +53,7 @@ const props = defineProps<{
   events: PaginatedEvents;
   filters?: FiltersShape;
   facets: FilterFacets;
+  alertsMuted: boolean;
 }>();
 
 function normalizeFilters(input?: FiltersShape) {
@@ -112,6 +113,22 @@ watch(
 );
 
 const refreshing = ref(false);
+const muting = ref(false);
+
+function toggleMute() {
+  if (muting.value) return;
+  muting.value = true;
+  router.post(
+    route('dashboard.events.mute'),
+    { muted: !props.alertsMuted },
+    {
+      preserveScroll: true,
+      onFinish: () => {
+        muting.value = false;
+      },
+    },
+  );
+}
 
 function refresh() {
   if (refreshing.value) return;
@@ -169,13 +186,33 @@ function eventTypeLabel(type: string): string {
       </button>
 
       <button
-        class="ml-auto grid h-7 w-7 cursor-pointer place-items-center rounded-full border border-violet-400/40 text-violet-400 transition hover:bg-violet-400/10"
+        class="btn btn-xs ml-auto gap-1.5 cursor-pointer"
+        :class="alertsMuted ? 'border-amber-400/60 text-amber-400 hover:bg-amber-400/10' : 'btn-chill'"
+        :disabled="muting"
+        :aria-pressed="alertsMuted"
+        @click="toggleMute"
+      >
+        <VolumeX v-if="alertsMuted" class="h-3 w-3" />
+        <Volume2 v-else class="h-3 w-3" />
+        {{ alertsMuted ? 'Unmute alerts' : 'Mute all alerts' }}
+      </button>
+
+      <button
+        class="grid h-7 w-7 cursor-pointer place-items-center rounded-full border border-violet-400/40 text-violet-400 transition hover:bg-violet-400/10"
         type="button"
         aria-label="Show info"
         @click="showInfo = true"
       >
         ?
       </button>
+    </div>
+
+    <div
+      v-if="alertsMuted"
+      class="mb-2 flex items-center gap-2 border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-sm text-foreground"
+    >
+      <VolumeX class="h-4 w-4 shrink-0 text-amber-400" />
+      <span>All alerts are muted. Events keep recording; unmute to fire alerts again.</span>
     </div>
 
     <!-- Collapsible Filters -->
@@ -270,7 +307,11 @@ function eventTypeLabel(type: string): string {
     <div class="w-full max-w-md rounded-xl bg-base-100 p-5 shadow-xl bg-background">
       <div class="flex items-start justify-between gap-3">
         <p class="text-sm font-medium leading-6">
-          Your recent events. click an event and tap Yes to replay the event in your overlay(s)
+          Your recent events. Click an event and tap Yes to replay the event in your overlay(s).
+          The mute button silences every alert in one click - visuals, sounds, TTS and bot messages -
+          until you unmute. On a phone without being logged in? Open
+          <code class="rounded bg-black/10 px-1 dark:bg-white/10">/events/feed#your-overlay-token</code>
+          to see this feed and the mute button using an overlay token instead.
         </p>
 
         <button class="text-lg leading-none text-base-content/60 hover:text-base-content cursor-pointer" type="button"

--- a/resources/js/pages/dashboard/recents.vue
+++ b/resources/js/pages/dashboard/recents.vue
@@ -6,7 +6,8 @@ import EventsTable from '@/components/EventsTable.vue';
 import Pagination from '@/components/Pagination.vue';
 import RekaToast from '@/components/RekaToast.vue';
 import EmptyState from '@/components/EmptyState.vue';
-import { Check, ExternalLink, ListPlus, Radio, RefreshCw } from '@lucide/vue';
+import EventsFeedLinkButton from '@/components/EventsFeedLinkButton.vue';
+import { Check, ListPlus, Radio, RefreshCw } from '@lucide/vue';
 import Heading from '@/components/Heading.vue';
 import debounce from 'lodash/debounce';
 import { EVENT_TYPE_LABELS } from '@/composables/useEventColors';
@@ -294,10 +295,9 @@ const breadcrumbs = [
               {{ refreshing ? 'Working' : 'Refresh' }}
             </button>
           </div>
-          <a href="/dashboard/events" target="_blank" class="btn btn-primary self-start sm:self-auto cursor-pointer">
-            Embed view
-            <ExternalLink class="ml-2 h-4 w-4" />
-          </a>
+          <div class="self-start sm:self-auto">
+            <EventsFeedLinkButton />
+          </div>
         </div>
 
         <!-- Filters Section -->

--- a/resources/js/pages/help/Controls.vue
+++ b/resources/js/pages/help/Controls.vue
@@ -14,10 +14,12 @@ import {
   Sparkles,
   Trash,
   Tv,
+  VolumeX,
   type LucideIcon,
 } from '@lucide/vue';
 import Heading from '@/components/Heading.vue';
 import {
+  ALERTS_PRESETS,
   KOFI_PRESETS,
   GPS_PRESETS,
   STREAMLABS_PRESETS,
@@ -58,6 +60,7 @@ const presetSections: PresetSummary[] = [
   { label: 'Buy Me a Coffee', icon: HandHeart, count: BMAC_PRESETS.length, blurb: 'Supporter and membership data, including the latest support type.' },
   { label: 'Throne', icon: Gift, count: THRONE_PRESETS.length, blurb: 'Gift data plus Throne-only extras: item name, product thumbnail URL, and a surprise-gift flag.' },
   { label: 'Overlabels GPS', icon: MapPinned, count: GPS_PRESETS.length, blurb: 'Live location data from the Overlabels GPS app: speed, coordinates, distance, battery, and per-session aggregates.' },
+  { label: 'Overlabels Alerts', icon: VolumeX, count: ALERTS_PRESETS.length, blurb: 'The global alert mute state, no integration required. Show a banner while muted: [[[if:c:alerts:muted]]]ALERTS ARE MUTED[[[endif]]] - it flips live when you hit the mute button on the Events page.' },
 ];
 
 const totalPresets = presetSections.reduce((sum, s) => sum + s.count, 0);

--- a/resources/views/events/feed.blade.php
+++ b/resources/views/events/feed.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <link rel="icon" href="/favicon.svg" sizes="any">
+    <title>Stream Events - Overlabels</title>
+    @vite('resources/js/events-feed/app.ts')
+</head>
+<body class="bg-background text-foreground">
+<div id="events-feed-root"></div>
+<div id="events-feed-error" style="display:none; min-height:100vh; align-items:center; justify-content:center; padding:24px; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size:15px; line-height:1.5; text-align:center; color:#a1a1aa; background:#09090b;"></div>
+<script>
+    (function () {
+        // The token lives in the URL fragment, which never reaches the
+        // server. The Vue app sends it to /api/events itself.
+        const token = window.location.hash.substring(1);
+        if (!token || token.length !== 64) {
+            const el = document.getElementById('events-feed-error');
+            el.style.display = 'flex';
+            el.textContent = 'This link is incomplete. Copy the full events feed link, including everything after the # sign, from the Events page on Overlabels.';
+        } else {
+            window.__EVENTS_FEED__ = { token: token };
+        }
+    })();
+</script>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\DeployWebhookController;
+use App\Http\Controllers\Api\EventFeedController;
 use App\Http\Controllers\Api\ExternalWebhookController;
 use App\Http\Controllers\Api\GpsSessionMapController;
 use App\Http\Controllers\Api\Internal\BotAccountageController;
@@ -51,6 +52,21 @@ Route::get('/user', function (Request $request) {
 Route::get('/lists/{slug}', [ListReadController::class, 'show'])
     ->name('api.lists.show')
     ->where('slug', '[a-z][a-z0-9_]{0,49}')
+    ->middleware(['throttle:overlay', 'lockdown'])
+    ->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
+
+// Token-authed events feed for /events/feed (phone-friendly, no Twitch login
+// needed). Same OverlayAccessToken as overlays; token travels as a ?token=
+// query param (GET) or JSON body field (POST), never in the URL path. Reading
+// requires the `read` ability, the mute toggle requires `write` - the first
+// endpoints to enforce token abilities. Stateless like the overlay render
+// route. See App\Http\Controllers\Api\EventFeedController.
+Route::get('/events', [EventFeedController::class, 'index'])
+    ->name('api.events.index')
+    ->middleware(['throttle:overlay', 'lockdown'])
+    ->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
+Route::post('/events/mute', [EventFeedController::class, 'mute'])
+    ->name('api.events.mute')
     ->middleware(['throttle:overlay', 'lockdown'])
     ->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Console\Commands\GamejamDebug;
 use App\Events\GameStateChanged;
 use App\Events\UserRegistered;
+use App\Http\Controllers\AlertMuteController;
 use App\Http\Controllers\CloudinaryUploadController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\EventTemplateMappingController;
@@ -224,6 +225,18 @@ Route::get('/dashboard/stream-sessions', [StreamSessionController::class, 'index
 Route::get('/dashboard/events', [DashboardController::class, 'recentEvents'])
     ->middleware(['auth.redirect'])
     ->name('dashboard.events');
+
+Route::post('/dashboard/events/mute', [AlertMuteController::class, 'update'])
+    ->middleware(['auth.redirect'])
+    ->name('dashboard.events.mute');
+
+// Token-authed events feed shell (phone-friendly /dashboard/events sibling).
+// Served without auth on purpose: the overlay token lives in the URL fragment
+// and is read client-side, so the server never sees it here. The shell shows
+// nothing until the Vue app authenticates against /api/events with the token.
+Route::get('/events/feed', function () {
+    return view('events.feed');
+})->name('events.feed');
 
 Route::get('/login', [PageController::class, 'notAuthorized'])
     ->middleware(['guest'])

--- a/tests/Feature/AlertMuteTest.php
+++ b/tests/Feature/AlertMuteTest.php
@@ -1,0 +1,266 @@
+<?php
+
+use App\Events\AlertTriggered;
+use App\Events\ControlValueUpdated;
+use App\Models\BotChatOutbox;
+use App\Models\ExternalEvent;
+use App\Models\ExternalEventTemplateMapping;
+use App\Models\ExternalIntegration;
+use App\Models\OverlayControl;
+use App\Models\OverlayTemplate;
+use App\Models\TwitchEvent;
+use App\Models\User;
+use App\Services\AlertMuteService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Event;
+
+uses(DatabaseTransactions::class);
+
+function muteTestUser(): User
+{
+    return User::factory()->create(['twitch_id' => (string) fake()->unique()->randomNumber(9)]);
+}
+
+function muteTestAlertTemplate(User $user): OverlayTemplate
+{
+    return OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => 'alert',
+        'slug' => 'alert-'.fake()->unique()->lexify('????????'),
+    ]);
+}
+
+function muteTestKofiPipeline(User $user, OverlayTemplate $alertTemplate): ExternalIntegration
+{
+    $integration = ExternalIntegration::factory()->create([
+        'user_id' => $user->id,
+        'service' => 'kofi',
+        'enabled' => true,
+        'credentials' => Crypt::encryptString(json_encode(['verification_token' => 'mute-tok'])),
+    ]);
+
+    ExternalEventTemplateMapping::create([
+        'user_id' => $user->id,
+        'service' => 'kofi',
+        'event_type' => 'donation',
+        'overlay_template_id' => $alertTemplate->id,
+        'enabled' => true,
+        'duration_ms' => 5000,
+    ]);
+
+    return $integration;
+}
+
+function muteTestKofiPayload(): array
+{
+    return [
+        'verification_token' => 'mute-tok',
+        'kofi_transaction_id' => 'txn-'.fake()->uuid(),
+        'from_name' => 'Bob',
+        'message' => 'Hi!',
+        'amount' => '5.00',
+        'currency' => 'USD',
+        'type' => 'Donation',
+        'is_subscription_payment' => false,
+        'is_first_subscription_payment' => false,
+    ];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AlertMuteService
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('setMuted provisions a user-scoped source-managed alerts:muted control and broadcasts', function () {
+    Event::fake([ControlValueUpdated::class]);
+    $user = muteTestUser();
+    $service = app(AlertMuteService::class);
+
+    expect($service->isMuted($user))->toBeFalse();
+
+    $service->setMuted($user, true);
+
+    expect($service->isMuted($user))->toBeTrue();
+    $this->assertDatabaseHas('overlay_controls', [
+        'user_id' => $user->id,
+        'source' => 'alerts',
+        'key' => 'muted',
+        'type' => 'boolean',
+        'value' => '1',
+        'overlay_template_id' => null,
+        'source_managed' => true,
+    ]);
+
+    Event::assertDispatched(ControlValueUpdated::class, function (ControlValueUpdated $event) use ($user) {
+        return $event->key === 'alerts:muted'
+            && $event->overlaySlug === ''
+            && $event->value === '1'
+            && $event->broadcasterId === $user->twitch_id;
+    });
+});
+
+test('setMuted is idempotent and only broadcasts on an actual change', function () {
+    $user = muteTestUser();
+    $service = app(AlertMuteService::class);
+    $service->setMuted($user, true);
+
+    Event::fake([ControlValueUpdated::class]);
+    $service->setMuted($user, true);
+    Event::assertNotDispatched(ControlValueUpdated::class);
+
+    $service->setMuted($user, false);
+    Event::assertDispatched(ControlValueUpdated::class, fn (ControlValueUpdated $e) => $e->value === '0');
+    expect($service->isMuted($user))->toBeFalse();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session toggle endpoint
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('session mute endpoint toggles the mute state', function () {
+    $user = muteTestUser();
+    $this->actingAs($user);
+
+    $this->post('/dashboard/events/mute', ['muted' => true])->assertRedirect();
+    expect(app(AlertMuteService::class)->isMuted($user))->toBeTrue();
+
+    $this->post('/dashboard/events/mute', ['muted' => false])->assertRedirect();
+    expect(app(AlertMuteService::class)->isMuted($user))->toBeFalse();
+});
+
+test('session mute endpoint requires auth', function () {
+    $this->post('/dashboard/events/mute', ['muted' => true])->assertRedirect();
+    expect(OverlayControl::where('source', 'alerts')->where('key', 'muted')->exists())->toBeFalse();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dispatch-site guards: muted is muted
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('a live external event fires no alert and no bot message while muted, but is still recorded', function () {
+    $user = muteTestUser();
+    $alertTemplate = muteTestAlertTemplate($user);
+    $alertTemplate->update(['bot_message_expression' => 'Thanks [[[event.from_name]]]!']);
+    $user->update(['bot_enabled' => true]);
+    $integration = muteTestKofiPipeline($user, $alertTemplate);
+
+    app(AlertMuteService::class)->setMuted($user, true);
+
+    Event::fake([AlertTriggered::class]);
+    $payload = muteTestKofiPayload();
+
+    $this->post("/api/webhooks/kofi/{$integration->webhook_token}", ['data' => json_encode($payload)]);
+
+    Event::assertNotDispatched(AlertTriggered::class);
+    expect(BotChatOutbox::where('user_id', $user->id)->count())->toBe(0);
+
+    // The event itself still lands - only alert output is suppressed.
+    expect(ExternalEvent::where('user_id', $user->id)->where('service', 'kofi')->count())->toBe(1);
+});
+
+test('a live external event fires the alert again after unmuting', function () {
+    $user = muteTestUser();
+    $alertTemplate = muteTestAlertTemplate($user);
+    $integration = muteTestKofiPipeline($user, $alertTemplate);
+
+    app(AlertMuteService::class)->setMuted($user, true);
+    app(AlertMuteService::class)->setMuted($user, false);
+
+    Event::fake([AlertTriggered::class]);
+
+    $this->post("/api/webhooks/kofi/{$integration->webhook_token}", ['data' => json_encode(muteTestKofiPayload())]);
+
+    Event::assertDispatched(AlertTriggered::class);
+});
+
+test('external event replay is blocked with a warning while muted', function () {
+    $user = muteTestUser();
+    $externalEvent = ExternalEvent::create([
+        'user_id' => $user->id,
+        'service' => 'kofi',
+        'event_type' => 'donation',
+        'message_id' => 'msg-'.fake()->uuid(),
+        'raw_payload' => ['from_name' => 'Dave'],
+        'normalized_payload' => ['event.from_name' => 'Dave'],
+    ]);
+
+    app(AlertMuteService::class)->setMuted($user, true);
+    $this->actingAs($user);
+
+    Event::fake([AlertTriggered::class]);
+
+    $this->post("/external-events/{$externalEvent->id}/replay")
+        ->assertRedirect()
+        ->assertSessionHas('type', 'warning');
+
+    Event::assertNotDispatched(AlertTriggered::class);
+});
+
+test('twitch event replay is blocked with a warning while muted', function () {
+    $user = muteTestUser();
+    $twitchEvent = TwitchEvent::create([
+        'user_id' => $user->id,
+        'event_type' => 'channel.cheer',
+        'event_data' => ['user_name' => 'Cheerer', 'bits' => 100],
+        'twitch_timestamp' => now(),
+        'processed' => true,
+    ]);
+
+    app(AlertMuteService::class)->setMuted($user, true);
+    $this->actingAs($user);
+
+    Event::fake([AlertTriggered::class]);
+
+    $this->post("/events/{$twitchEvent->id}/replay")
+        ->assertRedirect()
+        ->assertSessionHas('type', 'warning');
+
+    Event::assertNotDispatched(AlertTriggered::class);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reserved key + preset provisioning
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('alerts is a reserved bare control key', function () {
+    $user = muteTestUser();
+    $template = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => 'static',
+        'slug' => 'static-'.fake()->unique()->lexify('????????'),
+    ]);
+    $this->actingAs($user);
+
+    $this->postJson("/templates/{$template->id}/controls", [
+        'key' => 'alerts',
+        'type' => 'text',
+    ])->assertStatus(422);
+});
+
+test('the alerts:muted preset can be added from the control picker', function () {
+    $user = muteTestUser();
+    $template = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => 'static',
+        'slug' => 'static-'.fake()->unique()->lexify('????????'),
+    ]);
+    $this->actingAs($user);
+
+    $this->postJson("/templates/{$template->id}/controls", [
+        'key' => 'muted',
+        'type' => 'boolean',
+        'source' => 'alerts',
+    ])->assertStatus(201);
+
+    $this->assertDatabaseHas('overlay_controls', [
+        'user_id' => $user->id,
+        'source' => 'alerts',
+        'key' => 'muted',
+        'overlay_template_id' => null,
+        'source_managed' => true,
+        'value' => '0',
+    ]);
+});

--- a/tests/Feature/EventFeedApiTest.php
+++ b/tests/Feature/EventFeedApiTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Models\ExternalEvent;
+use App\Models\OverlayAccessToken;
+use App\Models\TwitchEvent;
+use App\Models\User;
+use App\Services\AlertMuteService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+uses(DatabaseTransactions::class);
+
+function eventFeedUser(): User
+{
+    return User::factory()->create(['twitch_id' => (string) fake()->unique()->randomNumber(9)]);
+}
+
+function eventFeedToken(User $user, ?string $abilities = null): string
+{
+    $plain = bin2hex(random_bytes(32));
+    OverlayAccessToken::create([
+        'user_id' => $user->id,
+        'token_hash' => hash('sha256', $plain),
+        'token_prefix' => substr($plain, 0, 8),
+        'name' => 'event-feed-test',
+        'is_active' => true,
+        'abilities' => $abilities,
+    ]);
+
+    return $plain;
+}
+
+function eventFeedSeedEvents(User $user): void
+{
+    TwitchEvent::create([
+        'user_id' => $user->id,
+        'event_type' => 'channel.follow',
+        'event_data' => ['user_name' => 'NewFollower'],
+        'twitch_timestamp' => now(),
+        'processed' => true,
+    ]);
+
+    ExternalEvent::create([
+        'user_id' => $user->id,
+        'service' => 'kofi',
+        'event_type' => 'donation',
+        'message_id' => 'msg-'.fake()->uuid(),
+        'raw_payload' => ['from_name' => 'Donor'],
+        'normalized_payload' => ['event.from_name' => 'Donor', 'event.amount' => '5.00'],
+    ]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/events
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('returns the owner events for a valid token', function () {
+    $user = eventFeedUser();
+    $token = eventFeedToken($user);
+    eventFeedSeedEvents($user);
+
+    $resp = $this->getJson("/api/events?token={$token}")->assertOk();
+
+    expect($resp->json('events.total'))->toBe(2)
+        ->and($resp->json('alerts_muted'))->toBeFalse()
+        ->and($resp->json('twitch_id'))->toBe($user->twitch_id)
+        ->and($resp->json('facets.sources'))->toContain('twitch', 'kofi');
+});
+
+test('never returns another user\'s events', function () {
+    $owner = eventFeedUser();
+    $other = eventFeedUser();
+    eventFeedSeedEvents($other);
+    $token = eventFeedToken($owner);
+
+    $resp = $this->getJson("/api/events?token={$token}")->assertOk();
+
+    expect($resp->json('events.total'))->toBe(0);
+});
+
+test('applies source and range filters', function () {
+    $user = eventFeedUser();
+    $token = eventFeedToken($user);
+    eventFeedSeedEvents($user);
+
+    $resp = $this->getJson("/api/events?token={$token}&source=kofi")->assertOk();
+    expect($resp->json('events.total'))->toBe(1)
+        ->and($resp->json('events.data.0.source'))->toBe('kofi');
+});
+
+test('refuses a missing, malformed, or unknown token with 401', function () {
+    $user = eventFeedUser();
+    eventFeedToken($user);
+
+    $this->getJson('/api/events')->assertStatus(401);
+    $this->getJson('/api/events?token=tooshort')->assertStatus(401);
+    $this->getJson('/api/events?token='.str_repeat('b', 64))->assertStatus(401);
+});
+
+test('requires the read ability when the token has abilities set', function () {
+    $user = eventFeedUser();
+    $writeOnly = eventFeedToken($user, 'write');
+    $readable = eventFeedToken($user, 'read');
+    $unrestricted = eventFeedToken($user);
+
+    $this->getJson("/api/events?token={$writeOnly}")->assertStatus(403);
+    $this->getJson("/api/events?token={$readable}")->assertOk();
+    $this->getJson("/api/events?token={$unrestricted}")->assertOk();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/events/mute
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('mutes and unmutes with a write-able token', function () {
+    $user = eventFeedUser();
+    $token = eventFeedToken($user, 'read,write');
+
+    $this->postJson('/api/events/mute', ['token' => $token, 'muted' => true])
+        ->assertOk()
+        ->assertJsonPath('alerts_muted', true);
+
+    expect(app(AlertMuteService::class)->isMuted($user))->toBeTrue();
+
+    $this->postJson('/api/events/mute', ['token' => $token, 'muted' => false])
+        ->assertOk()
+        ->assertJsonPath('alerts_muted', false);
+
+    expect(app(AlertMuteService::class)->isMuted($user))->toBeFalse();
+});
+
+test('a token without the write ability cannot mute', function () {
+    $user = eventFeedUser();
+    $readOnly = eventFeedToken($user, 'read');
+
+    $this->postJson('/api/events/mute', ['token' => $readOnly, 'muted' => true])
+        ->assertStatus(403);
+
+    expect(app(AlertMuteService::class)->isMuted($user))->toBeFalse();
+});
+
+test('a token with no abilities set can mute (unrestricted, backward compatible)', function () {
+    $user = eventFeedUser();
+    $token = eventFeedToken($user);
+
+    $this->postJson('/api/events/mute', ['token' => $token, 'muted' => true])
+        ->assertOk()
+        ->assertJsonPath('alerts_muted', true);
+});
+
+test('mute requires a valid token and a boolean muted flag', function () {
+    $user = eventFeedUser();
+    $token = eventFeedToken($user);
+
+    $this->postJson('/api/events/mute', ['muted' => true])->assertStatus(401);
+    $this->postJson('/api/events/mute', ['token' => str_repeat('c', 64), 'muted' => true])->assertStatus(401);
+    $this->postJson('/api/events/mute', ['token' => $token])->assertStatus(422);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Feed shell
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('the events feed shell is served without authentication', function () {
+    $this->get('/events/feed')->assertOk();
+});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -21,6 +21,7 @@ export default defineConfig(() => ({
                 'resources/js/app.ts',
                 'resources/js/overlay/app.js',
                 'resources/js/map/app.ts',
+                'resources/js/events-feed/app.ts',
                 'resources/js/help-reference/main.ts',
             ],
             refresh: true,


### PR DESCRIPTION
## Summary

Two user-requested pieces that make the events page usable mid-stream from a phone:

**Token-authed events feed (`/events/feed#<token>`)**
- Standalone page (own Vite entry) authenticated by the same `OverlayAccessToken` overlays use - token in the URL fragment, read client-side, never sent to the server in a URL. No Twitch login needed on mobile.
- New stateless endpoints `GET /api/events` + `POST /api/events/mute` (`throttle:overlay` + `lockdown`, Sanctum-stateful shed), sharing the exact dashboard query via the extracted `UnifiedEventFeedService`.
- **Token abilities enforced for the first time**: feed requires `read`, mute requires `write`; tokens with no abilities stay unrestricted so every existing token keeps working. Mute is deliberately the only write a token can perform, and each mute write lands in the token's access log.
- Live updates via the existing overlay broadcasting-auth endpoint; `EventsTable` gained a `readonly` prop (replay stays a logged-in action).

**Global alert mute (muted is muted)**
- State lives in ONE place: the service-managed boolean control `alerts:muted`, provisioned lazily on first toggle. Templates read it live: `[[[if:c:alerts:muted]]]ALERTS ARE MUTED[[[endif]]]`, plus `[[[c:alerts:muted_at]]]` for free.
- `AlertMuteService` guards all three alert build-sites before any output: no visual broadcast, no sound, no ElevenLabs synthesis, no bot chat message. Events keep recording; controls keep updating.
- No replay bypass - replaying while muted returns a warning; test cheer reports `alerts_muted`.
- Mute button + amber banner on `/dashboard/events` and the token feed; `alerts:muted` in the Add-Control preset picker ("Overlabels - Alerts" group) and on the Controls help page.
- Drive-by: `alerts`, `fourthwall`, `bmac`, `throne` added to `RESERVED_KEYS` (the last three were missing).

## Test plan

- 1004 tests green (20 new in `AlertMuteTest` + `EventFeedApiTest`): mute service provisioning/idempotency, all three dispatch-site guards, replay-while-muted warnings, ability enforcement (read/write/unrestricted), owner scoping, filters, feed shell.
- Manually verified end to end: read+write token, mute/unmute from the feed, Twitch CLI follow event recorded but fired no alert while muted, preset control added and flipping live in an overlay, feed opened in a private tab via the fragment hash.
- Pint + ESLint + vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)