### PR TITLE
Builder: block previews honor height:100%

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,9 @@
 # CHANGELOG JULY 2026
 
+## July 25th, 2026 - fix(builder): block previews honor height:100%
+
+A block styled with `height: 100%` filled its cell in the rendered overlay but not in the Builder's placement preview - full width, shrunk height. The preview iframe's document reset set no height on `html`/`body`, so a percentage height inside resolved against an indefinite parent and collapsed to auto (width was unaffected because block elements fill width by default). The reset now includes `height: 100%`, which also makes the preview environment faithfully mirror the compiled one, where the block wrapper is a grid item with a definite height. One line, preview-only - compiled output was always correct.
+
 ## July 25th, 2026 - fix(builder): renamed blocks update their placement labels
 
 Renaming a block did not change its label on Builder placements: drift detection deliberately compares only head/html/css (drift = rendered output), so a name-only change never qualified for the refresh flow - and never will, because the name is a provenance label, not output. Labels are now treated as live instead of snapshot-frozen: whenever the editor sees a fresh source (the mount/refocus check or a picker fetch), placement names silently follow it - no badge, no refresh ceremony, persisted with the next save. Descriptions were never stored on placements; the picker already shows them fresh per page load.

--- a/resources/js/components/builder/BuilderPlacement.vue
+++ b/resources/js/components/builder/BuilderPlacement.vue
@@ -35,9 +35,12 @@ const previewDoc = computed(() => {
   html = html.replace(/\[\[\[[^\]]*]]]/g, '');
   css = css.replace(/\[\[\[[^\]]*]]]/g, '');
 
+  // height:100% on html/body mirrors the compiled environment: there the
+  // block's wrapper is a grid item with a definite height, so a block using
+  // height:100% must resolve the same way inside the preview iframe.
   return `<!DOCTYPE html>
 <html lang="en">
-  <head><style>html,body{margin:0;padding:0;background:transparent;overflow:hidden;}</style><style>${css}</style>${props.placement.snapshot.head}</head>
+  <head><style>html,body{margin:0;padding:0;height:100%;background:transparent;overflow:hidden;}</style><style>${css}</style>${props.placement.snapshot.head}</head>
   <body>${html}</body>
 </html>`;
 });


### PR DESCRIPTION
## Summary

A block styled with `height: 100%` filled its cell in the rendered overlay but not in the Builder's placement preview - full width, shrunk height.

Root cause: the preview iframe's document reset set no height on `html`/`body`, so a percentage height inside resolved against an indefinite parent and collapsed to auto (width was unaffected because block elements fill width by default). The compiled overlay was always correct, since there the block wrapper is a grid item with a definite height.

Fix: `height: 100%` added to the iframe reset - one line, preview-only - which also makes the preview environment faithfully mirror the compiled one for any cell-filling block.

## Test plan

- Block with `.item { width: 100%; height: 100%; background: ... }`: preview now fills the whole cell, matching the rendered overlay
- Content-sized blocks (no percentage heights) unchanged
- ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)