### PR TITLE
fix(templates): stop templates list 500 when changing a filter from a bare URL

### DIFF
--- a/app/Http/Controllers/OverlayTemplateController.php
+++ b/app/Http/Controllers/OverlayTemplateController.php
@@ -88,7 +88,7 @@ class OverlayTemplateController extends Controller
 
         return Inertia::render('templates/index', [
             'templates' => $templates,
-            'filters' => $request->only(['filter', 'search', 'type', 'sort', 'direction']),
+            'filters' => (object) $request->only(['filter', 'search', 'type', 'sort', 'direction']),
         ]);
     }
 

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,13 @@
 # CHANGELOG JULY 2026
 
+## July 6th, 2026 - fix(templates): stop the templates list crashing when a filter is changed from a bare URL
+
+Visiting `/templates` with no query string and then changing the Ownership (or any) filter threw a 500: `column "function sort() { [native code] }" does not exist`. The ORDER BY was literally receiving the string form of JavaScript's native `Array.prototype.sort`.
+
+- **Root cause**: an empty `$request->only([...])` returns a PHP `[]`, which serializes to a JSON array. On the Vue side `props.filters` then arrived as `[]` instead of `{}`, so `normalizeFilters` read `input?.sort` / `input?.filter` off an array and got the native `Array.prototype.sort` / `.filter` methods (truthy functions) instead of strings. That is also why both selects rendered "unset" - no `<option value>` matches a function. On the next `applyFilter`, `buildQuery` saw a truthy non-`'created_at'` value and serialized the function into the URL, which reached Postgres as an ORDER BY column name.
+- **Fix at the source** (`OverlayTemplateController@index`): cast the filters payload to `(object)` so the empty case serializes as `{}`, never `[]`.
+- **Defense in depth** (`templates/index.vue` `normalizeFilters`): only accept string values, so a non-string can never again leak into the query string regardless of the payload shape.
+
 ## July 5th, 2026 - docs(bot): rename the "Bot Commands" help page to "Bot Expressions"
 
 The bot's user-facing feature is branded "Expressions" - and the dashboard route to author them is `/settings/bot/expressions` - but the help doc still said "Bot Commands" and lived at `/help/bot/commands`. That discrepancy is gone: the page is now "Bot Expressions" throughout, at `/help/bot/expressions`.

--- a/resources/js/pages/templates/index.vue
+++ b/resources/js/pages/templates/index.vue
@@ -26,12 +26,17 @@ const props = defineProps<{
 }>();
 
 function normalizeFilters(input?: FiltersShape) {
+  // Only accept string values. An empty PHP `$request->only()` serializes to a
+  // JSON array, which arrives here as `[]` - reading `.sort`/`.filter` off that
+  // yields native Array methods (functions), not strings, which then leak into
+  // the query string and crash the ORDER BY. Guarding on typeof keeps us safe.
+  const str = (val: unknown) => (typeof val === 'string' ? val : '');
   return {
-    filter: input?.filter || 'all_templates',
-    search: input?.search || '',
-    type: input?.type || '',
-    sort: input?.sort || 'created_at',
-    direction: input?.direction || 'desc',
+    filter: str(input?.filter) || 'all_templates',
+    search: str(input?.search),
+    type: str(input?.type),
+    sort: str(input?.sort) || 'created_at',
+    direction: str(input?.direction) || 'desc',
   };
 }
 


### PR DESCRIPTION
## The bug

Visiting `/templates` with no query string, then changing the Ownership (or any) filter, threw a 500:

```
column "function sort() { [native code] }" does not exist
```

That string is JavaScript's native `Array.prototype.sort`, and it was reaching the SQL `ORDER BY`.

## Why it happened

1. On a bare visit the query string is empty, so `$request->only([...])` returns a PHP `[]`.
2. PHP serializes an empty array as JSON `[]`, so `props.filters` arrived in Vue as an **array**, not an object.
3. `normalizeFilters` read `input?.sort` / `input?.filter` off that array, which resolve to the native `Array.prototype.sort` / `.filter` **functions** (truthy) instead of strings. That is also why both selects rendered "unset" - no `<option value>` matches a function.
4. On the next `applyFilter`, `buildQuery`'s check `filters.value.sort !== 'created_at'` passed (a function is not equal to `'created_at'`), so it serialized the function into the URL, which reached Postgres as an `ORDER BY` column name.

## The fix

- **Root cause** (`OverlayTemplateController@index`): cast the filters payload to `(object)` so the empty case serializes as `{}`, never `[]`.
- **Defense in depth** (`templates/index.vue` `normalizeFilters`): only accept string values, so a non-string can never again leak into the query string regardless of the payload shape.

Changelog updated. Lint clean. Manually verified: changing filters from a bare `/templates` URL no longer 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)