### PR TITLE
docs(bot): rename "Bot Commands" help page to "Bot Expressions"

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -28,7 +28,7 @@ class SitemapController extends Controller
         ['path' => '/help/why-overlabels', 'priority' => '0.7', 'changefreq' => 'monthly'],
         ['path' => '/help/manifesto', 'priority' => '0.6', 'changefreq' => 'monthly'],
         ['path' => '/help/bot', 'priority' => '0.7', 'changefreq' => 'monthly'],
-        ['path' => '/help/bot/commands', 'priority' => '0.7', 'changefreq' => 'monthly'],
+        ['path' => '/help/bot/expressions', 'priority' => '0.7', 'changefreq' => 'monthly'],
         ['path' => '/help/gamejam', 'priority' => '0.6', 'changefreq' => 'monthly'],
         ['path' => '/help/reference', 'priority' => '0.8', 'changefreq' => 'weekly'],
     ];

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,14 @@
 # CHANGELOG JULY 2026
 
+## July 5th, 2026 - docs(bot): rename the "Bot Commands" help page to "Bot Expressions"
+
+The bot's user-facing feature is branded "Expressions" - and the dashboard route to author them is `/settings/bot/expressions` - but the help doc still said "Bot Commands" and lived at `/help/bot/commands`. That discrepancy is gone: the page is now "Bot Expressions" throughout, at `/help/bot/expressions`.
+
+- **Route renamed**: `/help/bot/commands` -> `/help/bot/expressions`, route name `help.bot.commands` -> `help.bot.expressions`. The Vue file stays `help/bot/Commands.vue` (only its route and copy changed). Sitemap entry updated. A `Route::redirect(..., 301)` keeps the old `/help/bot/commands` URL working for any bookmarks or search-indexed links.
+- **Copy fully purged** of the word "command" in prose: title, hero, breadcrumb, TOC, section headings, warning block, and card descriptions now read "expression" (e.g. "Control expressions are OFF by default", "Your own expressions", "meta-expression"). Left untouched on purpose: literal syntax tokens (`!command`, `!cmd`, `!commands`, `!ol cmd`), the other bots' owned command names, and the simulated bot replies (they mirror what the bot actually says).
+- **Callers updated**: the Bot help index nav card, the two links from the Aliases page, and the Settings > Integrations bot blurb all point at the new route and read "Bot Expressions".
+- The `localStorage` acknowledgment key (`help.bot.commands.controlsWarningAck`) was intentionally left unchanged so streamers who already dismissed the controls-access warning don't see it again.
+
 ## July 4th, 2026 - fix(events): hide the redundant bare sub that Twitch fires next to every resub
 
 A resub emits two EventSub events at the same instant - `channel.subscribe` and `channel.subscription.message` - so the feed always showed a pointless pair: "JP_4468 resub T1" directly above "JP_4468 sub T1". Now the bare sub is folded away and only the resub row remains.

--- a/resources/js/events-feed/app.ts
+++ b/resources/js/events-feed/app.ts
@@ -50,7 +50,6 @@ try {
     wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
     forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
     enabledTransports: ['ws', 'wss'],
-    //@ts-ignore
     authorizer: feedAuthorizer,
   });
 } catch (err) {

--- a/resources/js/events-feed/app.ts
+++ b/resources/js/events-feed/app.ts
@@ -50,6 +50,7 @@ try {
     wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
     forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
     enabledTransports: ['ws', 'wss'],
+    //@ts-ignore
     authorizer: feedAuthorizer,
   });
 } catch (err) {

--- a/resources/js/pages/help/Aliases.vue
+++ b/resources/js/pages/help/Aliases.vue
@@ -130,7 +130,7 @@ const breadcrumbs: BreadcrumbItem[] = [
           </div>
           <p class="mt-4 text-foreground">
             Full <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">!ol alias</code> reference
-            (add / edit / delete / options) lives on <Link href="/help/bot/commands#ol" class="text-violet-400 hover:underline">/help/bot/commands</Link>.
+            (add / edit / delete / options) lives on <Link href="/help/bot/expressions#ol" class="text-violet-400 hover:underline">/help/bot/expressions</Link>.
           </p>
         </section>
 
@@ -419,8 +419,8 @@ const breadcrumbs: BreadcrumbItem[] = [
               who fired them.
             </li>
             <li>
-              <Link href="/help/bot/commands" class="text-violet-400 hover:underline">Bot Commands</Link> - every
-              built-in chat command the @overlabels bot ships with, plus the full <code>!ol</code> chat-admin
+              <Link href="/help/bot/expressions" class="text-violet-400 hover:underline">Bot Expressions</Link> - every
+              built-in chat expression the @overlabels bot ships with, plus the full <code>!ol</code> chat-admin
               vocabulary.
             </li>
             <li>

--- a/resources/js/pages/help/bot/Commands.vue
+++ b/resources/js/pages/help/bot/Commands.vue
@@ -230,14 +230,16 @@ const miscCommands: BotCommandDoc[] = [
     canonical-url="https://overlabels.com/help/bot/expressions"
   >
     <!-- Hero -->
-    <div class="mb-8">
+    <div>
       <Heading
         title="Bot Expressions"
         title-class="text-4xl font-bold mb-4"
         description="Every chat expression the @overlabels Twitch bot understands - controls, !ol chat-admin meta-expression, list operations, and built-ins. Click a row to expand it and show an example."
       />
     </div>
-
+    <div class="mt-4 mb-8">
+      <p>Warning: This page is&hellip; Slightly overwhelming. I'm fully aware of that and I hope to make this page less of a knowledge bomb in the future. For now: if you learn how <code>!ol</code> works, you're well on your way to become an Overlabels Bot Expressions expert.</p>
+    </div>
     <!-- Controls-access warning (collapsed version once acknowledged) -->
     <div
       v-if="!iUnderstand"

--- a/resources/js/pages/help/bot/Commands.vue
+++ b/resources/js/pages/help/bot/Commands.vue
@@ -141,7 +141,7 @@ const olCommands: BotCommandDoc[] = [
   {
     command: '!ol cmd options <name> <option> <value>',
     tier: 'moderator',
-    summary: 'Tune one option on an expression. Options: cooldown, permission, enabled, hidden.',
+    summary: 'Tune one option on an expression. Options: cooldown, permission, enabled, destroy, hidden.',
     example: { chat: '!ol cmd options lol cooldown 30', reply: '@mod !lol cooldown is now 30s' },
     notes: 'Permission shortforms work: mod, sub, vip, bc, all. Booleans accept true/false/on/off/yes/no/1/0.',
   },
@@ -408,6 +408,7 @@ const miscCommands: BotCommandDoc[] = [
           <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">cooldown</code> - integer seconds, 0 to 86400. Broadcaster bypasses cooldown.</li>
           <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">permission</code> - <code>everyone</code> / <code>sub</code> / <code>vip</code> / <code>mod</code> / <code>broadcaster</code>. <code>all</code> is a synonym for everyone, <code>bc</code> for broadcaster.</li>
           <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">enabled</code> - <code>true</code> or <code>false</code> (also accepts on/off, yes/no, 1/0).</li>
+          <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">destroy</code> - integer hours, 0 to 8760 (1 year).</li>
           <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">hidden</code> - hides this expression from the future <code>!commands</code> listing without disabling it.</li>
         </ul>
       </div>
@@ -458,14 +459,7 @@ const miscCommands: BotCommandDoc[] = [
         Everything above is built into the bot. On top of that you can author four kinds of custom expressions - each
         is managed from the dashboard, and three of them are also reachable through <code>!ol</code> in chat.
       </p>
-      <div class="grid gap-3 sm:grid-cols-3">
-        <a :href="route('help.expressions')" class="block border border-sidebar-border bg-sidebar-accent p-4 hover:border-violet-400/50">
-          <p class="mb-1 font-semibold text-foreground">Bot Expressions</p>
-          <p class="text-sm text-muted-foreground">
-            Custom <code>!command</code> chat replies templated against controls, Helix data, and the chatter who
-            fired them. The bot speaks the resolved string.
-          </p>
-        </a>
+      <div class="grid gap-3 sm:grid-cols-2">
         <a :href="route('help.bot.aliases')" class="block border border-sidebar-border bg-sidebar-accent p-4 hover:border-violet-400/50">
           <p class="mb-1 font-semibold text-foreground">Bot Aliases</p>
           <p class="text-sm text-muted-foreground">

--- a/resources/js/pages/help/bot/Commands.vue
+++ b/resources/js/pages/help/bot/Commands.vue
@@ -8,7 +8,7 @@ import Heading from '@/components/Heading.vue';
 const breadcrumbs: BreadcrumbItem[] = [
   { title: 'Help', href: '/help' },
   { title: 'Twitch Bot', href: '/help/bot' },
-  { title: 'Commands', href: '/help/bot/commands' },
+  { title: 'Expressions', href: '/help/bot/expressions' },
 ];
 
 const STORAGE_KEY = 'help.bot.commands.controlsWarningAck';
@@ -148,7 +148,7 @@ const olCommands: BotCommandDoc[] = [
   {
     command: '!ol alias add <name> <target>',
     tier: 'moderator',
-    summary: 'Create a Bot Alias - a short command that rewrites to a longer one.',
+    summary: 'Create a Bot Alias - a short expression that rewrites to a longer one.',
     example: { chat: '!ol alias add w !inc wins {1}', reply: '@mod added alias !w -> !inc wins {1}' },
     notes: 'Use {1}, {2}, ... for positional args from the alias call site. {*} captures all remaining args. Aliases can target builtins or your expressions, but not other aliases (one hop only).',
   },
@@ -169,7 +169,7 @@ const olCommands: BotCommandDoc[] = [
     tier: 'moderator',
     summary: 'Same options as !ol cmd options, applied to an alias.',
     example: { chat: '!ol alias options w permission broadcaster', reply: '@mod alias !w permission is now broadcaster' },
-    notes: 'The target command\'s own permission still applies after the alias rewrite, so this only restricts who can trigger the alias itself.',
+    notes: 'The target expression\'s own permission still applies after the alias rewrite, so this only restricts who can trigger the alias itself.',
   },
   {
     command: '!ol list [cmd|alias]',
@@ -193,7 +193,7 @@ const listCommands: BotCommandDoc[] = [
     tier: 'moderator',
     summary: 'Operate on one of your Lists. ~20 actions cover read, append, draw, snapshot, clear, etc.',
     example: { chat: '!list raffle count', reply: '@mod \'raffle\' has 17 entries' },
-    notes: 'The verb after the slug is the action. Full action vocabulary lives on the /help/lists page - this command exposes every action there to chat.',
+    notes: 'The verb after the slug is the action. Full action vocabulary lives on the /help/lists page - this expression exposes every action there to chat.',
   },
 ];
 
@@ -225,16 +225,16 @@ const miscCommands: BotCommandDoc[] = [
 <template>
   <HelpLayout
     :breadcrumbs="breadcrumbs"
-    title="Bot Commands - Overlabels Help"
-    description="Every chat command the @overlabels Twitch bot understands - controls, !ol chat-admin meta-command, list operations, and built-ins."
-    canonical-url="https://overlabels.com/help/bot/commands"
+    title="Bot Expressions - Overlabels Help"
+    description="Every chat expression the @overlabels Twitch bot understands - controls, !ol chat-admin meta-expression, list operations, and built-ins."
+    canonical-url="https://overlabels.com/help/bot/expressions"
   >
     <!-- Hero -->
     <div class="mb-8">
       <Heading
-        title="Bot Commands"
+        title="Bot Expressions"
         title-class="text-4xl font-bold mb-4"
-        description="Every chat command the @overlabels Twitch bot understands - controls, !ol chat-admin meta-command, list operations, and built-ins. Click a row to expand it and show an example."
+        description="Every chat expression the @overlabels Twitch bot understands - controls, !ol chat-admin meta-expression, list operations, and built-ins. Click a row to expand it and show an example."
       />
     </div>
 
@@ -245,14 +245,14 @@ const miscCommands: BotCommandDoc[] = [
     >
       <h2 class="mb-2 text-xl font-semibold text-amber-500">
         <ShieldAlert class="mr-2 inline-block h-5 w-5" />
-        Control commands are OFF by default
+        Control expressions are OFF by default
       </h2>
       <p class="mb-3 text-foreground">
         Everything in the <em>Controls</em> section below is gated behind a per-channel switch. The default is
         <strong>off</strong>: until you flip it on, the bot will ignore <code>!control</code>, <code>!set</code>,
         <code>!increment</code>, <code>!decrement</code>, <code>!reset</code>, <code>!enable</code>,
-        <code>!disable</code>, and <code>!toggle</code> entirely. <strong>The !ol chat-admin commands and
-        !list meta-command work regardless</strong> - they don't touch your controls layer.
+        <code>!disable</code>, and <code>!toggle</code> entirely. <strong>The !ol chat-admin expressions and
+        !list meta-expression work regardless</strong> - they don't touch your controls layer.
       </p>
       <p class="mb-3 text-foreground">
         To open the controls surface for your channel, type <code class="rounded bg-background px-1.5 py-0.5 font-mono">!enablecontrols</code>
@@ -285,8 +285,8 @@ const miscCommands: BotCommandDoc[] = [
         <li><a href="#controls" class="text-violet-400 hover:underline">Controls</a></li>
         <li><a href="#access" class="text-violet-400 hover:underline">Controls-access switch</a></li>
         <li><a href="#ol" class="text-violet-400 hover:underline"><code>!ol</code> chat-admin</a></li>
-        <li><a href="#list" class="text-violet-400 hover:underline"><code>!list</code> meta-command</a></li>
-        <li><a href="#user" class="text-violet-400 hover:underline">Your own commands</a></li>
+        <li><a href="#list" class="text-violet-400 hover:underline"><code>!list</code> meta-expression</a></li>
+        <li><a href="#user" class="text-violet-400 hover:underline">Your own expressions</a></li>
         <li><a href="#misc" class="text-violet-400 hover:underline">Miscellaneous</a></li>
         <li><a href="#tiers" class="text-violet-400 hover:underline">Permission tiers</a></li>
       </ol>
@@ -362,7 +362,7 @@ const miscCommands: BotCommandDoc[] = [
     <section class="mb-12" id="ol">
       <h2 class="mb-3 text-2xl font-bold"><code>!ol</code> chat-admin</h2>
       <p class="mb-3 text-foreground">
-        Manage your custom commands and aliases without leaving Twitch. <code class="rounded bg-background px-1.5 py-0.5 font-mono">!ol</code>
+        Manage your custom expressions and aliases without leaving Twitch. <code class="rounded bg-background px-1.5 py-0.5 font-mono">!ol</code>
         is namespaced this way so it doesn't fight with other bots (StreamElements, Wizebot, Nightbot, Streamlabs Cloudbot
         all already own <code>!command</code> / <code>!cmd</code> / <code>!commands</code>).
       </p>
@@ -406,16 +406,16 @@ const miscCommands: BotCommandDoc[] = [
           <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">cooldown</code> - integer seconds, 0 to 86400. Broadcaster bypasses cooldown.</li>
           <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">permission</code> - <code>everyone</code> / <code>sub</code> / <code>vip</code> / <code>mod</code> / <code>broadcaster</code>. <code>all</code> is a synonym for everyone, <code>bc</code> for broadcaster.</li>
           <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">enabled</code> - <code>true</code> or <code>false</code> (also accepts on/off, yes/no, 1/0).</li>
-          <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">hidden</code> - hides this command from the future <code>!commands</code> listing without disabling it.</li>
+          <li><code class="rounded bg-background px-1.5 py-0.5 font-mono">hidden</code> - hides this expression from the future <code>!commands</code> listing without disabling it.</li>
         </ul>
       </div>
     </section>
 
     <!-- Section: !list -->
     <section class="mb-12" id="list">
-      <h2 class="mb-3 text-2xl font-bold"><code>!list</code> meta-command</h2>
+      <h2 class="mb-3 text-2xl font-bold"><code>!list</code> meta-expression</h2>
       <p class="mb-5 text-foreground">
-        One mod-only command exposes the full action vocabulary of your Lists to chat. The shape is
+        One mod-only expression exposes the full action vocabulary of your Lists to chat. The shape is
         <code class="rounded bg-background px-1.5 py-0.5 font-mono">!list &lt;slug&gt; &lt;action&gt; [args]</code> and the verbs
         cover read (<code>count</code>, <code>first</code>, <code>random</code>...), grow (<code>add</code>), shrink (<code>draw</code>, <code>pop</code>, <code>clear</code>),
         snapshot/restore, and lifecycle (<code>disable</code>, <code>enable</code>).
@@ -451,9 +451,9 @@ const miscCommands: BotCommandDoc[] = [
 
     <!-- Section: User-defined -->
     <section class="mb-12" id="user">
-      <h2 class="mb-3 text-2xl font-bold">Your own commands</h2>
+      <h2 class="mb-3 text-2xl font-bold">Your own expressions</h2>
       <p class="mb-4 text-foreground">
-        Everything above is built into the bot. On top of that you can author four kinds of custom commands - each
+        Everything above is built into the bot. On top of that you can author four kinds of custom expressions - each
         is managed from the dashboard, and three of them are also reachable through <code>!ol</code> in chat.
       </p>
       <div class="grid gap-3 sm:grid-cols-3">
@@ -467,20 +467,20 @@ const miscCommands: BotCommandDoc[] = [
         <a :href="route('help.bot.aliases')" class="block border border-sidebar-border bg-sidebar-accent p-4 hover:border-violet-400/50">
           <p class="mb-1 font-semibold text-foreground">Bot Aliases</p>
           <p class="text-sm text-muted-foreground">
-            Short commands that rewrite to longer ones before dispatch. <code>!w 2</code> becomes
+            Short expressions that rewrite to longer ones before dispatch. <code>!w 2</code> becomes
             <code>!inc wins 2</code>. Positional placeholders: <code>{1}</code>, <code>{2}</code>, <code>{*}</code>.
           </p>
         </a>
         <a :href="`${route('help.lists')}#appenders`" class="block border border-sidebar-border bg-sidebar-accent p-4 hover:border-violet-400/50">
           <p class="mb-1 font-semibold text-foreground">List Appenders</p>
           <p class="text-sm text-muted-foreground">
-            Chat commands that append a chatter's input to one of your Lists. Raffle entries, quote walls,
+            Chat expressions that append a chatter's input to one of your Lists. Raffle entries, quote walls,
             song requests - one verb per kind of growing list.
           </p>
         </a>
       </div>
       <p class="mt-4 text-sm text-foreground">
-        A custom command can't claim the name of a built-in - <code>!control</code>, <code>!ol</code>,
+        A custom expression can't claim the name of a built-in - <code>!control</code>, <code>!ol</code>,
         <code>!list</code>, <code>!ping</code>, etc. are reserved. Validation catches the collision at save time
         on both the dashboard and <code>!ol cmd add</code>.
       </p>
@@ -514,7 +514,7 @@ const miscCommands: BotCommandDoc[] = [
         </details>
       </div>
       <p class="mt-3 text-sm text-foreground">
-        Chat Castle (the chat-driven map game) ships several command verbs of its own - <code>!join</code>,
+        Chat Castle (the chat-driven map game) ships several chat verbs of its own - <code>!join</code>,
         <code>!p</code>, <code>!h</code>, <code>!a</code>, <code>!s</code>, <code>!castlehelp</code>. Those are
         documented separately at <a href="/help/gamejam" class="text-violet-400 hover:underline">/help/gamejam</a>.
       </p>

--- a/resources/js/pages/help/bot/Index.vue
+++ b/resources/js/pages/help/bot/Index.vue
@@ -12,9 +12,9 @@ const breadcrumbs: BreadcrumbItem[] = [
 
 const pages = [
   {
-    title: 'Commands',
-    description: 'The built-in chat commands the bot ships with, plus one working example per command.',
-    href: '/help/bot/commands',
+    title: 'Expressions',
+    description: 'The built-in chat expressions the bot ships with, plus one working example per expression.',
+    href: '/help/bot/expressions',
     icon: Terminal,
   },
   {

--- a/resources/js/pages/settings/bot/expressions/Index.vue
+++ b/resources/js/pages/settings/bot/expressions/Index.vue
@@ -139,7 +139,7 @@ function expiresIn(iso: string): string {
                 </span>
               </div>
 
-              <p class="break-words font-mono text-sm text-foreground/80">{{ expression.expression }}</p>
+              <p class="wrap-break-word font-mono text-sm text-foreground/80">{{ expression.expression }}</p>
 
               <p class="text-xs text-foreground/60">
                 Last fired: {{ formatDate(expression.last_fired_at) }}

--- a/resources/js/pages/settings/bot/expressions/Index.vue
+++ b/resources/js/pages/settings/bot/expressions/Index.vue
@@ -72,7 +72,9 @@ function expiresIn(iso: string): string {
           title="Bot expressions"
           description="Custom chat commands that read from your controls, Twitch data, and the chatter who fired them. The bot speaks the resolved string."
         />
-
+        <div>
+          <a class="btn btn-primary" href="/help/bot/expressions" target="_blank">Learn how Bot Expressions work</a>
+        </div>
         <div v-if="!botEnabled" class="rounded border border-amber-500/40 bg-amber-500/5 p-4 text-sm">
           <p class="text-foreground">
             The Overlabels bot isn't enabled yet. Bot expressions are saved here, but nothing fires until the bot is on.

--- a/resources/js/pages/settings/integrations/index.vue
+++ b/resources/js/pages/settings/integrations/index.vue
@@ -336,7 +336,7 @@ function formatDate(iso: string | null): string {
                   Run <code class="rounded bg-muted px-1 py-0.5 text-xs">/mod overlabels</code> in your Twitch chat so the bot can post without rate limits, then try <code class="rounded bg-muted px-1 py-0.5 text-xs">!ping</code> - it should reply with pong.
                 </p>
                 <p v-else class="text-sm text-muted-foreground">
-                  Enable to have the bot join your channel. Default <a :href="route('help.bot.commands')" target="_blank" class="underline hover:text-foreground">bot commands</a> are enabled automatically the first time you enable it.
+                  Enable to have the bot join your channel. Default <a :href="route('help.bot.expressions')" target="_blank" class="underline hover:text-foreground">bot expressions</a> are enabled automatically the first time you enable it.
                 </p>
               </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -173,9 +173,12 @@ Route::get('/help/bot', function () {
     return Inertia::render('help/bot/Index');
 })->name('help.bot');
 
-Route::get('/help/bot/commands', function () {
+Route::get('/help/bot/expressions', function () {
     return Inertia::render('help/bot/Commands');
-})->name('help.bot.commands');
+})->name('help.bot.expressions');
+
+// Renamed from /help/bot/commands - keep old links and indexed URLs working.
+Route::redirect('/help/bot/commands', '/help/bot/expressions', 301);
 
 Route::get('/help/gamejam', function () {
     return Inertia::render('help/gamejam/Index');


### PR DESCRIPTION
Aligns the help documentation with the bot's user-facing brand. The bot's feature is "Expressions" and the dashboard route is `/settings/bot/expressions`, but the help doc still said "Bot Commands" at `/help/bot/commands`. This closes that gap and folds in a few related touch-ups.

## What changed

**Route**
- `/help/bot/commands` -> `/help/bot/expressions`; route name `help.bot.commands` -> `help.bot.expressions`
- Added a `301` redirect from the old `/help/bot/commands` so bookmarks and search-indexed URLs keep working
- The Vue file stays `help/bot/Commands.vue` (only its route and copy changed)

**Copy**
- Purged the prose word "command" from the page in favor of "expression" (title, hero, breadcrumb, TOC, section headings, warning block, card descriptions)
- Left untouched on purpose: literal syntax tokens (`!command`, `!cmd`, `!commands`, `!ol cmd`), other bots' owned command names, and simulated bot replies (they mirror what the bot actually says)
- Added a friendly "this page is a lot" intro paragraph to the hero
- Documented the new `destroy` option (integer hours, 0 to 8760) on `!ol cmd options`
- Removed the redundant "Bot Expressions" card that pointed at `/help/expressions` (it duplicated this very page's brand); "Your own expressions" grid is now 2-up

**Callers updated**
- Bot help index nav card, the two links from the Aliases page, and the Settings > Integrations bot blurb now point at the new route and read "Bot Expressions"
- Sitemap entry updated
- Settings > Bot Expressions page gained a "Learn how Bot Expressions work" button linking to the help page

**Small fixes**
- `wrap-break-word` on the expression preview in the settings list
- `@ts-ignore` on the events-feed authorizer

## Notes
- The `localStorage` key `help.bot.commands.controlsWarningAck` was intentionally left unchanged so streamers who already dismissed the controls-access warning don't see it again
- The `/settings/bot/expressions` page description still reads "Custom chat commands that read from..." - not touched here, flag if you want it purged too

🤖 Generated with [Claude Code](https://claude.com/claude-code)