### PR TITLE
Builder feedback round 1: canvas scaling fix + drag-to-move

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,14 @@
 # CHANGELOG JULY 2026
 
+## July 25th, 2026 - feat(builder): drag blocks around the canvas with the mouse
+
+Move/arrow buttons worked but felt like a miss the moment you tried them: you want to grab a block and drag it. Now you can - placed blocks drag cell-to-cell across the grid, live-snapping as you go.
+
+- **Drag semantics**: the block follows the pointer with its grab point preserved (no jump-to-top-left), snapped to grid cells. Every candidate position runs through the same `fits()` occupancy check as the buttons and keyboard, so a drag can never overlap another block - it visibly stops at the last valid cell and drops wherever it sits when you release. Dragging across an occupied region to free space on the other side works.
+- **Pointer capture** on the placement is the load-bearing trick: block previews are iframes, which swallow pointer events - capture keeps move/up events flowing for the whole drag, and retargets the trailing click so releasing over an empty cell does not pop the block picker or deselect.
+- **Click vs drag**: a 5px slack keeps plain clicks as select. Buttons, arrow keys, and Delete all still work; grab/grabbing cursors signal draggability; `touch-none` makes it behave on touch screens.
+- **State**: one new `moveTo(id, x, y)` absolute move in `useBuilderState` (the drag target), wired into both the standalone Builder page and the edit-page BuilderEditor (which marks the form dirty only when a block actually moved).
+
 ## July 25th, 2026 - fix(builder): canvas actually scales down to fit the page
 
 First bug from real use: the Builder canvas rendered at a full 1920x1080 with `scale` stuck at 1. Root cause was layout, not the ResizeObserver: `transform: scale()` never affects layout size, so the 1920px-wide grid still occupied 1920px, and the `1fr` column track in the page layout (`grid-cols-[1fr_280px]`) has an `auto` minimum that grows to fit content. The column stretched to 1920px, the wrapper measured 1920px, and `1920 / 1920 = 1`.

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,6 +1,11 @@
 # CHANGELOG JULY 2026
 
-## July 25th, 2026 - feat(builder): the Builder - compose overlays from blocks on a CSS grid (part 2)
+## July 25th, 2026 - fix(builder): canvas actually scales down to fit the page
+
+First bug from real use: the Builder canvas rendered at a full 1920x1080 with `scale` stuck at 1. Root cause was layout, not the ResizeObserver: `transform: scale()` never affects layout size, so the 1920px-wide grid still occupied 1920px, and the `1fr` column track in the page layout (`grid-cols-[1fr_280px]`) has an `auto` minimum that grows to fit content. The column stretched to 1920px, the wrapper measured 1920px, and `1920 / 1920 = 1`.
+
+- **Fix**: `minmax(0,1fr)` for the canvas column plus `min-w-0` on the column div, in both `builder/create.vue` and `BuilderEditor.vue` (edit page had the same bug). The column now sizes to the free space and the canvas scales to fit it.
+- **Checkerboard background**: swapped leftover Tailwind v3 `theme(colors.sidebar.DEFAULT)` syntax for `var(--color-sidebar)` + `bg-size-[32px_32px]` so the empty-canvas checkerboard actually renders in v4.
 
 The assembly gap, closed: users who do not write HTML can now open `/builder`, set up a grid (12x8 default on a 1920x1080 canvas), click a cell, pick a block from the library, and save. The output is a plain static overlay - the entire existing machinery (render pipeline, Add to OBS, tokens, alerts, controls, WebSockets) works on it untouched, because the Builder compiles down to the same three head/html/css strings every template is made of. Zero new engine.
 

--- a/resources/js/components/builder/BuilderCanvas.vue
+++ b/resources/js/components/builder/BuilderCanvas.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   cellClick: [x: number, y: number];
   select: [id: string | null];
+  moveTo: [id: string, x: number, y: number];
 }>();
 
 // The canvas renders at its real OBS size (1920x1080) and is scaled down with
@@ -32,7 +33,75 @@ onMounted(() => {
   if (wrapper.value) observer.observe(wrapper.value);
 });
 
-onBeforeUnmount(() => observer?.disconnect());
+onBeforeUnmount(() => {
+  observer?.disconnect();
+  endDrag();
+});
+
+// Drag-to-move. The placement captures the pointer; the canvas translates
+// pointer position to grid cells and asks the parent to move the block. The
+// parent validates against occupancy, so a drag can never overlap another
+// block - the block just stops at the last valid cell.
+const gridEl = ref<HTMLDivElement | null>(null);
+const drag = ref<{ id: string; startX: number; startY: number; offsetX: number; offsetY: number; active: boolean } | null>(null);
+
+function cellAt(e: PointerEvent): { x: number; y: number } | null {
+  if (!gridEl.value) return null;
+  const rect = gridEl.value.getBoundingClientRect();
+  if (rect.width === 0) return null;
+  // Work in unscaled canvas pixels; the live rect already reflects the scale.
+  const ux = (e.clientX - rect.left) / (rect.width / props.canvas.width);
+  const uy = (e.clientY - rect.top) / (rect.height / props.canvas.height);
+  const periodX = (props.canvas.width - props.grid.gap * (props.grid.cols - 1)) / props.grid.cols + props.grid.gap;
+  const periodY = (props.canvas.height - props.grid.gap * (props.grid.rows - 1)) / props.grid.rows + props.grid.gap;
+  return {
+    x: Math.min(Math.max(Math.floor(ux / periodX) + 1, 1), props.grid.cols),
+    y: Math.min(Math.max(Math.floor(uy / periodY) + 1, 1), props.grid.rows),
+  };
+}
+
+function onDragStart(id: string, e: PointerEvent) {
+  const placement = props.placements.find((p) => p.instance_id === id);
+  const cell = cellAt(e);
+  if (!placement || !cell) return;
+  emit('select', id);
+  drag.value = {
+    id,
+    startX: e.clientX,
+    startY: e.clientY,
+    // Where inside the block it was grabbed, so the block doesn't jump
+    // to put its top-left cell under the pointer.
+    offsetX: Math.min(Math.max(cell.x - placement.x, 0), placement.w - 1),
+    offsetY: Math.min(Math.max(cell.y - placement.y, 0), placement.h - 1),
+    active: false,
+  };
+  window.addEventListener('pointermove', onDragMove);
+  window.addEventListener('pointerup', endDrag);
+  window.addEventListener('pointercancel', endDrag);
+}
+
+function onDragMove(e: PointerEvent) {
+  const d = drag.value;
+  if (!d) return;
+  if (!d.active) {
+    // A few px of slack keeps plain clicks as select, not micro-drags.
+    if (Math.abs(e.clientX - d.startX) + Math.abs(e.clientY - d.startY) < 5) return;
+    d.active = true;
+  }
+  const placement = props.placements.find((p) => p.instance_id === d.id);
+  const cell = cellAt(e);
+  if (!placement || !cell) return;
+  const x = Math.min(Math.max(cell.x - d.offsetX, 1), props.grid.cols - placement.w + 1);
+  const y = Math.min(Math.max(cell.y - d.offsetY, 1), props.grid.rows - placement.h + 1);
+  if (x !== placement.x || y !== placement.y) emit('moveTo', d.id, x, y);
+}
+
+function endDrag() {
+  drag.value = null;
+  window.removeEventListener('pointermove', onDragMove);
+  window.removeEventListener('pointerup', endDrag);
+  window.removeEventListener('pointercancel', endDrag);
+}
 
 const emptyCells = computed(() => {
   const cells: Array<{ x: number; y: number }> = [];
@@ -49,6 +118,7 @@ const emptyCells = computed(() => {
   <div ref="wrapper" class="w-full">
     <div :style="{ height: `${canvas.height * scale}px` }" class="overflow-hidden">
       <div
+        ref="gridEl"
         class="grid border border-sidebar-border bg-[repeating-conic-gradient(var(--color-sidebar)_0%_25%,transparent_0%_50%)] bg-size-[32px_32px]"
         :style="{
           width: `${canvas.width}px`,
@@ -80,6 +150,7 @@ const emptyCells = computed(() => {
           :sample-data="sampleData"
           :selected="placement.instance_id === selectedId"
           @select="(id) => emit('select', id)"
+          @drag-start="onDragStart"
         />
       </div>
     </div>

--- a/resources/js/components/builder/BuilderCanvas.vue
+++ b/resources/js/components/builder/BuilderCanvas.vue
@@ -49,7 +49,7 @@ const emptyCells = computed(() => {
   <div ref="wrapper" class="w-full">
     <div :style="{ height: `${canvas.height * scale}px` }" class="overflow-hidden">
       <div
-        class="grid border border-sidebar-border bg-[repeating-conic-gradient(theme(colors.sidebar.DEFAULT)_0%_25%,transparent_0%_50%)] bg-[length:32px_32px] dark:bg-[repeating-conic-gradient(rgba(255,255,255,0.03)_0%_25%,transparent_0%_50%)]"
+        class="grid border border-sidebar-border bg-[repeating-conic-gradient(var(--color-sidebar)_0%_25%,transparent_0%_50%)] bg-size-[32px_32px]"
         :style="{
           width: `${canvas.width}px`,
           height: `${canvas.height}px`,

--- a/resources/js/components/builder/BuilderEditor.vue
+++ b/resources/js/components/builder/BuilderEditor.vue
@@ -100,8 +100,8 @@ defineExpose({
 </script>
 
 <template>
-  <div class="grid grid-cols-1 gap-4 p-4 xl:grid-cols-[1fr_280px]">
-    <div class="space-y-4">
+  <div class="grid grid-cols-1 gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+    <div class="min-w-0 space-y-4">
       <div class="border border-sidebar-border bg-sidebar-accent p-4">
         <BuilderGridControls :grid="state.grid.value" @update="setGrid" />
       </div>

--- a/resources/js/components/builder/BuilderEditor.vue
+++ b/resources/js/components/builder/BuilderEditor.vue
@@ -65,6 +65,9 @@ function markDirty<A extends unknown[]>(fn: (...args: A) => void) {
 }
 
 const move = markDirty((dx: number, dy: number) => state.move(state.selectedId.value!, dx, dy));
+const moveTo = (id: string, x: number, y: number) => {
+  if (state.moveTo(id, x, y)) emit('dirty');
+};
 const resize = markDirty((dw: number, dh: number) => state.resize(state.selectedId.value!, dw, dh));
 const removeSelected = markDirty(() => state.remove(state.selectedId.value!));
 const setGrid = markDirty(state.setGrid);
@@ -115,10 +118,11 @@ defineExpose({
         :is-cell-occupied="(x, y) => state.occupied(x, y)"
         @cell-click="onCellClick"
         @select="(id) => (state.selectedId.value = id)"
+        @move-to="moveTo"
       />
 
       <p class="text-sm text-muted-foreground">
-        Click an empty cell to place a block. Click a block to select it, then use the panel or arrow keys to move it,
+        Click an empty cell to place a block. Drag a block to move it, or select it and use the panel or arrow keys -
         Shift + arrows to resize, Delete to remove. Save with the page's Save button.
       </p>
     </div>

--- a/resources/js/components/builder/BuilderPlacement.vue
+++ b/resources/js/components/builder/BuilderPlacement.vue
@@ -8,7 +8,16 @@ const props = defineProps<{
   selected: boolean;
 }>();
 
-const emit = defineEmits<{ select: [id: string] }>();
+const emit = defineEmits<{ select: [id: string]; dragStart: [id: string, event: PointerEvent] }>();
+
+// Pointer capture keeps move/up events flowing to this element even when the
+// pointer crosses the preview iframes (which would otherwise swallow them).
+// The canvas owns the actual drag math; this just hands it the pointer.
+function onPointerDown(e: PointerEvent) {
+  if (e.button !== 0) return;
+  (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  emit('dragStart', props.placement.instance_id, e);
+}
 
 // Same preview approach as the template create page: substitute sample data
 // into the block's code, strip leftover tag/conditional markers for visual
@@ -41,10 +50,11 @@ const gridArea = computed(
   <div
     :style="{ gridArea }"
     :class="[
-      'relative min-h-0 min-w-0 cursor-pointer overflow-hidden transition-shadow',
+      'relative min-h-0 min-w-0 cursor-grab touch-none overflow-hidden transition-shadow select-none active:cursor-grabbing',
       selected ? 'ring-2 ring-violet-500 z-10' : 'ring-1 ring-sidebar-border/60 hover:ring-violet-400/60',
     ]"
     @click.stop="emit('select', placement.instance_id)"
+    @pointerdown="onPointerDown"
   >
     <iframe
       :srcdoc="previewDoc"

--- a/resources/js/composables/useBuilderState.ts
+++ b/resources/js/composables/useBuilderState.ts
@@ -96,6 +96,17 @@ export function useBuilderState(initial?: BuilderMetadata | null) {
         return placement;
     }
 
+    /** Absolute move (drag target). Returns true when the block actually moved. */
+    function moveTo(id: string, x: number, y: number): boolean {
+        const p = placements.value.find((pl) => pl.instance_id === id);
+        if (!p || (p.x === x && p.y === y)) return false;
+        if (!fits(x, y, p.w, p.h, id)) return false;
+        p.x = x;
+        p.y = y;
+        placements.value = [...placements.value];
+        return true;
+    }
+
     function move(id: string, dx: number, dy: number): void {
         const p = placements.value.find((pl) => pl.instance_id === id);
         if (!p) return;
@@ -168,6 +179,7 @@ export function useBuilderState(initial?: BuilderMetadata | null) {
         clampSpan,
         addPlacement,
         move,
+        moveTo,
         resize,
         remove,
         setGrid,

--- a/resources/js/pages/builder/create.vue
+++ b/resources/js/pages/builder/create.vue
@@ -212,8 +212,8 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
         </div>
       </div>
 
-      <div class="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_280px]">
-        <div class="space-y-4">
+      <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+        <div class="min-w-0 space-y-4">
           <div class="border border-sidebar-border bg-sidebar-accent p-4">
             <BuilderGridControls :grid="state.grid.value" @update="state.setGrid" />
           </div>

--- a/resources/js/pages/builder/create.vue
+++ b/resources/js/pages/builder/create.vue
@@ -227,10 +227,11 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
             :is-cell-occupied="(x, y) => state.occupied(x, y)"
             @cell-click="onCellClick"
             @select="(id) => (state.selectedId.value = id)"
+            @move-to="(id, x, y) => state.moveTo(id, x, y)"
           />
 
           <p class="text-sm text-muted-foreground">
-            Click an empty cell to place a block. Click a block to select it, then use the panel or arrow keys to move it,
+            Click an empty cell to place a block. Drag a block to move it, or select it and use the panel or arrow keys -
             Shift + arrows to resize, Delete to remove.
           </p>
         </div>


### PR DESCRIPTION
## Summary

First round of fixes and polish from real use of the Builder v1 (merged in #154).

### fix(builder): canvas actually scales down to fit the page

The canvas rendered at a full 1920x1080 with `scale` stuck at 1. Root cause was layout, not the ResizeObserver: `transform: scale()` never affects layout size, so the 1920px-wide grid still occupied 1920px, and the bare `1fr` column track (`grid-cols-[1fr_280px]`) has an `auto` minimum that grows to fit content. The column stretched to 1920px, the wrapper measured 1920px, and `1920 / 1920 = 1`.

- `minmax(0,1fr)` for the canvas column + `min-w-0` on the column div, in both `builder/create.vue` and `BuilderEditor.vue`
- Also swaps leftover Tailwind v3 `theme()` syntax for `var(--color-sidebar)` so the empty-canvas checkerboard renders in v4

### feat(builder): drag blocks around the canvas with the mouse

Placed blocks now drag cell-to-cell across the grid with live snapping, alongside the existing panel buttons and arrow keys.

- The block follows the pointer with its grab point preserved (no jump-to-top-left)
- Every candidate position runs through the same `fits()` occupancy check as the buttons/keyboard, so a drag can never overlap another block - it visibly stops at the last valid cell. Dragging across an occupied region to free space beyond works
- Pointer capture on the placement keeps events flowing over the iframe previews (which otherwise swallow them) and retargets the trailing click, so releasing over an empty cell does not pop the block picker
- 5px slack keeps plain clicks as select; grab/grabbing cursors; `touch-none` for touch screens
- One new `moveTo(id, x, y)` absolute move in `useBuilderState`; the edit-page editor marks the form dirty only when a block actually moved

## Test plan

- Open `/builder` on a wide (xl+) viewport: the grid scales to fit the column instead of rendering at 1920px with horizontal scroll
- Place two blocks, drag one around: snaps to cells, refuses to overlap the other, drops where it sits
- Plain click still selects; arrow keys / Shift + arrows / Delete unchanged
- Same behavior on the edit page grid editor for a composed overlay; dragging enables Save
- ESLint clean, vue-tsc has no new errors (the `events-feed/app.ts` pusher-js typing error is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)