### PR TITLE
Builder: renamed blocks update their placement labels

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,9 @@
 # CHANGELOG JULY 2026
 
+## July 25th, 2026 - fix(builder): renamed blocks update their placement labels
+
+Renaming a block did not change its label on Builder placements: drift detection deliberately compares only head/html/css (drift = rendered output), so a name-only change never qualified for the refresh flow - and never will, because the name is a provenance label, not output. Labels are now treated as live instead of snapshot-frozen: whenever the editor sees a fresh source (the mount/refocus check or a picker fetch), placement names silently follow it - no badge, no refresh ceremony, persisted with the next save. Descriptions were never stored on placements; the picker already shows them fresh per page load.
+
 ## July 25th, 2026 - feat(builder): "used by block" pill on the Controls tab
 
 On builder-composed overlays, template controls that a placed block references now carry a pill in the same visual family as the service-managed label - block icon plus the block's name (first name +N when several blocks share the key), tooltip listing all of them. Deliberately "used by", not "came from": it is computed by scanning the placement snapshots in `metadata.builder` for `[[[c:key]]]` and `[[[if:c:key ...]]]` references, so it is always true, even for a hand-made control that a block happens to use. No lock - block controls stay fully editable. Composes with the existing badge: referenced by a placed block = block pill, referenced by none = "Not used by any block". Client-side only, zero backend.

--- a/resources/js/composables/useBlockSourceSync.ts
+++ b/resources/js/composables/useBlockSourceSync.ts
@@ -86,6 +86,9 @@ export function useBlockSourceSync(state: ReturnType<typeof useBuilderState>) {
       snapshot: { head: norm(data.head), html: norm(data.html), css: norm(data.css) },
       controls: data.controls ?? [],
     });
+    // Names are labels, not output: a renamed source updates its placements
+    // immediately, with none of the stale-snapshot ceremony.
+    if (data.name) state.syncBlockNames(new Map([[blockId, data.name]]));
     recompute();
   }
 

--- a/resources/js/composables/useBuilderState.ts
+++ b/resources/js/composables/useBuilderState.ts
@@ -114,6 +114,23 @@ export function useBuilderState(initial?: BuilderMetadata | null) {
         placements.value = [...placements.value];
     }
 
+    /**
+     * Block names are provenance labels, not rendered output, so unlike the
+     * code snapshot they are never frozen: whenever a fresh source is seen,
+     * placement labels silently follow it. Persisted with the next save.
+     */
+    function syncBlockNames(names: ReadonlyMap<number, string>): void {
+        let changed = false;
+        for (const p of placements.value) {
+            const name = names.get(p.block_template_id);
+            if (name && name !== p.block_name) {
+                p.block_name = name;
+                changed = true;
+            }
+        }
+        if (changed) placements.value = [...placements.value];
+    }
+
     /** Absolute move (drag target). Returns true when the block actually moved. */
     function moveTo(id: string, x: number, y: number): boolean {
         const p = placements.value.find((pl) => pl.instance_id === id);
@@ -197,6 +214,7 @@ export function useBuilderState(initial?: BuilderMetadata | null) {
         clampSpan,
         addPlacement,
         refreshSnapshot,
+        syncBlockNames,
         move,
         moveTo,
         resize,


### PR DESCRIPTION
## Summary

Renaming a block did not change its label on Builder placements. Root cause: drift detection deliberately compares only head/html/css (drift = rendered output), so a name-only change never qualified for the refresh flow - and never should, since the name is a provenance label, not output.

Names are now live instead of snapshot-frozen: whenever the editor sees a fresh source (the mount/refocus check or a picker fetch), placement labels silently follow it - no badge, no refresh ceremony - and persist into `metadata.builder` with the next save. Code snapshots keep the explicit refresh flow unchanged.

Descriptions were never stored on placements; the picker already shows them fresh per page load, so nothing to do there.

## Test plan

- Place a block, rename it on its edit page in another tab, return to the Builder tab: the placement label and selected-block panel update within a moment, with no stale badge or sync prompt
- A rename plus a code edit still shows the "Source updated" badge for the code, with the name already fresh
- ESLint + vue-tsc clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)