### PR TITLE
Copy any static overlay as a Block + breadcrumb fix + sidebar link

### DIFF
--- a/app/Http/Controllers/OverlayTemplateController.php
+++ b/app/Http/Controllers/OverlayTemplateController.php
@@ -1267,7 +1267,15 @@ class OverlayTemplateController extends Controller
             abort(403, 'Cannot fork private template');
         }
 
-        $fork = $template->fork($request->user());
+        $validated = $request->validate([
+            'type' => 'sometimes|nullable|in:static,block',
+        ]);
+
+        // Only a static source offers a target-type choice; alerts and blocks
+        // always copy as themselves.
+        $asType = $template->type === 'static' ? ($validated['type'] ?? null) : null;
+
+        $fork = $template->fork($request->user(), $asType);
 
         $connectedServices = ExternalIntegration::where('user_id', $request->user()->id)
             ->where('enabled', true)

--- a/app/Models/OverlayTemplate.php
+++ b/app/Models/OverlayTemplate.php
@@ -383,11 +383,25 @@ class OverlayTemplate extends Model
     /**
      * Fork this template
      */
-    public function fork(User $user): self
+    public function fork(User $user, ?string $asType = null): self
     {
         $fork = $this->replicate();
         $fork->owner_id = $user->id;
         $fork->fork_of_id = $this->id;
+
+        // Copy-as-conversion: a static overlay can be copied as a block for
+        // the Builder. A Builder-composed source keeps its compiled output but
+        // drops the grid editing state - a block is a leaf piece, not a grid
+        // of other blocks.
+        if ($asType !== null && $asType !== $this->type) {
+            $fork->type = $asType;
+            if ($asType === 'block' && isset($fork->metadata['builder'])) {
+                $metadata = $fork->metadata;
+                unset($metadata['builder']);
+                $fork->metadata = $metadata ?: null;
+            }
+        }
+
         // Create the forked name and limit to 100 characters
         $copiedName = 'Copy: '.$this->owner->name.' - '.$this->name;
         if (strlen($copiedName) > 70) {

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,6 +1,14 @@
 # CHANGELOG JULY 2026
 
-## July 25th, 2026 - feat(builder): surface controls left behind by removed blocks
+## July 25th, 2026 - feat(templates): copy any static overlay as a Block
+
+The Copy action on a static overlay now asks what the copy should become: a static overlay (the existing behavior) or a Block for the Builder. That turns the entire public library of static overlays into potential Builder material - see a community overlay you like, copy it as a Block, place it on your grid.
+
+- **Choice dialog** on the show and edit pages' Copy action, static templates only. Alerts (and blocks) copy as themselves with the existing confirm, no dialog.
+- **Backend**: the fork endpoint accepts an optional `type` (`static`/`block`, anything else 422s) which is only honored when the source is static - alerts can never be converted into, or out of, anything. Copying a Builder-composed overlay as a Block keeps the compiled output but drops the grid editing state (a block is a leaf piece, not a grid of other blocks); copying it as a static overlay keeps the grid fully editable.
+- Controls still flow through the existing import wizard regardless of target type - blocks carry controls, so nothing changes there.
+- The quick-copy actions on the templates table/cards and the public preview page keep the direct static-to-static behavior (they are full-navigation form posts, no dialog surface).
+- **Tests**: 5 new in BlockTemplateTest - static-to-block, default stays static, builder-composed conversion (grid state dropped as block, kept as static), alert ignores the requested type, `type=alert` rejected. 14/14 green.
 
 Removing a block from the canvas keeps the controls it brought along - deliberately, so a counter at 500 survives a layout experiment and re-adding the block picks it right back up. But the leftovers were invisible, and a few removed blocks could quietly pile up a heap of stray controls. Inform, don't gate:
 

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,6 +1,12 @@
 # CHANGELOG JULY 2026
 
-## July 25th, 2026 - feat(templates): copy any static overlay as a Block
+## July 25th, 2026 - fix(breadcrumbs): a copied-as-Block template no longer inherits the source's list crumb
+
+Copy a static overlay as a Block and the new block's breadcrumb said "My static overlays" forever, even when you clicked it from the My blocks list. Root cause in `useListContext`: the show page freezes the freshest global list context for a template on its first mount - and right after a copy, the freshest list you visited is still the SOURCE's list. The frozen origin then wins over every later navigation by design, so the wrong crumb stuck for the whole tab session.
+
+- **Fix**: a stored context (frozen or global) is only trusted when the template could actually appear in the list it points to - the candidate's `type`/`filter` params are checked against the template's own type and ownership. Impossible contexts are rejected and the frozen origin is re-written, which also self-heals any already-poisoned sessionStorage entries.
+- Same fix covers the unreported sibling: creating a block right after browsing the static list would freeze the wrong crumb the same way.
+- `captureListContext` now takes the template's raw attributes and derives the fallback itself; the crumb-and-delete-redirect agreement (the reason freezing exists) is unchanged.
 
 The Copy action on a static overlay now asks what the copy should become: a static overlay (the existing behavior) or a Block for the Builder. That turns the entire public library of static overlays into potential Builder material - see a community overlay you like, copy it as a Block, place it on your grid.
 

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -17,6 +17,7 @@ import {
   Bell,
   BotIcon,
   BookOpen,
+  Blocks,
   Brackets,
   FileText,
   HashIcon,
@@ -60,6 +61,7 @@ const mainNavItems = computed<NavItem[]>(() =>
     ? [
         { title: 'Overlays', href: '/templates?filter=mine&type=static', icon: Layers },
         { title: 'Alerts', href: '/templates?filter=mine&type=alert', icon: Bell },
+        { title: 'Blocks', href: '/templates?filter=mine&type=block', icon: Blocks },
         { title: 'Triggers', href: route('events.index'), icon: Megaphone },
         { title: 'Lists', href: route('lists.index'), icon: ListIcon },
         { title: 'Kits', href: route('kits.index'), icon: LayoutGrid }

--- a/resources/js/components/templates/CopyTypeDialog.vue
+++ b/resources/js/components/templates/CopyTypeDialog.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Blocks, Layers } from '@lucide/vue';
+
+// Shown when copying a static template: the copy can stay a static overlay
+// or become a Builder block. Alerts and blocks never see this dialog.
+defineProps<{ open: boolean }>();
+
+const emit = defineEmits<{
+  'update:open': [value: boolean];
+  choose: [type: 'static' | 'block'];
+}>();
+</script>
+
+<template>
+  <Dialog :open="open" @update:open="emit('update:open', $event)">
+    <DialogContent class="max-w-lg">
+      <DialogHeader>
+        <DialogTitle>Copy this overlay</DialogTitle>
+      </DialogHeader>
+
+      <p class="text-sm text-foreground">Choose what your copy becomes.</p>
+
+      <div class="grid gap-3 sm:grid-cols-2">
+        <button
+          type="button"
+          class="cursor-pointer border border-sidebar-border bg-sidebar-accent p-4 text-left transition-colors hover:border-violet-400 hover:bg-violet-400/10"
+          @click="emit('choose', 'static')"
+        >
+          <Layers class="mb-2 h-5 w-5 text-violet-400" />
+          <span class="block font-medium text-accent-foreground">Static overlay</span>
+          <span class="mt-1 block text-xs text-muted-foreground">An exact copy to edit and add to OBS.</span>
+        </button>
+
+        <button
+          type="button"
+          class="cursor-pointer border border-sidebar-border bg-sidebar-accent p-4 text-left transition-colors hover:border-violet-400 hover:bg-violet-400/10"
+          @click="emit('choose', 'block')"
+        >
+          <Blocks class="mb-2 h-5 w-5 text-violet-400" />
+          <span class="block font-medium text-accent-foreground">Block</span>
+          <span class="mt-1 block text-xs text-muted-foreground">A reusable piece to place on a grid in the Builder.</span>
+        </button>
+      </div>
+
+      <DialogFooter>
+        <button type="button" class="btn btn-cancel cursor-pointer" @click="emit('update:open', false)">Cancel</button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/resources/js/composables/useListContext.ts
+++ b/resources/js/composables/useListContext.ts
@@ -17,10 +17,6 @@ export type ListContext = { title: string; href: string };
 const GLOBAL_KEY = 'templates_list_context';
 const originKey = (templateId: number | string) => `template_origin:${templateId}`;
 
-function fallback(): ListContext {
-  return { title: 'My overlays', href: route('templates.index') };
-}
-
 // Build a deterministic breadcrumb context from a template's own attributes, for
 // when there is no recorded navigation history (direct URL, fresh tab, or
 // straight after create - sessionStorage is per-tab and dies with the tab).
@@ -74,20 +70,44 @@ export function recordListContext(ctx: ListContext): void {
   write(GLOBAL_KEY, ctx);
 }
 
+// A stored context is only trusted when this template could actually appear in
+// the list it points to - a crumb must never claim a list that cannot contain
+// the page it sits on. The canonical trap: copy a static overlay as a Block,
+// and the new block's show page would freeze the SOURCE's list ("My static
+// overlays" - still the freshest index visit at that moment) as its origin,
+// then serve that wrong crumb forever. Checking the candidate's filter params
+// against the template's own type + ownership rejects impossible contexts and
+// self-heals any stale frozen origin already sitting in sessionStorage.
+function matchesTemplate(ctx: ListContext, template: { type?: string | null; ownedByMe: boolean }): boolean {
+  try {
+    const params = new URL(ctx.href, window.location.origin).searchParams;
+    const typeParam = params.get('type');
+    if (typeParam && template.type && typeParam !== template.type) return false;
+    if (params.get('filter') === 'mine' && !template.ownedByMe) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Called once at mount on show/edit. Returns the context frozen for this
 // template, freezing the current global context on first visit. Subsequent
 // mounts for the same template (refresh, back/forward) return the frozen value.
 //
 // Precedence: a previously frozen origin wins, then the live list you navigated
-// from (GLOBAL_KEY), then `derived` (built from the template itself for cold
-// direct-paste / post-create), then the generic fallback. This keeps the "came
-// from this list" semantic when you actually arrived via the index, while giving
-// a direct visit an accurate contextual crumb instead of the generic one.
-export function captureListContext(templateId: number | string, derived?: ListContext): ListContext {
+// from (GLOBAL_KEY), then a context derived from the template itself (cold
+// direct-paste, fresh tab, straight after create or copy) - but a frozen or
+// global candidate is skipped when the template could not appear in that list
+// (see matchesTemplate above).
+export function captureListContext(
+  templateId: number | string,
+  template: { type?: string | null; ownedByMe: boolean },
+): ListContext {
   const frozen = read(originKey(templateId));
-  if (frozen) return frozen;
+  if (frozen && matchesTemplate(frozen, template)) return frozen;
 
-  const current = read(GLOBAL_KEY) ?? derived ?? fallback();
+  const global = read(GLOBAL_KEY);
+  const current = global && matchesTemplate(global, template) ? global : deriveListContext(template);
   write(originKey(templateId), current);
   return current;
 }

--- a/resources/js/composables/useTemplateActions.ts
+++ b/resources/js/composables/useTemplateActions.ts
@@ -54,11 +54,13 @@ export function useTemplateActions(template: any, options: TemplateActionOptions
     return true;
   };
 
-  const forkTemplate = async () => {
-    if (!confirm('Copy this template?')) return;
+  // Copy-type choice dialog (static templates only): the copy can become a
+  // static overlay or a Builder block. Alerts and blocks copy as themselves.
+  const copyChoiceOpen = ref(false);
 
+  const performFork = async (payload: Record<string, unknown> = {}) => {
     try {
-      const response = await axios.post(route('templates.fork', template));
+      const response = await axios.post(route('templates.fork', template), payload);
       const data = response.data;
 
       if (!openWizardFromPayload(data)) {
@@ -70,6 +72,20 @@ export function useTemplateActions(template: any, options: TemplateActionOptions
       toastMessage.value = 'Failed to copy template.';
       toastType.value = 'error';
     }
+  };
+
+  const forkTemplate = async () => {
+    if (template?.type === 'static') {
+      copyChoiceOpen.value = true;
+      return;
+    }
+    if (!confirm('Copy this template?')) return;
+    await performFork();
+  };
+
+  const forkAs = async (type: 'static' | 'block') => {
+    copyChoiceOpen.value = false;
+    await performFork({ type });
   };
 
   const deleteTemplate = async () => {
@@ -104,6 +120,8 @@ export function useTemplateActions(template: any, options: TemplateActionOptions
     canDelete,
     previewTemplate,
     forkTemplate,
+    forkAs,
+    copyChoiceOpen,
     deleteTemplate,
     toastMessage,
     toastType,

--- a/resources/js/pages/templates/edit.vue
+++ b/resources/js/pages/templates/edit.vue
@@ -13,6 +13,7 @@ import TemplateScreenshot from '@/components/templates/TemplateScreenshot.vue';
 import ControlsManager from '@/components/ControlsManager.vue';
 import ControlPanel from '@/components/ControlPanel.vue';
 import ForkImportWizard from '@/components/ForkImportWizard.vue';
+import CopyTypeDialog from '@/components/templates/CopyTypeDialog.vue';
 import IntegrationSuggestionModal from '@/components/IntegrationSuggestionModal.vue';
 import TemplateMeta from '@/components/TemplateMeta.vue';
 import TriggerManager, { type TriggerData } from '@/components/TriggerManager.vue';
@@ -135,6 +136,8 @@ const {
   canDelete,
   previewTemplate,
   forkTemplate,
+  forkAs,
+  copyChoiceOpen,
   deleteTemplate,
   toastMessage: templateToastMessage,
   toastType: templateToastType,
@@ -535,6 +538,7 @@ onMounted(() => {
       :required-services="forkWizardRequiredServices"
       :connected-services="forkWizardConnectedServices"
     />
+    <CopyTypeDialog v-model:open="copyChoiceOpen" @choose="forkAs" />
     <div class="p-4">
       <!-- Header -->
       <div class="mb-6 flex items-start justify-between">

--- a/resources/js/pages/templates/edit.vue
+++ b/resources/js/pages/templates/edit.vue
@@ -51,7 +51,7 @@ import { sanitizeHtmlFields } from '@/utils/sanitize';
 import { compileTailwindCss } from '@/utils/compileTailwind';
 import { useLinkWarning } from '@/composables/useLinkWarning';
 import { useTemplateActions } from '@/composables/useTemplateActions';
-import { captureListContext, deriveListContext } from '@/composables/useListContext';
+import { captureListContext } from '@/composables/useListContext';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -201,7 +201,7 @@ function ejectToCodeEditor() {
 // the template itself. The edit page is owner-only, so ownership is always "My".
 const listContext = captureListContext(
   props.template?.id,
-  deriveListContext({ type: props.template?.type, ownedByMe: true }),
+  { type: props.template?.type, ownedByMe: true },
 );
 
 const breadcrumbs: BreadcrumbItem[] = [

--- a/resources/js/pages/templates/show.vue
+++ b/resources/js/pages/templates/show.vue
@@ -10,6 +10,7 @@ import TriggerManager, { type TriggerData } from '@/components/TriggerManager.vu
 import { Dialog, DialogContent, DialogFooter, DialogTitle } from '@/components/ui/dialog';
 import ControlPanel from '@/components/ControlPanel.vue';
 import ForkImportWizard from '@/components/ForkImportWizard.vue';
+import CopyTypeDialog from '@/components/templates/CopyTypeDialog.vue';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
 import {
   DropdownMenu,
@@ -143,6 +144,8 @@ const {
   canDelete,
   previewTemplate,
   forkTemplate,
+  forkAs,
+  copyChoiceOpen,
   deleteTemplate,
   toastMessage,
   toastType,
@@ -213,6 +216,7 @@ const breadcrumbs: BreadcrumbItem[] = [
       :required-services="forkWizardRequiredServices"
       :connected-services="forkWizardConnectedServices"
     />
+    <CopyTypeDialog v-model:open="copyChoiceOpen" @choose="forkAs" />
 
     <div class="p-4">
       <!-- Header -->

--- a/resources/js/pages/templates/show.vue
+++ b/resources/js/pages/templates/show.vue
@@ -39,7 +39,7 @@ import {
 } from '@lucide/vue';
 import TemplateMeta from '@/components/TemplateMeta.vue';
 import { useTemplateActions } from '@/composables/useTemplateActions';
-import { captureListContext, deriveListContext } from '@/composables/useListContext';
+import { captureListContext } from '@/composables/useListContext';
 import { VisuallyHidden } from 'reka-ui';
 import { Badge } from '@/components/ui/badge';
 
@@ -188,7 +188,7 @@ const copyToClipboard = (url: string, shownValue: string) => {
 // to a crumb derived from the template's own type + ownership.
 const listContext = captureListContext(
   props.template?.id,
-  deriveListContext({ type: props.template?.type, ownedByMe: props.canEdit }),
+  { type: props.template?.type, ownedByMe: props.canEdit },
 );
 
 const breadcrumbs: BreadcrumbItem[] = [

--- a/tests/Feature/BlockTemplateTest.php
+++ b/tests/Feature/BlockTemplateTest.php
@@ -155,6 +155,81 @@ test('the static overlay picker on the alert edit page excludes blocks', functio
     );
 });
 
+// ──────────────────────────────────────────────────────────────────────────────
+// Copy as: static templates can be copied as blocks
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('copying a static template as a block yields a block', function () {
+    $user = makeBlockUser();
+    $this->actingAs($user);
+    $static = makeTemplateOfType($user, 'static');
+
+    $response = $this->postJson("/templates/{$static->id}/fork", ['type' => 'block']);
+
+    $response->assertOk();
+    $fork = OverlayTemplate::find($response->json('template.id'));
+    expect($fork->type)->toBe('block')
+        ->and($static->fresh()->type)->toBe('static');
+});
+
+test('copying a static template without a type stays static', function () {
+    $user = makeBlockUser();
+    $this->actingAs($user);
+    $static = makeTemplateOfType($user, 'static');
+
+    $response = $this->postJson("/templates/{$static->id}/fork");
+
+    expect(OverlayTemplate::find($response->json('template.id'))->type)->toBe('static');
+});
+
+test('copying a builder composed overlay as a block drops the grid state', function () {
+    $user = makeBlockUser();
+    $this->actingAs($user);
+    $builderMetadata = [
+        'version' => 1,
+        'grid' => ['cols' => 12, 'rows' => 8, 'gap' => 8],
+        'canvas' => ['width' => 1920, 'height' => 1080],
+        'placements' => [],
+    ];
+    $static = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => 'static',
+        'slug' => 'composed-'.fake()->unique()->lexify('????????'),
+        'metadata' => ['builder' => $builderMetadata],
+    ]);
+
+    $asBlock = OverlayTemplate::find(
+        $this->postJson("/templates/{$static->id}/fork", ['type' => 'block'])->json('template.id')
+    );
+    $asStatic = OverlayTemplate::find(
+        $this->postJson("/templates/{$static->id}/fork", ['type' => 'static'])->json('template.id')
+    );
+
+    expect($asBlock->type)->toBe('block')
+        ->and($asBlock->metadata)->toBeNull()
+        // Copied as static, the grid stays editable in the Builder.
+        ->and($asStatic->metadata['builder'])->toBe($builderMetadata);
+});
+
+test('an alert copy ignores the requested type', function () {
+    $user = makeBlockUser();
+    $this->actingAs($user);
+    $alert = makeTemplateOfType($user, 'alert');
+
+    $response = $this->postJson("/templates/{$alert->id}/fork", ['type' => 'block']);
+
+    expect(OverlayTemplate::find($response->json('template.id'))->type)->toBe('alert');
+});
+
+test('copying as an alert is rejected', function () {
+    $user = makeBlockUser();
+    $this->actingAs($user);
+    $static = makeTemplateOfType($user, 'static');
+
+    $this->postJson("/templates/{$static->id}/fork", ['type' => 'alert'])->assertUnprocessable();
+});
+
 test('a block renders through the overlay pipeline for its owner', function () {
     $this->mock(TwitchTokenService::class, function ($mock) {
         $mock->shouldReceive('ensureValidToken')->andReturnTrue();


### PR DESCRIPTION
## Summary

### feat(templates): copy any static overlay as a Block

The Copy action on a static overlay now asks what the copy should become: a static overlay (existing behavior) or a Block for the Builder. That turns the entire public library of static overlays into potential Builder material - see a community overlay you like, copy it as a Block, place it on your grid.

- Choice dialog on the show and edit pages' Copy action, static templates only. Alerts and blocks copy as themselves with the existing confirm, no dialog
- The fork endpoint accepts an optional `type` (`static`/`block`, anything else 422s), honored only when the source is static - nothing can be converted into or out of an alert, even by hand-crafted requests
- Copying a Builder-composed overlay **as a Block** keeps the compiled output but drops the grid editing state (a block is a leaf piece, not a grid of other blocks); copying it **as static** keeps the grid fully editable
- Controls still flow through the existing import wizard regardless of target type
- The quick-copy actions on the templates table/cards and public preview keep the direct static-to-static behavior (full-navigation form posts, no dialog surface)

### fix(breadcrumbs): a copied-as-Block template no longer inherits the source's list crumb

Copying a static overlay as a Block froze the SOURCE's list ("My static overlays") as the new block's breadcrumb origin - the freshest global list context at first mount was still the list the copy was made from, and a frozen origin wins over later navigation by design. `captureListContext` now validates frozen and global candidates against the template's own type + ownership, rejects contexts whose list could not contain the template, and re-freezes. Self-heals already-poisoned sessionStorage entries, and fixes the same bug on fresh block creation. The crumb-and-delete-redirect agreement that freezing exists for is unchanged.

### feat(nav): direct link to Blocks in the sidebar

Added a direct link to the Block template type in the "My Stuff" section of the main app navigation.

## Test plan

- Copy a static overlay both ways: as static (unchanged behavior) and as Block (lands as `type=block`, appears in the /builder picker)
- Copy an alert: no dialog, copies as alert; `type=alert` via API is rejected (422)
- Copy a Builder-composed overlay as Block (no grid editor on the copy) and as static (grid editor intact)
- Fresh copied block shows "My blocks" breadcrumb immediately and after navigating from /templates?filter=mine&type=block
- Tests: 5 new in BlockTemplateTest covering the conversion matrix, 14/14 green; ESLint + vue-tsc + Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)