### PR TITLE
Builder feedback round 2: block controls visibility + stray control surfacing

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,6 +1,13 @@
 # CHANGELOG JULY 2026
 
-## July 25th, 2026 - fix(builder): block controls show up on the Controls tab right after save
+## July 25th, 2026 - feat(builder): surface controls left behind by removed blocks
+
+Removing a block from the canvas keeps the controls it brought along - deliberately, so a counter at 500 survives a layout experiment and re-adding the block picks it right back up. But the leftovers were invisible, and a few removed blocks could quietly pile up a heap of stray controls. Inform, don't gate:
+
+- **Badge**: on builder-composed overlays, the Controls tab flags template controls whose `c:{key}` tag no longer appears anywhere in the compiled output with "Not used by any block" (amber pill, tooltip explains the value is preserved and how to reattach or delete). Computed purely client-side from `template_tags`, which the server already re-extracts on every save - including piped, defaulted, and `[[[if:...]]]` conditional references, so a control used only in a condition is never falsely flagged.
+- **Save toast**: a builder-mode save that leaves orphans behind says so - "Overlay saved. N controls are no longer used by any block - review them on the Controls tab."
+- No auto-delete, by design: shared keys mean another block may still use the control, expressions and system keys (like `tts`) can reference controls outside the overlay HTML, and silent data loss is worse than a visible leftover. Deletion stays one deliberate click on the Controls tab.
+- Zero backend changes.
 
 Placing a block that carries controls, saving, and opening the Controls tab showed... nothing until a hard refresh. Two stacked causes on the edit page: the controls import fires in `onSuccess`, which is AFTER Inertia already delivered the refreshed page props (so `props.controls` predates the import), and the Controls/Values tabs render from `localControls`, which is copied from props once at mount and never re-synced.
 

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,6 +1,12 @@
 # CHANGELOG JULY 2026
 
-## July 25th, 2026 - feat(builder): drag blocks around the canvas with the mouse
+## July 25th, 2026 - fix(builder): block controls show up on the Controls tab right after save
+
+Placing a block that carries controls, saving, and opening the Controls tab showed... nothing until a hard refresh. Two stacked causes on the edit page: the controls import fires in `onSuccess`, which is AFTER Inertia already delivered the refreshed page props (so `props.controls` predates the import), and the Controls/Values tabs render from `localControls`, which is copied from props once at mount and never re-synced.
+
+- **Fix**: the import endpoint already returns the created control models, so the `.then` now merges `data.created` into `localControls` - no extra request, no server change. The tab contents are `v-if`-mounted per switch, so they pick the merged list up immediately.
+- Controls are still created at save time, not at placement - placing a block and abandoning the session must not leave stray controls behind.
+- The standalone `/builder` page was never affected (it navigates to the show page with a fresh load after save).
 
 Move/arrow buttons worked but felt like a miss the moment you tried them: you want to grab a block and drag it. Now you can - placed blocks drag cell-to-cell across the grid, live-snapping as you go.
 

--- a/resources/js/components/ControlsManager.vue
+++ b/resources/js/components/ControlsManager.vue
@@ -105,6 +105,20 @@ function snippetKey(ctrl: OverlayControl): string {
   return ctrl.source_managed && ctrl.source ? `${ctrl.source}:${ctrl.key}` : ctrl.key;
 }
 
+// Builder-composed overlays only: flag template controls whose tag no longer
+// appears in the compiled output, i.e. every block that used them has been
+// removed from the canvas. The value is deliberately preserved (re-adding the
+// block reattaches it) - this badge just makes the leftovers visible so the
+// user can decide. template_tags is re-extracted server-side on every save.
+const builderComposed = computed(() => !!props.template?.metadata?.builder);
+
+function isBlockOrphan(ctrl: OverlayControl): boolean {
+  const tags = props.template?.template_tags;
+  if (!builderComposed.value || !Array.isArray(tags)) return false;
+  if (ctrl.source || ctrl.overlay_template_id === null) return false;
+  return !tags.includes(`c:${ctrl.key}`);
+}
+
 async function copySnippet(ctrl: OverlayControl) {
   const key = snippetKey(ctrl);
   try {
@@ -408,6 +422,13 @@ const controlsCounter = computed(() => controls.value.length);
                     >
                       <LockIcon class="h-2.5 w-2.5" />
                       {{ SERVICE_LABELS[ctrl.source] ?? ctrl.source }}
+                    </span>
+                    <span
+                      v-if="isBlockOrphan(ctrl)"
+                      class="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-600 dark:text-amber-400"
+                      title="No block on the canvas references this control. Its value is preserved - re-adding a block with the same key picks it back up, or delete it here if you no longer need it."
+                    >
+                      Not used by any block
                     </span>
                   </div>
                   <p v-if="ctrl.description" class="text-xs text-foreground whitespace-pre-line">{{ ctrl.description }}</p>

--- a/resources/js/pages/templates/edit.vue
+++ b/resources/js/pages/templates/edit.vue
@@ -424,12 +424,20 @@ const submitForm = async () => {
 
       // Import controls for blocks placed this session (existing keys are
       // skipped server-side - same semantics as the Copy import wizard).
+      // This runs AFTER Inertia already delivered the refreshed props, so the
+      // created controls must be merged into localControls by hand - the
+      // Controls and Values tabs render from it and remount per tab switch.
       if (builderMode.value && builderEditor.value) {
         const controls = builderEditor.value.controlsForImport();
         if (controls.length) {
           axios
             .post(`/templates/${props.template.id}/controls/import`, {
               controls: controls.map((c) => ({ ...c, action: 'create' })),
+            })
+            .then(({ data }) => {
+              if (data?.created?.length) {
+                localControls.value = [...localControls.value, ...data.created];
+              }
             })
             .catch(() => pushToast('Overlay saved, but importing block controls failed.', 'warning'));
         }

--- a/resources/js/pages/templates/edit.vue
+++ b/resources/js/pages/templates/edit.vue
@@ -376,6 +376,20 @@ const openExternalLink = (link: any, target: string) => window.open(link, target
 const suggestionModalOpen = ref(false);
 const showSuggestionLink = ref(false);
 
+// Template controls whose tag no longer appears in the compiled output, i.e.
+// every block that used them was removed from the canvas. Values are kept on
+// purpose (re-adding the block reattaches them); the save toast and a badge
+// on the Controls tab surface them so the user can clean up deliberately.
+// Runs against the fresh post-save props: Inertia swaps them in before
+// onSuccess, and the server re-extracts template_tags on every content save.
+function countBlockOrphans(): number {
+  const tags = props.template?.template_tags;
+  if (!builderMode.value || !Array.isArray(tags)) return 0;
+  return localControls.value.filter(
+    (c) => !c.source && c.overlay_template_id !== null && !tags.includes(`c:${c.key}`),
+  ).length;
+}
+
 const submitForm = async () => {
   // Builder mode: recompose the grid + placements into head/html/css first,
   // so the rest of the save path (sanitize, compile, put) is identical.
@@ -455,7 +469,14 @@ const submitForm = async () => {
         );
       } else {
         showSuggestionLink.value = false;
-        pushToast('Overlay saved successfully!', 'success');
+        const orphans = countBlockOrphans();
+        if (orphans === 1) {
+          pushToast('Overlay saved. 1 control is no longer used by any block - review it on the Controls tab.', 'info');
+        } else if (orphans > 1) {
+          pushToast(`Overlay saved. ${orphans} controls are no longer used by any block - review them on the Controls tab.`, 'info');
+        } else {
+          pushToast('Overlay saved successfully!', 'success');
+        }
       }
     },
     onError: () => pushToast('Failed to save overlay.', 'error')

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -160,6 +160,7 @@ export interface OverlayTemplate {
     block?: { default_span?: { w: number; h: number }; category?: string };
     builder?: BuilderMetadata;
   } | null;
+  template_tags?: string[] | null;
   owner?: {
     id: number;
     name: string;


### PR DESCRIPTION
## Summary

Two control-related findings from real Builder use, both frontend-only.

### fix(builder): block controls show up on the Controls tab right after save

Placing a block that carries controls, saving, and opening the Controls tab showed nothing until a hard refresh. Two stacked causes on the edit page: the controls import fires in `onSuccess` - after Inertia already delivered the refreshed props, so `props.controls` predates the import - and the Controls/Values tabs render from `localControls`, which is copied from props once at mount and never re-synced.

The import endpoint already returns the created control models, so the `.then` now merges `data.created` into `localControls`. The tab contents are `v-if`-mounted per switch, so they pick the merged list up immediately. No extra request, no server change. The standalone `/builder` page was never affected (fresh page load after save).

### feat(builder): surface controls left behind by removed blocks

Removing a block keeps the controls it brought along - deliberately, so a counter at 500 survives a layout experiment and re-adding the block picks it right back up. But the leftovers were invisible and could quietly pile up. Inform, don't gate:

- **Badge**: on builder-composed overlays, the Controls tab flags template controls whose `c:{key}` tag no longer appears in the compiled output with an amber "Not used by any block" pill (tooltip explains the value is preserved, and how to reattach or delete)
- **Toast**: a builder-mode save that strands controls says so: "Overlay saved. N controls are no longer used by any block - review them on the Controls tab"
- Computed purely client-side from `template_tags`, which the server re-extracts on every content save - including piped, defaulted, and `[[[if:...]]]` conditional references, so a control used only in a condition is never falsely flagged
- No auto-delete, by design: shared keys mean another block may still use the control, and expressions or system keys (like `tts`) can reference controls outside the overlay HTML. Deletion stays one deliberate click

## Test plan

- Place a block with controls in the edit-page Builder, save, open Controls tab: the imported control is there without a refresh
- Remove that block, save: toast counts the stray, Controls tab badges it
- Delete the badged control (count drops) or re-place the block and save (badge gone, value intact)
- Non-builder overlays: no badge, unchanged save toast
- ESLint + vue-tsc clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)