### PR TITLE
Builder: refresh placed blocks from source + 'used by block' pill

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,6 +1,8 @@
 # CHANGELOG JULY 2026
 
-## July 25th, 2026 - feat(builder): refresh placed blocks from their source
+## July 25th, 2026 - feat(builder): "used by block" pill on the Controls tab
+
+On builder-composed overlays, template controls that a placed block references now carry a pill in the same visual family as the service-managed label - block icon plus the block's name (first name +N when several blocks share the key), tooltip listing all of them. Deliberately "used by", not "came from": it is computed by scanning the placement snapshots in `metadata.builder` for `[[[c:key]]]` and `[[[if:c:key ...]]]` references, so it is always true, even for a hand-made control that a block happens to use. No lock - block controls stay fully editable. Composes with the existing badge: referenced by a placed block = block pill, referenced by none = "Not used by any block". Client-side only, zero backend.
 
 Editing a block after placing it left the placement on the old snapshot, and the only remedy was remove + re-place, losing position and size. Now the Builder notices and offers to sync - explicitly, in the editing session only.
 

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,6 +1,14 @@
 # CHANGELOG JULY 2026
 
-## July 25th, 2026 - fix(breadcrumbs): a copied-as-Block template no longer inherits the source's list crumb
+## July 25th, 2026 - feat(builder): refresh placed blocks from their source
+
+Editing a block after placing it left the placement on the old snapshot, and the only remedy was remove + re-place, losing position and size. Now the Builder notices and offers to sync - explicitly, in the editing session only.
+
+- **Detection**: on editor mount and window refocus (throttled to once per 10s), the current snapshots of all distinct placed blocks are fetched and string-compared against the stored ones. String comparison is ground truth - no timestamps to store, and it works retroactively on every composed overlay saved before this feature existed. Covers the edit-the-block-in-another-tab round trip.
+- **UI**: an amber "Source updated" badge on each drifted placement, a "Refresh from source" button in the selected-block panel, and a bar above the canvas - "The source of N placed blocks changed. Sync into this session?" - with a Sync all action.
+- **Refresh** re-takes the snapshot in place: same instance_id, position, and size (remove + re-add without losing the layout). The source's controls are registered like a fresh placement, so new control keys ride along at the next save. On the edit page a refresh marks the form dirty.
+- **The snapshot invariant is untouched**: nothing propagates to a saved overlay until the owner saves. A deleted or newly-private source is skipped silently - the placement keeps rendering its snapshot, which is the invariant working as intended. The picker's fetch feeds the same source cache, so a just-placed block can never be flagged stale by an older background check or silently downgraded by a refresh.
+- Zero backend changes; this is step 1 of the Hot Blocks ladder (docs/design/hot-blocks-idea.md, local).
 
 Copy a static overlay as a Block and the new block's breadcrumb said "My static overlays" forever, even when you clicked it from the My blocks list. Root cause in `useListContext`: the show page freezes the freshest global list context for a template on its first mount - and right after a copy, the freshest list you visited is still the SOURCE's list. The frozen origin then wins over every later navigation by design, so the wrong crumb stuck for the whole tab session.
 

--- a/resources/js/components/ControlsManager.vue
+++ b/resources/js/components/ControlsManager.vue
@@ -13,6 +13,7 @@ import {
   ChevronsUpDown,
   ChevronsDownUp,
   LockIcon,
+  Blocks,
 } from '@lucide/vue';
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -111,6 +112,43 @@ function snippetKey(ctrl: OverlayControl): string {
 // block reattaches it) - this badge just makes the leftovers visible so the
 // user can decide. template_tags is re-extracted server-side on every save.
 const builderComposed = computed(() => !!props.template?.metadata?.builder);
+
+// Which placed blocks reference each control key. Built by scanning the
+// placement snapshots for [[[c:key]]] (and [[[if:c:key ...]]]) tags, so it is
+// "used by", not "came from" - always true, even for a hand-made control that
+// a block happens to reference. Keys with a colon are namespaced service tags
+// (c:kofi:x) and never template-scoped, so they are skipped.
+const blockUsage = computed<Map<string, string[]>>(() => {
+  const map = new Map<string, string[]>();
+  for (const placement of props.template?.metadata?.builder?.placements ?? []) {
+    const code = `${placement.snapshot?.head ?? ''}\n${placement.snapshot?.html ?? ''}\n${placement.snapshot?.css ?? ''}`;
+    const keys = new Set<string>();
+    for (const match of code.matchAll(/\[\[\[(?:if:)?c:([a-zA-Z0-9_.:-]+)/g)) {
+      if (!match[1].includes(':')) keys.add(match[1]);
+    }
+    for (const key of keys) {
+      const names = map.get(key) ?? [];
+      if (!names.includes(placement.block_name)) names.push(placement.block_name);
+      map.set(key, names);
+    }
+  }
+  return map;
+});
+
+function usedByBlocks(ctrl: OverlayControl): string[] {
+  if (ctrl.source || ctrl.overlay_template_id === null) return [];
+  return blockUsage.value.get(ctrl.key) ?? [];
+}
+
+function usedByBlocksLabel(ctrl: OverlayControl): string {
+  const names = usedByBlocks(ctrl);
+  return names.length > 1 ? `${names[0]} +${names.length - 1}` : (names[0] ?? '');
+}
+
+function usedByBlocksTitle(ctrl: OverlayControl): string {
+  const names = usedByBlocks(ctrl);
+  return `Used by block${names.length === 1 ? '' : 's'}: ${names.join(', ')}. Block controls stay fully editable.`;
+}
 
 function isBlockOrphan(ctrl: OverlayControl): boolean {
   const tags = props.template?.template_tags;
@@ -422,6 +460,14 @@ const controlsCounter = computed(() => controls.value.length);
                     >
                       <LockIcon class="h-2.5 w-2.5" />
                       {{ SERVICE_LABELS[ctrl.source] ?? ctrl.source }}
+                    </span>
+                    <span
+                      v-if="usedByBlocks(ctrl).length"
+                      class="inline-flex items-center gap-1 rounded-full border border-muted-foreground/30 bg-mauve-300/50 px-2 py-0.5 text-[10px] text-muted-foreground dark:bg-mauve-700/50"
+                      :title="usedByBlocksTitle(ctrl)"
+                    >
+                      <Blocks class="h-2.5 w-2.5" />
+                      {{ usedByBlocksLabel(ctrl) }}
                     </span>
                     <span
                       v-if="isBlockOrphan(ctrl)"

--- a/resources/js/components/builder/BuilderCanvas.vue
+++ b/resources/js/components/builder/BuilderCanvas.vue
@@ -10,12 +10,14 @@ const props = defineProps<{
   selectedId: string | null;
   sampleData: Record<string, string>;
   isCellOccupied: (x: number, y: number) => boolean;
+  stalePlacementIds?: Set<string>;
 }>();
 
 const emit = defineEmits<{
   cellClick: [x: number, y: number];
   select: [id: string | null];
   moveTo: [id: string, x: number, y: number];
+  syncAll: [];
 }>();
 
 // The canvas renders at its real OBS size (1920x1080) and is scaled down with
@@ -116,6 +118,15 @@ const emptyCells = computed(() => {
 
 <template>
   <div ref="wrapper" class="w-full">
+    <div
+      v-if="stalePlacementIds && stalePlacementIds.size > 0"
+      class="mb-2 flex flex-wrap items-center justify-between gap-2 border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-foreground"
+    >
+      <span>
+        The source of {{ stalePlacementIds.size }} placed block{{ stalePlacementIds.size === 1 ? '' : 's' }} changed. Sync into this session?
+      </span>
+      <button type="button" class="btn btn-cancel btn-sm shrink-0 cursor-pointer" @click="emit('syncAll')">Sync all</button>
+    </div>
     <div :style="{ height: `${canvas.height * scale}px` }" class="overflow-hidden">
       <div
         ref="gridEl"
@@ -149,6 +160,7 @@ const emptyCells = computed(() => {
           :placement="placement"
           :sample-data="sampleData"
           :selected="placement.instance_id === selectedId"
+          :source-stale="stalePlacementIds?.has(placement.instance_id) ?? false"
           @select="(id) => emit('select', id)"
           @drag-start="onDragStart"
         />

--- a/resources/js/components/builder/BuilderEditor.vue
+++ b/resources/js/components/builder/BuilderEditor.vue
@@ -7,6 +7,7 @@ import BuilderGridControls from '@/components/builder/BuilderGridControls.vue';
 import BlockPickerModal, { type LibraryBlock } from '@/components/builder/BlockPickerModal.vue';
 import SelectedBlockPanel from '@/components/builder/SelectedBlockPanel.vue';
 import { useBuilderState, type BuilderControlDef } from '@/composables/useBuilderState';
+import { useBlockSourceSync } from '@/composables/useBlockSourceSync';
 import { composeBuilderTemplate } from '@/utils/composeBuilderTemplate';
 
 // The Builder editing surface inside the template edit page's Code tab.
@@ -21,6 +22,15 @@ const props = defineProps<{
 const emit = defineEmits<{ dirty: []; error: [message: string] }>();
 
 const state = useBuilderState(props.initial);
+const { stalePlacementIds, refreshPlacement, syncAll, noteFreshSource } = useBlockSourceSync(state);
+
+function refreshSelectedFromSource() {
+  if (state.selectedId.value && refreshPlacement(state.selectedId.value)) emit('dirty');
+}
+
+function syncAllFromSource() {
+  if (syncAll() > 0) emit('dirty');
+}
 
 const pickerOpen = ref(false);
 const pickerCell = ref<{ x: number; y: number } | null>(null);
@@ -37,6 +47,7 @@ async function onPickBlock(block: LibraryBlock) {
 
   try {
     const { data } = await axios.get(route('templates.blocks.snapshot', block.id));
+    noteFreshSource(block.id, data);
     const span = data.default_span ?? { w: 4, h: 2 };
     const placed = state.addPlacement(
       { id: data.id, slug: data.slug, name: data.name },
@@ -116,9 +127,11 @@ defineExpose({
         :selected-id="state.selectedId.value"
         :sample-data="sampleData"
         :is-cell-occupied="(x, y) => state.occupied(x, y)"
+        :stale-placement-ids="stalePlacementIds"
         @cell-click="onCellClick"
         @select="(id) => (state.selectedId.value = id)"
         @move-to="moveTo"
+        @sync-all="syncAllFromSource"
       />
 
       <p class="text-sm text-muted-foreground">
@@ -131,9 +144,11 @@ defineExpose({
       <SelectedBlockPanel
         v-if="state.selected.value"
         :placement="state.selected.value"
+        :source-stale="stalePlacementIds.has(state.selected.value.instance_id)"
         @move="move"
         @resize="resize"
         @remove="removeSelected"
+        @refresh-source="refreshSelectedFromSource"
       />
       <div class="border border-sidebar-border bg-sidebar-accent p-4 text-xs text-muted-foreground">
         Blocks that use controls bring them along on save. Blocks sharing a control key stay in sync.

--- a/resources/js/components/builder/BuilderPlacement.vue
+++ b/resources/js/components/builder/BuilderPlacement.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   placement: BuilderPlacement;
   sampleData: Record<string, string>;
   selected: boolean;
+  sourceStale?: boolean;
 }>();
 
 const emit = defineEmits<{ select: [id: string]; dragStart: [id: string, event: PointerEvent] }>();
@@ -65,6 +66,13 @@ const gridArea = computed(
     />
     <div class="pointer-events-none absolute top-0 left-0 max-w-full truncate bg-sidebar-accent/90 px-2 py-0.5 font-mono text-xs text-foreground">
       {{ placement.block_name }}
+    </div>
+    <div
+      v-if="sourceStale"
+      class="pointer-events-none absolute top-0 right-0 bg-amber-500/90 px-2 py-0.5 text-[10px] font-medium text-black"
+      title="The source of this block changed since it was placed. Select it to refresh."
+    >
+      Source updated
     </div>
   </div>
 </template>

--- a/resources/js/components/builder/SelectedBlockPanel.vue
+++ b/resources/js/components/builder/SelectedBlockPanel.vue
@@ -1,15 +1,17 @@
 <script setup lang="ts">
 import type { BuilderPlacement } from '@/types';
-import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Trash2 } from '@lucide/vue';
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, RefreshCcw, Trash2 } from '@lucide/vue';
 
 defineProps<{
   placement: BuilderPlacement;
+  sourceStale?: boolean;
 }>();
 
 const emit = defineEmits<{
   move: [dx: number, dy: number];
   resize: [dw: number, dh: number];
   remove: [];
+  refreshSource: [];
 }>();
 </script>
 
@@ -18,6 +20,14 @@ const emit = defineEmits<{
     <div class="text-sm font-medium text-accent-foreground">{{ placement.block_name }}</div>
     <div class="font-mono text-xs text-muted-foreground">
       {{ placement.w }} x {{ placement.h }} at column {{ placement.x }}, row {{ placement.y }}
+    </div>
+
+    <div v-if="sourceStale" class="space-y-2 border border-amber-500/40 bg-amber-500/10 p-2.5 text-xs text-foreground">
+      <p>The source of this block changed since it was placed here.</p>
+      <button type="button" class="btn btn-cancel btn-sm cursor-pointer" @click="emit('refreshSource')">
+        <RefreshCcw class="mr-1.5 size-3.5" />
+        Refresh from source
+      </button>
     </div>
 
     <div class="flex items-center gap-2">

--- a/resources/js/composables/useBlockSourceSync.ts
+++ b/resources/js/composables/useBlockSourceSync.ts
@@ -1,0 +1,124 @@
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import axios from 'axios';
+import type { BuilderControlDef, useBuilderState } from '@/composables/useBuilderState';
+
+/**
+ * "Refresh from source" for the Builder editor: detects placements whose
+ * snapshot has drifted from the current block source and lets the user re-take
+ * the snapshot in place (same instance_id, position, and size).
+ *
+ * Editor-scoped by design. A saved overlay never changes until its owner
+ * saves it - this only touches the editing session, so the snapshot-copy
+ * invariant (blocks are never dereferenced at render) stays fully intact.
+ *
+ * Drift detection is a plain string comparison against a freshly fetched
+ * snapshot: ground truth, no timestamps to store, and it works retroactively
+ * on composed overlays saved before this feature existed. Checks run on mount
+ * and on window focus (throttled), covering the edit-the-block-in-another-tab
+ * round trip.
+ */
+
+interface BlockSource {
+  name: string;
+  snapshot: { head: string; html: string; css: string };
+  controls: BuilderControlDef[];
+}
+
+interface SnapshotPayload {
+  name: string;
+  head?: string | null;
+  html?: string | null;
+  css?: string | null;
+  controls?: BuilderControlDef[];
+}
+
+const RECHECK_MIN_MS = 10_000;
+
+export function useBlockSourceSync(state: ReturnType<typeof useBuilderState>) {
+  // instance_ids whose snapshot differs from the current source.
+  const stalePlacementIds = ref<Set<string>>(new Set());
+
+  // Latest fetched source per block id - refresh applies from this cache, so
+  // detecting and refreshing can never disagree about what "latest" means.
+  const sources = new Map<number, BlockSource>();
+  let lastCheck = 0;
+
+  const norm = (value: string | null | undefined) => value ?? '';
+
+  function differs(a: { head?: string | null; html?: string | null; css?: string | null }, b: BlockSource['snapshot']): boolean {
+    return norm(a.head) !== b.head || norm(a.html) !== b.html || norm(a.css) !== b.css;
+  }
+
+  function recompute(): void {
+    const stale = new Set<string>();
+    for (const p of state.placements.value) {
+      const src = sources.get(p.block_template_id);
+      if (src && differs(p.snapshot, src.snapshot)) stale.add(p.instance_id);
+    }
+    stalePlacementIds.value = stale;
+  }
+
+  async function check(): Promise<void> {
+    lastCheck = Date.now();
+    const ids = [...new Set(state.placements.value.map((p) => p.block_template_id))];
+    if (ids.length === 0) {
+      stalePlacementIds.value = new Set();
+      return;
+    }
+
+    const results = await Promise.allSettled(ids.map((id) => axios.get(route('templates.blocks.snapshot', id))));
+    results.forEach((result, i) => {
+      // A deleted or newly-private source is skipped silently: the placement
+      // keeps rendering its snapshot - the invariant working as intended.
+      if (result.status !== 'fulfilled') return;
+      noteFreshSource(ids[i], result.value.data as SnapshotPayload);
+    });
+    recompute();
+  }
+
+  // Cache a source fetched elsewhere (block picker, this checker). A block
+  // placed this session is fresh by definition - caching its payload prevents
+  // an older background fetch from flagging it, or a refresh from silently
+  // downgrading it.
+  function noteFreshSource(blockId: number, data: SnapshotPayload): void {
+    sources.set(blockId, {
+      name: data.name,
+      snapshot: { head: norm(data.head), html: norm(data.html), css: norm(data.css) },
+      controls: data.controls ?? [],
+    });
+    recompute();
+  }
+
+  /** Re-take one placement's snapshot from the cached source. True when it changed. */
+  function refreshPlacement(instanceId: string): boolean {
+    const placement = state.placements.value.find((p) => p.instance_id === instanceId);
+    if (!placement) return false;
+    const src = sources.get(placement.block_template_id);
+    if (!src || !differs(placement.snapshot, src.snapshot)) return false;
+    state.refreshSnapshot(instanceId, src);
+    recompute();
+    return true;
+  }
+
+  /** Refresh every stale placement. Returns how many were refreshed. */
+  function syncAll(): number {
+    let refreshed = 0;
+    for (const id of [...stalePlacementIds.value]) {
+      if (refreshPlacement(id)) refreshed++;
+    }
+    return refreshed;
+  }
+
+  function onWindowFocus(): void {
+    if (Date.now() - lastCheck < RECHECK_MIN_MS) return;
+    void check();
+  }
+
+  onMounted(() => {
+    window.addEventListener('focus', onWindowFocus);
+    void check();
+  });
+  onBeforeUnmount(() => window.removeEventListener('focus', onWindowFocus));
+
+  return { stalePlacementIds, refreshPlacement, syncAll, noteFreshSource };
+}

--- a/resources/js/composables/useBuilderState.ts
+++ b/resources/js/composables/useBuilderState.ts
@@ -96,6 +96,24 @@ export function useBuilderState(initial?: BuilderMetadata | null) {
         return placement;
     }
 
+    /**
+     * Re-take a placement's snapshot from its source block ("Refresh from
+     * source"). Position, size, and instance_id stay put - this is remove +
+     * re-add without losing the layout. The source's controls are registered
+     * like a fresh placement so any NEW control keys ride along at save time.
+     */
+    function refreshSnapshot(
+        id: string,
+        source: { name: string; snapshot: { head: string; html: string; css: string }; controls: BuilderControlDef[] },
+    ): void {
+        const p = placements.value.find((pl) => pl.instance_id === id);
+        if (!p) return;
+        p.block_name = source.name;
+        p.snapshot = { ...source.snapshot };
+        sessionControlDefs.set(id, source.controls);
+        placements.value = [...placements.value];
+    }
+
     /** Absolute move (drag target). Returns true when the block actually moved. */
     function moveTo(id: string, x: number, y: number): boolean {
         const p = placements.value.find((pl) => pl.instance_id === id);
@@ -178,6 +196,7 @@ export function useBuilderState(initial?: BuilderMetadata | null) {
         occupied,
         clampSpan,
         addPlacement,
+        refreshSnapshot,
         move,
         moveTo,
         resize,

--- a/resources/js/pages/builder/create.vue
+++ b/resources/js/pages/builder/create.vue
@@ -13,6 +13,7 @@ import BlockPickerModal, { type LibraryBlock } from '@/components/builder/BlockP
 import SelectedBlockPanel from '@/components/builder/SelectedBlockPanel.vue';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useBuilderState, type BuilderControlDef } from '@/composables/useBuilderState';
+import { useBlockSourceSync } from '@/composables/useBlockSourceSync';
 import { composeBuilderTemplate } from '@/utils/composeBuilderTemplate';
 import { sanitizeHtmlFields } from '@/utils/sanitize';
 import { compileTailwindCss } from '@/utils/compileTailwind';
@@ -26,6 +27,20 @@ const props = defineProps<{
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Builder', href: '/builder' }];
 
 const state = useBuilderState();
+const { stalePlacementIds, refreshPlacement, syncAll, noteFreshSource } = useBlockSourceSync(state);
+
+function refreshSelectedFromSource() {
+  if (state.selectedId.value && refreshPlacement(state.selectedId.value)) {
+    toast('Block refreshed from its source.', 'success');
+  }
+}
+
+function syncAllFromSource() {
+  const refreshed = syncAll();
+  if (refreshed > 0) {
+    toast(`${refreshed} block${refreshed === 1 ? '' : 's'} refreshed from source.`, 'success');
+  }
+}
 
 const name = ref('');
 const description = ref('');
@@ -71,6 +86,7 @@ async function onPickBlock(block: LibraryBlock) {
 
   try {
     const { data } = await axios.get(route('templates.blocks.snapshot', block.id));
+    noteFreshSource(block.id, data);
     const span = data.default_span ?? { w: 4, h: 2 };
     const placed = state.addPlacement(
       { id: data.id, slug: data.slug, name: data.name },
@@ -225,9 +241,11 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
             :selected-id="state.selectedId.value"
             :sample-data="props.sampleData"
             :is-cell-occupied="(x, y) => state.occupied(x, y)"
+            :stale-placement-ids="stalePlacementIds"
             @cell-click="onCellClick"
             @select="(id) => (state.selectedId.value = id)"
             @move-to="(id, x, y) => state.moveTo(id, x, y)"
+            @sync-all="syncAllFromSource"
           />
 
           <p class="text-sm text-muted-foreground">
@@ -252,9 +270,11 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
           <SelectedBlockPanel
             v-if="state.selected.value"
             :placement="state.selected.value"
+            :source-stale="stalePlacementIds.has(state.selected.value.instance_id)"
             @move="(dx, dy) => state.move(state.selectedId.value!, dx, dy)"
             @resize="(dw, dh) => state.resize(state.selectedId.value!, dw, dh)"
             @remove="state.remove(state.selectedId.value!)"
+            @refresh-source="refreshSelectedFromSource"
           />
 
           <div class="border border-sidebar-border bg-sidebar-accent p-4 text-sm text-foreground">


### PR DESCRIPTION
## Summary

Two frontend-only features closing out the block-staleness and control-provenance feedback. Zero backend changes in this PR.

### feat(builder): refresh placed blocks from their source

Editing a block after placing it left the placement on the old snapshot - the only remedy was remove + re-place, losing position and size. Now the Builder notices and offers to sync, explicitly, in the editing session only:

- **Detection**: on editor mount and window refocus (throttled to once per 10s), current snapshots of all distinct placed blocks are fetched and string-compared against the stored ones. String comparison is ground truth - no timestamps, and it works retroactively on composed overlays saved before this feature existed. Covers the edit-the-block-in-another-tab round trip
- **UI**: amber "Source updated" badge on drifted placements, "Refresh from source" in the selected-block panel, and a bar above the canvas - "The source of N placed blocks changed. Sync into this session?" - with Sync all
- **Refresh** re-takes the snapshot in place: same instance_id, position, and size. The source's controls are registered like a fresh placement so new keys ride along at the next save. On the edit page a refresh marks the form dirty
- **Snapshot invariant untouched**: nothing propagates to a saved overlay until the owner saves. Deleted or newly-private sources are skipped silently - the placement keeps rendering its snapshot. The picker's fetch feeds the same source cache, so a just-placed block can never be flagged stale by an older background check or silently downgraded by a refresh

### feat(builder): "used by block" pill on the Controls tab

On builder-composed overlays, template controls referenced by a placed block carry a pill in the same visual family as the service-managed label - Blocks icon + block name ("First Block +2" for shared keys, tooltip lists all). Deliberately "used by", not "came from": computed by scanning placement snapshots in `metadata.builder` for `[[[c:key]]]` and `[[[if:c:key ...]]]` references, so it stays honest for hand-made controls a block uses. No lock - block controls remain fully editable. Composes with the existing badge: referenced by a placed block = block pill, referenced by none = "Not used by any block".

## Test plan

- Place a block, edit its source in another tab, save, switch back: badge + panel button + sync bar appear; refresh updates the preview in place, layout untouched; save persists
- Sync all with multiple drifted placements; verify per-placement refresh clears only its own badge
- Delete the source block: no badge, placement keeps rendering
- Controls tab on a composed overlay: block-referenced controls wear their block's name; a control from a removed block shows "Not used by any block" instead
- ESLint + vue-tsc clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)