### PR TITLE
feat(events): replay alerts from the token-authed events feed

### DIFF
--- a/app/Http/Controllers/Api/EventFeedController.php
+++ b/app/Http/Controllers/Api/EventFeedController.php
@@ -3,7 +3,11 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\ExternalEventController;
+use App\Http\Controllers\TwitchEventSubController;
+use App\Models\ExternalEvent;
 use App\Models\OverlayAccessToken;
+use App\Models\TwitchEvent;
 use App\Services\AlertMuteService;
 use App\Services\UnifiedEventFeedService;
 use Illuminate\Http\JsonResponse;
@@ -16,10 +20,10 @@ use Illuminate\Http\Request;
  * mute their alerts. Serves /events/feed, which reads the token from the URL
  * fragment client-side (the fragment never reaches the server).
  *
- * First consumers of token abilities: reading the feed requires `read`, the
- * mute toggle requires `write` (tokens with no abilities set are unrestricted,
- * matching hasAbility(), so existing overlay tokens keep working). The mute
- * toggle is deliberately the only write an overlay token can perform.
+ * First consumers of token abilities: reading the feed requires `read`; the
+ * writes - the mute toggle and event replay - require `write` (tokens with no
+ * abilities set are unrestricted, matching hasAbility(), so existing overlay
+ * tokens keep working). Every write lands in the token's access log.
  */
 class EventFeedController extends Controller
 {
@@ -74,6 +78,66 @@ class EventFeedController extends Controller
         $accessToken->recordAccess($request->ip(), $request->userAgent(), 'events-feed:mute');
 
         return response()->json(['alerts_muted' => $muted]);
+    }
+
+    /**
+     * Replay a Twitch event as an alert. Same core as the dashboard replay
+     * (mute guard, mapping resolution, broadcast + TTS + bot message).
+     */
+    public function replayTwitch(Request $request, TwitchEvent $twitchEvent): JsonResponse
+    {
+        $accessToken = $this->resolveToken($request, 'write');
+        if ($accessToken instanceof JsonResponse) {
+            return $accessToken;
+        }
+
+        // 404 (not 403) for foreign events: a token must not be able to probe
+        // which event ids exist for other users.
+        if ($twitchEvent->user_id !== $accessToken->user_id) {
+            return response()->json(['error' => 'Event not found.'], 404);
+        }
+
+        $result = app(TwitchEventSubController::class)->replayForUser($accessToken->user, $twitchEvent);
+
+        return $this->replayResponse($request, $accessToken, $result);
+    }
+
+    /**
+     * Replay an external (Ko-fi, StreamLabs, ...) event as an alert.
+     */
+    public function replayExternal(Request $request, ExternalEvent $externalEvent): JsonResponse
+    {
+        $accessToken = $this->resolveToken($request, 'write');
+        if ($accessToken instanceof JsonResponse) {
+            return $accessToken;
+        }
+
+        if ($externalEvent->user_id !== $accessToken->user_id) {
+            return response()->json(['error' => 'Event not found.'], 404);
+        }
+
+        $result = app(ExternalEventController::class)->replayForUser($accessToken->user, $externalEvent);
+
+        return $this->replayResponse($request, $accessToken, $result);
+    }
+
+    /**
+     * Map a replay core result to JSON: success and warning (muted) are 200s
+     * the feed shows as-is, error (no active mapping) is a 422.
+     *
+     * @param  array{message: string, type: string}  $result
+     */
+    private function replayResponse(Request $request, OverlayAccessToken $accessToken, array $result): JsonResponse
+    {
+        if ($result['type'] === 'success') {
+            // Writes leave a trail in the token's access log.
+            $accessToken->recordAccess($request->ip(), $request->userAgent(), 'events-feed:replay');
+        }
+
+        return response()->json(
+            ['message' => $result['message'], 'type' => $result['type']],
+            $result['type'] === 'error' ? 422 : 200,
+        );
     }
 
     private function resolveToken(Request $request, string $ability): OverlayAccessToken|JsonResponse

--- a/app/Http/Controllers/ExternalEventController.php
+++ b/app/Http/Controllers/ExternalEventController.php
@@ -7,6 +7,7 @@ use App\Jobs\SynthesizeAlertTts;
 use App\Models\BotChatOutbox;
 use App\Models\ExternalEvent;
 use App\Models\ExternalEventTemplateMapping;
+use App\Models\User;
 use App\Services\AlertMuteService;
 use App\Services\Expressions\AlertExpressionRenderer;
 use Illuminate\Http\RedirectResponse;
@@ -21,14 +22,25 @@ class ExternalEventController extends Controller
      */
     public function replay(Request $request, ExternalEvent $externalEvent): RedirectResponse
     {
-        $user = $request->user();
+        $result = $this->replayForUser($request->user(), $externalEvent);
 
+        return back()->with('message', $result['message'])->with('type', $result['type']);
+    }
+
+    /**
+     * Replay core, independent of how the request was authenticated (dashboard
+     * session or overlay token via the events feed).
+     *
+     * @return array{message: string, type: string}
+     */
+    public function replayForUser(User $user, ExternalEvent $externalEvent): array
+    {
         if ($externalEvent->user_id !== $user->id) {
-            return back()->with('message', 'You do not own this event.')->with('type', 'error');
+            return ['message' => 'You do not own this event.', 'type' => 'error'];
         }
 
         if (app(AlertMuteService::class)->isMuted($user)) {
-            return back()->with('message', 'Alerts are muted. Unmute alerts to replay events.')->with('type', 'warning');
+            return ['message' => 'Alerts are muted. Unmute alerts to replay events.', 'type' => 'warning'];
         }
 
         $data = $externalEvent->normalized_payload ?? [];
@@ -41,7 +53,7 @@ class ExternalEventController extends Controller
         );
 
         if (! $mapping || ! $mapping->template) {
-            return back()->with('message', 'No active alert mapping found for this event type.')->with('type', 'error');
+            return ['message' => 'No active alert mapping found for this event type.', 'type' => 'error'];
         }
 
         $template = $mapping->template;
@@ -95,6 +107,6 @@ class ExternalEventController extends Controller
 
         $label = ucfirst($externalEvent->event_type).' ('.ucfirst($externalEvent->service).')';
 
-        return back()->with('message', "Replayed {$label} alert.")->with('type', 'success');
+        return ['message' => "Replayed {$label} alert.", 'type' => 'success'];
     }
 }

--- a/app/Http/Controllers/TwitchEventSubController.php
+++ b/app/Http/Controllers/TwitchEventSubController.php
@@ -684,14 +684,27 @@ class TwitchEventSubController extends Controller
      */
     public function replay(Request $request, TwitchEvent $twitchEvent)
     {
-        $user = $request->user();
+        $result = $this->replayForUser($request->user(), $twitchEvent);
 
+        return back()->with('message', $result['message'])->with('type', $result['type']);
+    }
+
+    /**
+     * Replay core, independent of how the request was authenticated (dashboard
+     * session or overlay token via the events feed).
+     *
+     * @return array{message: string, type: string}
+     *
+     * @throws RandomException
+     */
+    public function replayForUser(User $user, TwitchEvent $twitchEvent): array
+    {
         if ($twitchEvent->user_id !== $user->id) {
-            return back()->with('message', 'You do not own this event.')->with('type', 'error');
+            return ['message' => 'You do not own this event.', 'type' => 'error'];
         }
 
         if (app(AlertMuteService::class)->isMuted($user)) {
-            return back()->with('message', 'Alerts are muted. Unmute alerts to replay events.')->with('type', 'warning');
+            return ['message' => 'Alerts are muted. Unmute alerts to replay events.', 'type' => 'warning'];
         }
 
         $mapping = EventTemplateMapping::resolveForEvent(
@@ -701,7 +714,7 @@ class TwitchEventSubController extends Controller
         );
 
         if (! $mapping || ! $mapping->template) {
-            return back()->with('message', 'No active template mapping found for this event type.')->with('type', 'error');
+            return ['message' => 'No active template mapping found for this event type.', 'type' => 'error'];
         }
 
         $reconstructedData = [
@@ -711,9 +724,8 @@ class TwitchEventSubController extends Controller
 
         $this->renderEventAlert($user, $mapping, $reconstructedData);
         $randomString = str_pad(random_int(1, 999999), 4, '0', STR_PAD_LEFT);
-        $message = "Replayed alert $twitchEvent->event_type (ID: $twitchEvent->id-$randomString)";
 
-        return back()->with('message', $message)->with('type', 'success');
+        return ['message' => "Replayed alert $twitchEvent->event_type (ID: $twitchEvent->id-$randomString)", 'type' => 'success'];
     }
 
     /**

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,24 @@
 # CHANGELOG JULY 2026
 
+## July 3rd, 2026 - feat(events): replay alerts from the token-authed events feed
+
+The feed shipped view-only (mute was the single token write), but replaying an alert from your phone mid-stream is exactly what the feed is for. Replay is now the second write an overlay token can perform.
+
+**Backend**
+
+- New token-authed endpoints: `POST /api/events/{id}/replay` (Twitch) and `POST /api/external-events/{id}/replay` (Ko-fi/StreamLabs/...). Same posture as the mute toggle: `throttle:overlay` + `lockdown`, Sanctum-stateful shed, token in the JSON body, `write` ability required, successful replays land in the token's access log (`events-feed:replay`).
+- Foreign event ids return 404 (not 403) so a token cannot probe which ids exist for other users.
+- The replay cores were extracted out of the session-bound actions into `replayForUser(User, event)` on `TwitchEventSubController` / `ExternalEventController` - dashboard replay and feed replay run the exact same logic (ownership, mute guard, mapping resolution, broadcast + TTS + bot message). Dashboard behavior unchanged, including flash messages.
+- Muted replay still returns the "Alerts are muted" warning - the feed gets the same no-bypass rule as the dashboard.
+
+**Frontend**
+
+- `EventsTable` lost the `readonly` prop and gained an optional `token` prop: without it replay posts via Inertia as before; with it replay posts to the token API via fetch and emits a `replay-result` event (the feed has no Inertia flash messages).
+- `EventsFeed` shows the replay outcome in an inline notice (violet success / amber warning / red error, auto-clears) and passes the token through.
+- Feed info dialog and the feed-link warning copy updated: the link can now also replay alerts on stream, and the warning says so explicitly.
+
+Tests: 6 new Pest tests covering write-ability replay for both event kinds, read-only 403, foreign-event 404, muted warning, and missing-mapping 422. Full suite 1010 green.
+
 ## July 3rd, 2026 - fix(events): readonly guard on the replay confirm popover
 
 Clicking a row on the token-authed events feed crashed with `page$1.get() is undefined`. The `readonly` guard covered the row's own `@click` and `openConfirm()`, but Reka's `PopoverTrigger` toggles open state on its own click, so `@update:open` set `confirmingId` unconditionally and the "Replay?" confirm still opened - and its Yes button calls Inertia's `router.post`, which has no page state on the feed (plain `createApp`, no Inertia).

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,11 @@
 # CHANGELOG JULY 2026
 
+## July 3rd, 2026 - fix(events): readonly guard on the replay confirm popover
+
+Clicking a row on the token-authed events feed crashed with `page$1.get() is undefined`. The `readonly` guard covered the row's own `@click` and `openConfirm()`, but Reka's `PopoverTrigger` toggles open state on its own click, so `@update:open` set `confirmingId` unconditionally and the "Replay?" confirm still opened - and its Yes button calls Inertia's `router.post`, which has no page state on the feed (plain `createApp`, no Inertia).
+
+- `EventsTable.vue`: `@update:open` now checks `canReplay(event)` before opening the confirm, closing the trigger path that bypassed the readonly guard.
+
 ## July 3rd, 2026 - feat(events): one-click feed link + QR from the recents page
 
 Closes the "how do I even get the feed URL onto my phone" gap from the feed feature: plaintext tokens are shown once, so no page could reconstruct the link after the fact. Now the recents page mints it for you.

--- a/resources/js/components/EventsFeedLinkButton.vue
+++ b/resources/js/components/EventsFeedLinkButton.vue
@@ -41,10 +41,10 @@ defineExpose({ generateFeedUrl });
   >
     <template #instructions>
       <p class="text-foreground">
-        The link opens your live events feed with the mute-all-alerts button - no login needed.
-        Anyone with the link can read your event history and mute or unmute your alerts, so treat
-        it like a password. If it ever leaks, revoke the "Events feed" token on the Tokens page
-        and generate a new link here.
+        The link opens your live events feed with the mute-all-alerts button and event replay -
+        no login needed. Anyone with the link can read your event history, mute or unmute your
+        alerts, and replay past alerts on your stream, so treat it like a password. If it ever
+        leaks, revoke the "Events feed" token on the Tokens page and generate a new link here.
       </p>
     </template>
 

--- a/resources/js/components/EventsTable.vue
+++ b/resources/js/components/EventsTable.vue
@@ -10,9 +10,15 @@ const { eventDotClass, eventHoverBorderClass } = useEventColors();
 
 const props = defineProps<{
   events: UnifiedEvent[];
-  // Hides the replay affordance; used by the token-authed events feed, which
-  // is view-only (replay stays a logged-in dashboard action).
-  readonly?: boolean;
+  // When set, replay posts to the token-authed /api endpoints instead of the
+  // session-authed dashboard routes; used by the events feed, which has no
+  // session and no Inertia. Requires the token's `write` ability server-side.
+  token?: string;
+}>();
+
+const emit = defineEmits<{
+  // Replay outcome for pages without Inertia flash messages (the events feed).
+  'replay-result': [result: { message: string; type: string }];
 }>();
 
 const replayingId = ref<number | null>(null);
@@ -38,13 +44,18 @@ function confirmAndReplay(event: UnifiedEvent) {
 const nonReplayableTypes = ['stream.online', 'stream.offline', 'channel.channel_points_custom_reward_redemption.update'];
 
 function canReplay(event: UnifiedEvent): boolean {
-  if (props.readonly) return false;
   if (event.source !== 'twitch') return true;
   return !nonReplayableTypes.includes(event.event_type);
 }
 
 function replay(event: UnifiedEvent) {
   replayingId.value = event.id;
+
+  if (props.token) {
+    void replayViaToken(event, props.token);
+    return;
+  }
+
   const url = event.source === 'twitch'
     ? `/events/${event.id}/replay`
     : `/external-events/${event.id}/replay`;
@@ -58,6 +69,41 @@ function replay(event: UnifiedEvent) {
       },
     },
   );
+}
+
+async function replayViaToken(event: UnifiedEvent, token: string) {
+  const url = event.source === 'twitch'
+    ? `/api/events/${event.id}/replay`
+    : `/api/external-events/${event.id}/replay`;
+  const fallback = { message: 'Could not replay the event. Check your connection and try again.', type: 'error' };
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: JSON.stringify({ token }),
+    });
+
+    if (res.status === 403) {
+      emit('replay-result', { message: 'This feed link is not allowed to replay alerts.', type: 'error' });
+      return;
+    }
+
+    const json = await res.json().catch(() => null);
+    if (json?.message) {
+      emit('replay-result', { message: json.message, type: json.type ?? 'error' });
+    } else if (json?.error) {
+      emit('replay-result', { message: json.error, type: 'error' });
+    } else {
+      emit('replay-result', fallback);
+    }
+  } catch {
+    emit('replay-result', fallback);
+  } finally {
+    replayingId.value = null;
+  }
 }
 
 const externalEventLabels: Record<string, Record<string, string>> = {
@@ -263,7 +309,6 @@ function relativeTime(iso: string): string {
           <span class="text-sm text-foreground">Replay &ldquo;{{ event.label }}&rdquo;?</span>
           <button :ref="(el: any) => el?.focus({ focusVisible: true })" class="btn btn-primary btn-xs" @click="confirmAndReplay(event)">Yes</button>
           <button class="btn btn-chill btn-xs" @click="confirmingId = null">Cancel</button>
-
         </div>
       </PopoverContent>
     </Popover>

--- a/resources/js/components/EventsTable.vue
+++ b/resources/js/components/EventsTable.vue
@@ -223,7 +223,7 @@ function relativeTime(iso: string): string {
       v-for="event in events"
       :key="`${event.source}-${event.id}`"
       :open="confirmingId === event.id"
-      @update:open="(open: boolean) => (confirmingId = open ? event.id : null)"
+      @update:open="(open: boolean) => (confirmingId = open && canReplay(event) ? event.id : null)"
     >
       <PopoverTrigger as-child>
         <div
@@ -241,14 +241,14 @@ function relativeTime(iso: string): string {
           @keydown.enter.prevent="openConfirm(event)"
           @keydown.space.prevent="openConfirm(event)"
         >
-          <div class="flex flex-row min-w-0 flex-1 gap-1 group text-sm" :id="label(event)">
+          <div class="flex flex-col md:flex-row min-w-0 flex-1 gap-1 group text-sm" :id="label(event)">
             <div class="flex flex-nowrap items-center gap-x-2 gap-y-1 max-w-full">
               <div class="h-2 w-2 shrink-0 rounded-full" :class="eventDotClass(event)"></div>
               <span v-if="who(event)" class="font-bold">{{ who(event) }}</span>
-              <div class="group-hover:text-foreground whitespace-nowrap overflow-x-hidden max-w-50 md:max-w-90 text-ellipsis">{{ label(event) }}</div>
+              <div class="group-hover:text-foreground whitespace-nowrap overflow-x-hidden md:max-w-90 text-ellipsis">{{ label(event) }}</div>
             </div>
             <div class="flex items-center gap-2 pl-4 text-xs w-full">
-              <div class="whitespace-nowrap text-ellipsis w-full">{{ relativeTime(event.created_at) }}</div>
+              <div class="whitespace-nowrap text-ellipsis">{{ relativeTime(event.created_at) }}</div>
               <RefreshCw v-if="replayingId === event.id" class="h-3 w-3 animate-spin" />
 
               <div v-if="details(event)" class="whitespace-nowrap text-ellipsis">{{ details(event) }}</div>

--- a/resources/js/events-feed/EventsFeed.vue
+++ b/resources/js/events-feed/EventsFeed.vue
@@ -41,6 +41,16 @@ const initialized = ref(false);
 const fatalError = ref<string | null>(null);
 const loadError = ref<string | null>(null);
 const muteError = ref<string | null>(null);
+const replayNotice = ref<{ message: string; type: string } | null>(null);
+let replayNoticeTimer: ReturnType<typeof setTimeout> | undefined;
+
+function onReplayResult(result: { message: string; type: string }) {
+  replayNotice.value = result;
+  clearTimeout(replayNoticeTimer);
+  replayNoticeTimer = setTimeout(() => {
+    replayNotice.value = null;
+  }, 6000);
+}
 
 async function load(showSpinner = true) {
   if (showSpinner) refreshing.value = true;
@@ -165,6 +175,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  clearTimeout(replayNoticeTimer);
   const echo = (window as any).Echo;
   if (echo && twitchId.value) {
     echo.leave(`twitch-events.${twitchId.value}`);
@@ -247,6 +258,18 @@ function eventTypeLabel(type: string): string {
       {{ muteError }}
     </div>
 
+    <div
+      v-if="replayNotice"
+      class="mb-2 border px-3 py-2 text-sm text-foreground"
+      :class="{
+        'border-violet-400/40 bg-violet-400/10': replayNotice.type === 'success',
+        'border-amber-400/40 bg-amber-400/10': replayNotice.type === 'warning',
+        'border-red-400/40 bg-red-400/10': replayNotice.type === 'error',
+      }"
+    >
+      {{ replayNotice.message }}
+    </div>
+
     <!-- Collapsible Filters -->
     <div v-show="filtersOpen" id="feed-filters" class="mb-2 border border-sidebar-border bg-sidebar-accent p-3">
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -315,7 +338,7 @@ function eventTypeLabel(type: string): string {
     </div>
 
     <div v-else-if="initialized" class="bg-card px-2 py-1 transition-opacity duration-300" :class="refreshing ? 'opacity-40' : 'opacity-100'">
-      <EventsTable v-if="events.length > 0" :events="events" readonly />
+      <EventsTable v-if="events.length > 0" :events="events" :token="token" @replay-result="onReplayResult" />
 
       <EmptyState v-else message="No events match your filters. Try widening the time range or clearing search." />
 
@@ -349,7 +372,7 @@ function eventTypeLabel(type: string): string {
     <div class="w-full max-w-md rounded-xl bg-background p-5 shadow-xl">
       <div class="flex items-start justify-between gap-3">
         <p class="text-sm font-medium leading-6">
-          Your recent events, live. Use the mute button to silence every alert in one tap - visuals, sounds, TTS and bot messages. Events keep recording while muted. Replaying events is available on the dashboard when you are logged in.
+          Your recent events, live. Use the mute button to silence every alert in one tap - visuals, sounds, TTS and bot messages. Events keep recording while muted. Tap an event to replay its alert on stream; unmute first, replay is blocked while alerts are muted.
         </p>
 
         <button

--- a/routes/api.php
+++ b/routes/api.php
@@ -58,15 +58,25 @@ Route::get('/lists/{slug}', [ListReadController::class, 'show'])
 // Token-authed events feed for /events/feed (phone-friendly, no Twitch login
 // needed). Same OverlayAccessToken as overlays; token travels as a ?token=
 // query param (GET) or JSON body field (POST), never in the URL path. Reading
-// requires the `read` ability, the mute toggle requires `write` - the first
-// endpoints to enforce token abilities. Stateless like the overlay render
-// route. See App\Http\Controllers\Api\EventFeedController.
+// requires the `read` ability, the writes (mute toggle, event replay) require
+// `write` - the first endpoints to enforce token abilities. Stateless like the
+// overlay render route. See App\Http\Controllers\Api\EventFeedController.
 Route::get('/events', [EventFeedController::class, 'index'])
     ->name('api.events.index')
     ->middleware(['throttle:overlay', 'lockdown'])
     ->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
 Route::post('/events/mute', [EventFeedController::class, 'mute'])
     ->name('api.events.mute')
+    ->middleware(['throttle:overlay', 'lockdown'])
+    ->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
+Route::post('/events/{twitchEvent}/replay', [EventFeedController::class, 'replayTwitch'])
+    ->name('api.events.replay')
+    ->whereNumber('twitchEvent')
+    ->middleware(['throttle:overlay', 'lockdown'])
+    ->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
+Route::post('/external-events/{externalEvent}/replay', [EventFeedController::class, 'replayExternal'])
+    ->name('api.external-events.replay')
+    ->whereNumber('externalEvent')
     ->middleware(['throttle:overlay', 'lockdown'])
     ->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
 

--- a/tests/Feature/EventFeedApiTest.php
+++ b/tests/Feature/EventFeedApiTest.php
@@ -1,11 +1,17 @@
 <?php
 
+use App\Events\AlertTriggered;
+use App\Models\EventTemplateMapping;
 use App\Models\ExternalEvent;
+use App\Models\ExternalEventTemplateMapping;
 use App\Models\OverlayAccessToken;
+use App\Models\OverlayTemplate;
 use App\Models\TwitchEvent;
 use App\Models\User;
 use App\Services\AlertMuteService;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
 
 uses(DatabaseTransactions::class);
 
@@ -154,6 +160,156 @@ test('mute requires a valid token and a boolean muted flag', function () {
     $this->postJson('/api/events/mute', ['muted' => true])->assertStatus(401);
     $this->postJson('/api/events/mute', ['token' => str_repeat('c', 64), 'muted' => true])->assertStatus(401);
     $this->postJson('/api/events/mute', ['token' => $token])->assertStatus(422);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/events/{id}/replay + /api/external-events/{id}/replay
+// ─────────────────────────────────────────────────────────────────────────────
+
+function eventFeedAlertTemplate(User $user): OverlayTemplate
+{
+    return OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => 'alert',
+        'slug' => 'alert-'.fake()->unique()->lexify('????????'),
+    ]);
+}
+
+function eventFeedMappedTwitchEvent(User $user): TwitchEvent
+{
+    EventTemplateMapping::create([
+        'user_id' => $user->id,
+        'event_type' => 'channel.follow',
+        'template_id' => eventFeedAlertTemplate($user)->id,
+        'duration_ms' => 5000,
+        'enabled' => true,
+    ]);
+
+    return TwitchEvent::create([
+        'user_id' => $user->id,
+        'event_type' => 'channel.follow',
+        'event_data' => ['user_name' => 'NewFollower'],
+        'twitch_timestamp' => now(),
+        'processed' => true,
+    ]);
+}
+
+function eventFeedMappedExternalEvent(User $user): ExternalEvent
+{
+    ExternalEventTemplateMapping::create([
+        'user_id' => $user->id,
+        'service' => 'kofi',
+        'event_type' => 'donation',
+        'overlay_template_id' => eventFeedAlertTemplate($user)->id,
+        'enabled' => true,
+        'duration_ms' => 5000,
+    ]);
+
+    return ExternalEvent::create([
+        'user_id' => $user->id,
+        'service' => 'kofi',
+        'event_type' => 'donation',
+        'message_id' => 'msg-'.fake()->uuid(),
+        'raw_payload' => ['from_name' => 'Donor'],
+        'normalized_payload' => ['event.from_name' => 'Donor', 'event.amount' => '5.00'],
+    ]);
+}
+
+test('a write-able token replays a twitch event', function () {
+    $user = eventFeedUser();
+    $user->update(['access_token' => 'feed-test-token']);
+    $token = eventFeedToken($user, 'read,write');
+    $event = eventFeedMappedTwitchEvent($user);
+
+    // renderEventAlert enriches the template with Helix data; keep it offline.
+    Http::fake(['api.twitch.tv/*' => Http::response(['data' => []], 200)]);
+    Event::fake([AlertTriggered::class]);
+
+    $this->postJson("/api/events/{$event->id}/replay", ['token' => $token])
+        ->assertOk()
+        ->assertJsonPath('type', 'success');
+
+    Event::assertDispatched(AlertTriggered::class);
+});
+
+test('a write-able token replays an external event', function () {
+    $user = eventFeedUser();
+    $token = eventFeedToken($user, 'read,write');
+    $event = eventFeedMappedExternalEvent($user);
+
+    Event::fake([AlertTriggered::class]);
+
+    $this->postJson("/api/external-events/{$event->id}/replay", ['token' => $token])
+        ->assertOk()
+        ->assertJsonPath('type', 'success');
+
+    Event::assertDispatched(AlertTriggered::class);
+});
+
+test('a token without the write ability cannot replay', function () {
+    $user = eventFeedUser();
+    $readOnly = eventFeedToken($user, 'read');
+    $twitchEvent = eventFeedMappedTwitchEvent($user);
+    $externalEvent = eventFeedMappedExternalEvent($user);
+
+    Event::fake([AlertTriggered::class]);
+
+    $this->postJson("/api/events/{$twitchEvent->id}/replay", ['token' => $readOnly])->assertStatus(403);
+    $this->postJson("/api/external-events/{$externalEvent->id}/replay", ['token' => $readOnly])->assertStatus(403);
+
+    Event::assertNotDispatched(AlertTriggered::class);
+});
+
+test('a token cannot replay another user\'s event and cannot probe event ids', function () {
+    $owner = eventFeedUser();
+    $stranger = eventFeedUser();
+    $token = eventFeedToken($stranger, 'read,write');
+    $twitchEvent = eventFeedMappedTwitchEvent($owner);
+    $externalEvent = eventFeedMappedExternalEvent($owner);
+
+    Event::fake([AlertTriggered::class]);
+
+    $this->postJson("/api/events/{$twitchEvent->id}/replay", ['token' => $token])->assertStatus(404);
+    $this->postJson("/api/external-events/{$externalEvent->id}/replay", ['token' => $token])->assertStatus(404);
+
+    Event::assertNotDispatched(AlertTriggered::class);
+});
+
+test('replay via token is blocked with a warning while alerts are muted', function () {
+    $user = eventFeedUser();
+    $token = eventFeedToken($user, 'read,write');
+    $event = eventFeedMappedTwitchEvent($user);
+
+    app(AlertMuteService::class)->setMuted($user, true);
+
+    Event::fake([AlertTriggered::class]);
+
+    $this->postJson("/api/events/{$event->id}/replay", ['token' => $token])
+        ->assertOk()
+        ->assertJsonPath('type', 'warning');
+
+    Event::assertNotDispatched(AlertTriggered::class);
+});
+
+test('replay via token without an active mapping returns a 422 error', function () {
+    $user = eventFeedUser();
+    $token = eventFeedToken($user, 'read,write');
+    $event = TwitchEvent::create([
+        'user_id' => $user->id,
+        'event_type' => 'channel.follow',
+        'event_data' => ['user_name' => 'NewFollower'],
+        'twitch_timestamp' => now(),
+        'processed' => true,
+    ]);
+
+    Event::fake([AlertTriggered::class]);
+
+    $this->postJson("/api/events/{$event->id}/replay", ['token' => $token])
+        ->assertStatus(422)
+        ->assertJsonPath('type', 'error');
+
+    Event::assertNotDispatched(AlertTriggered::class);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replay now works from `/events/feed#<token>` - tapping an event opens the replay confirm and fires the real alert on stream, same pipeline as the dashboard (visuals, TTS, bot message, mute guard included).
- New token-authed endpoints `POST /api/events/{id}/replay` and `POST /api/external-events/{id}/replay`: `write` ability required, `throttle:overlay` + `lockdown`, successful replays land in the token's access log. Foreign event ids return 404 so tokens cannot probe other users' event ids.
- Replay cores extracted to `replayForUser()` on `TwitchEventSubController` / `ExternalEventController` and shared with the session routes - dashboard behavior unchanged.
- `EventsTable`: `readonly` prop replaced by an optional `token` prop + `replay-result` emit; the feed shows the outcome as an inline notice (success / muted warning / error). No Inertia calls on the non-Inertia feed page anymore.
- Also includes the popover fix this builds on: the Reka `PopoverTrigger` toggle bypassed `canReplay()`, which both opened the confirm on non-replayable rows and caused the original `router.post` crash on the feed.
- Feed info dialog + feed-link warning copy updated: the link can now also replay alerts on stream.

## Test plan
- 6 new Pest tests: token replay for both event kinds, read-only token 403, foreign event 404, muted warning, missing mapping 422.
- Full suite: 1010 passed. ESLint, Pint, and production build clean.
- Manual: on the feed, tap a follow/cheer/sub row -> confirm -> alert fires; while muted -> amber warning notice; dashboard replay unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)