### PR TITLE
Help docs: The Builder and Blocks

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,6 +1,12 @@
 # CHANGELOG JULY 2026
 
-## July 25th, 2026 - fix(builder): block previews honor height:100%
+## July 26th, 2026 - docs(help): The Builder and Blocks help pages
+
+Two new help docs covering the block-based composing story, both in the established help-page format (TOC, numbered sections, callouts, bottom line) and linked from the help index:
+
+- **/help/builder** - for composers: what the Builder is (assembly, not a separate runtime), the grid and picker, drag/keyboard/preview, why saving yields a plain static overlay (with the actual compiled CSS shown), how controls come along (shared keys sync, removal keeps values), refresh from source, and the one-way eject door.
+- **/help/blocks** - for block authors: the third template type, creating from scratch or via Copy-as-Block, the fill-the-box CSS pattern (`width/height: 100%` against the definite-size wrapper), compile-time selector scoping with `:root`/`body` mapping (shown before/after), the keyframes/font-face global passthrough caveat, controls traveling with defaults + key-sharing design advice, snapshot semantics as a two-way trust promise, and publishing guidelines.
+- Both use HelpLayout (meta/OG boilerplate handled), routes registered as `help.builder` and `help.blocks`, two new cards on the help index (LayoutGrid and Blocks icons).
 
 A block styled with `height: 100%` filled its cell in the rendered overlay but not in the Builder's placement preview - full width, shrunk height. The preview iframe's document reset set no height on `html`/`body`, so a percentage height inside resolved against an indefinite parent and collapsed to auto (width was unaffected because block elements fill width by default). The reset now includes `height: 100%`, which also makes the preview environment faithfully mirror the compiled one, where the block wrapper is a grid item with a definite height. One line, preview-only - compiled output was always correct.
 

--- a/resources/js/pages/help/Blocks.vue
+++ b/resources/js/pages/help/Blocks.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
+import type { BreadcrumbItem } from '@/types';
+import HelpLayout from '@/layouts/HelpLayout.vue';
+import Heading from '@/components/Heading.vue';
+
+const breadcrumbs: BreadcrumbItem[] = [
+  { title: 'Help', href: '/help' },
+  { title: 'Blocks', href: '/help/blocks' },
+];
+
+// A minimal cell-filling block: fills whatever cell area it's placed on.
+const fillExample = `<!-- Body -->
+<div class="item">
+  [[[follower_count]]] followers
+</div>
+
+/* CSS */
+.item {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-content: center;
+  background-color: #15803d;
+  color: #ffffff;
+  font-size: 1.875rem;
+}`;
+
+// What the compiler does to a block's CSS at placement.
+const scopingExample = `/* you write */
+:root { --accent: #a78bfa; }
+.label { color: var(--accent); }
+
+/* the Builder compiles, for a placement with id a3f2 */
+#blk-a3f2 { --accent: #a78bfa; }
+#blk-a3f2 .label { color: var(--accent); }`;
+</script>
+
+<template>
+  <HelpLayout
+    :breadcrumbs="breadcrumbs"
+    title="Blocks - reusable building pieces for the Builder"
+    description="Blocks are the third template type in Overlabels: small, self-contained overlay pieces with live data and controls, built once and placed on any grid in the Builder. How to author one, how CSS scoping and snapshots work, and how controls travel."
+    canonical-url="https://overlabels.com/help/blocks"
+  >
+    <!-- Header -->
+    <div class="mb-10">
+      <Heading
+        title="Blocks"
+        title-class="text-4xl font-bold mb-4"
+        description="A block is a small, self-contained overlay piece: a follower counter, a donation goal, a chat box frame. Build it once with the same HTML, CSS, and tags as any overlay - then anyone can place it on a grid in the Builder, no code required on their end."
+      />
+    </div>
+
+    <!-- TOC -->
+    <div class="mb-12 border border-sidebar-border bg-card p-6">
+      <h2 class="mb-4 text-xl font-bold" id="toc">Table of contents</h2>
+      <ol class="list-decimal space-y-1 pl-6 text-foreground">
+        <li><a href="#what" class="text-violet-400 hover:underline">The third template type</a></li>
+        <li><a href="#creating" class="text-violet-400 hover:underline">Creating a block</a></li>
+        <li><a href="#css" class="text-violet-400 hover:underline">Writing block HTML and CSS</a></li>
+        <li><a href="#controls" class="text-violet-400 hover:underline">Controls travel with your block</a></li>
+        <li><a href="#snapshots" class="text-violet-400 hover:underline">Snapshots: placing copies your code</a></li>
+        <li><a href="#publishing" class="text-violet-400 hover:underline">Publishing your block</a></li>
+      </ol>
+    </div>
+
+    <!-- 1. What -->
+    <section class="mb-14" id="what">
+      <h2 class="mb-4 text-2xl font-bold">1. The third template type</h2>
+      <p class="mb-4 text-foreground">
+        Overlabels has three template types. <strong>Static overlays</strong> are the always-on layer you add to OBS.
+        <strong>Alerts</strong> fire on events and render inside a static overlay (see
+        <Link href="/help/overlays-vs-alerts" class="text-violet-400 hover:underline">Overlays vs Alerts</Link>).
+        <strong>Blocks</strong> are the new third kind: pieces. A block is never added to OBS by itself - it exists to
+        be placed on a grid in the
+        <Link href="/help/builder" class="text-violet-400 hover:underline">Builder</Link>, alongside other blocks,
+        compiling into a full static overlay.
+      </p>
+      <p class="text-foreground">
+        Inside a block, everything you already know works: template tags like
+        <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">[[[follower_count]]]</code>, conditionals,
+        <Link href="/help/formatting" class="text-violet-400 hover:underline">formatting pipes</Link>, and
+        <Link href="/help/controls" class="text-violet-400 hover:underline">Controls</Link>. A block is a regular
+        template that happens to be small and composable.
+      </p>
+    </section>
+
+    <!-- 2. Creating -->
+    <section class="mb-14" id="creating">
+      <h2 class="mb-4 text-2xl font-bold">2. Creating a block</h2>
+      <p class="mb-4 text-foreground">
+        Two ways in:
+      </p>
+      <ul class="mb-4 list-disc space-y-2 pl-6 text-foreground">
+        <li>
+          <strong>From scratch:</strong> Create Overlay and pick the <strong>Block</strong> card. You get the same
+          editor as every other template.
+        </li>
+        <li>
+          <strong>From an existing overlay:</strong> the <strong>Copy</strong> action on any static overlay asks
+          whether the copy should be a static overlay or a block. Great for turning a piece of the public library
+          into Builder material.
+        </li>
+      </ul>
+      <p class="text-foreground">
+        On the block's Meta tab you set a <strong>suggested size</strong>: how many grid columns and rows the block
+        occupies when someone places it (they can always resize afterwards). A compact counter might suggest 4x2; a
+        big centerpiece might want 8x4. If the free space at the clicked cell is smaller, the Builder shrinks the
+        placement to fit.
+      </p>
+    </section>
+
+    <!-- 3. CSS -->
+    <section class="mb-14" id="css">
+      <h2 class="mb-4 text-2xl font-bold">3. Writing block HTML and CSS</h2>
+      <p class="mb-4 text-foreground">
+        When a block is placed, it lives inside a wrapper element that spans its grid cells - a box with a definite
+        width and height. The single most useful pattern for a block is therefore <em>fill the box you're given</em>:
+      </p>
+      <pre class="mb-6 overflow-x-auto rounded border border-sidebar-border bg-card p-4 font-mono text-sm text-foreground"><code>{{ fillExample }}</code></pre>
+      <p class="mb-4 text-foreground">
+        <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">width: 100%; height: 100%</code> on your
+        root element makes the block fill whatever cell area a user gives it - 2x2 or 8x4, it adapts. Content-sized
+        blocks are fine too; they'll simply sit at their natural size inside their area.
+      </p>
+
+      <h3 class="mb-2 text-xl font-semibold">Your CSS is scoped for you</h3>
+      <p class="mb-4 text-foreground">
+        Write plain CSS with whatever class names you like. At compile time, the Builder prefixes every selector to
+        the block's own wrapper, so two blocks both styling
+        <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">.label</code> can never collide.
+        Selectors targeting <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">:root</code>,
+        <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">html</code>, or
+        <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">body</code> are mapped onto the wrapper -
+        so CSS variables you define on <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">:root</code>
+        become variables on your block, private to it:
+      </p>
+      <pre class="mb-6 overflow-x-auto rounded border border-sidebar-border bg-card p-4 font-mono text-sm text-foreground"><code>{{ scopingExample }}</code></pre>
+      <div class="rounded-lg border border-yellow-500/40 bg-yellow-500/5 p-5">
+        <p class="text-foreground">
+          <strong>Two limits to know:</strong>
+          <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">@keyframes</code> and
+          <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">@font-face</code> pass through globally,
+          so give animations distinctive names - two blocks defining
+          <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">@keyframes pulse</code> will fight over
+          it. And keep CSS reasonably flat: media queries are handled, but deeply nested exotic constructs may degrade
+          to plain prefixing.
+        </p>
+      </div>
+    </section>
+
+    <!-- 4. Controls -->
+    <section class="mb-14" id="controls">
+      <h2 class="mb-4 text-2xl font-bold">4. Controls travel with your block</h2>
+      <p class="mb-4 text-foreground">
+        Add controls to your block exactly as you would on any overlay, and reference them with
+        <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">[[[c:your_key]]]</code>. When someone
+        places your block and saves, the controls it needs are created on their overlay automatically, with your
+        defaults - the block arrives batteries included.
+      </p>
+      <ul class="list-disc space-y-2 pl-6 text-foreground">
+        <li>
+          If a control with the same key already exists on the overlay, it's <strong>shared</strong>, not duplicated.
+          Blocks that agree on a key stay in sync - deliberate, and worth designing for: a generic key like
+          <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">donation_total</code> invites sharing, a
+          specific one like <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">subathon_end_at</code>
+          keeps to itself.
+        </li>
+        <li>
+          Integration-managed controls (Ko-fi, StreamLabs, and friends) are account-wide already and don't travel with
+          blocks - only your own custom controls do.
+        </li>
+      </ul>
+    </section>
+
+    <!-- 5. Snapshots -->
+    <section class="mb-14" id="snapshots">
+      <h2 class="mb-4 text-2xl font-bold">5. Snapshots: placing copies your code</h2>
+      <p class="mb-4 text-foreground">
+        When someone places your block, the Builder copies your code <em>at that moment</em> into their overlay. From
+        then on, their overlay never references your block again. You can edit your block freely, rename it, even
+        delete it - overlays that placed it keep working, byte for byte, forever.
+      </p>
+      <div class="mb-4 rounded-lg border border-violet-400/40 bg-violet-400/5 p-5">
+        <p class="text-foreground">
+          This is a promise in both directions: <strong>your edits can never break someone's live stream</strong>, and
+          nobody's overlay can be changed behind their back. Trust by construction, not by policy.
+        </p>
+      </div>
+      <p class="text-foreground">
+        Updates still flow - just explicitly. When a placed block's source has newer code, the Builder shows a
+        "Source updated" badge on the placement and offers <strong>Refresh from source</strong>: one click re-takes
+        the snapshot in place, keeping position and size. Renames are even gentler - a block's name is just a label,
+        so placements pick up your new name automatically.
+      </p>
+    </section>
+
+    <!-- 6. Publishing -->
+    <section class="mb-14" id="publishing">
+      <h2 class="mb-4 text-2xl font-bold">6. Publishing your block</h2>
+      <p class="mb-4 text-foreground">
+        Flip your block to <strong>public</strong> and it appears in everyone's Builder picker, searchable by name and
+        description. A good public block ships with:
+      </p>
+      <ul class="mb-4 list-disc space-y-2 pl-6 text-foreground">
+        <li>a clear name and a description that says what it shows and which controls it uses,</li>
+        <li>a sensible suggested size,</li>
+        <li>fill-the-box CSS (see section 3) so it looks right at any placement size,</li>
+        <li>sane control defaults, so it renders something meaningful the moment it's placed.</li>
+      </ul>
+      <p class="text-foreground">
+        Private blocks are just as useful - build a personal kit of pieces and recompose your own overlays in minutes
+        instead of hours.
+      </p>
+    </section>
+
+    <!-- Bottom line -->
+    <div class="mb-14 rounded-lg border border-violet-400/40 bg-violet-400/5 p-6">
+      <p class="mb-3 text-lg font-medium text-foreground">Bottom line</p>
+      <p class="text-foreground">
+        A block is a regular template with a composable attitude: fill-the-box CSS, scoped styles, controls included,
+        snapshot-copied on placement so nothing breaks behind anyone's back. Build one well and it gets placed on
+        overlays you'll never see - which is exactly the point. To see the other side of the handshake, read
+        <Link href="/help/builder" class="text-violet-400 hover:underline">The Builder</Link>.
+      </p>
+    </div>
+  </HelpLayout>
+</template>

--- a/resources/js/pages/help/Blocks.vue
+++ b/resources/js/pages/help/Blocks.vue
@@ -48,7 +48,7 @@ const scopingExample = `/* you write */
       <Heading
         title="Blocks"
         title-class="text-4xl font-bold mb-4"
-        description="A block is a small, self-contained overlay piece: a follower counter, a donation goal, a chat box frame. Build it once with the same HTML, CSS, and tags as any overlay - then anyone can place it on a grid in the Builder, no code required on their end."
+        description="A block is a small, self-contained overlay piece: a follower counter, a donation goal, anything that can live within Overlabels. Build it once with the same HTML, CSS, and tags as any overlay - then anyone can place it on a grid in the Builder, no code required on their end."
       />
     </div>
 

--- a/resources/js/pages/help/Builder.vue
+++ b/resources/js/pages/help/Builder.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
+import type { BreadcrumbItem } from '@/types';
+import HelpLayout from '@/layouts/HelpLayout.vue';
+import Heading from '@/components/Heading.vue';
+
+const breadcrumbs: BreadcrumbItem[] = [
+  { title: 'Help', href: '/help' },
+  { title: 'The Builder', href: '/help/builder' },
+];
+
+// What a composed overlay actually compiles to: a fixed grid container and
+// one wrapper per placed block. Nothing magical, nothing proprietary.
+const compiledExample = `#builder-root {
+  position: fixed;
+  width: 1920px;
+  height: 1080px;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: repeat(8, 1fr);
+  gap: 8px;
+}
+
+#blk-a3f2 { grid-area: 1 / 1 / span 2 / span 4; }
+#blk-9k1x { grid-area: 3 / 5 / span 3 / span 4; }
+
+/* each block's own CSS follows, scoped to its wrapper */`;
+</script>
+
+<template>
+  <HelpLayout
+    :breadcrumbs="breadcrumbs"
+    title="The Builder - compose an overlay without writing code"
+    description="Set up a grid, click a cell, pick a block, save. The Builder compiles your composition into a plain static overlay that works with everything else in Overlabels - OBS, alerts, controls, live data."
+    canonical-url="https://overlabels.com/help/builder"
+  >
+    <!-- Header -->
+    <div class="mb-10">
+      <Heading
+        title="The Builder"
+        title-class="text-4xl font-bold mb-4"
+        description="Overlabels is HTML and CSS all the way down - but you don't have to write any of it. The Builder lets you compose a full overlay by placing ready-made blocks on a grid. Set up the grid, click a cell, pick a block, save. Done."
+      />
+    </div>
+
+    <!-- TOC -->
+    <div class="mb-12 border border-sidebar-border bg-card p-6">
+      <h2 class="mb-4 text-xl font-bold" id="toc">Table of contents</h2>
+      <ol class="list-decimal space-y-1 pl-6 text-foreground">
+        <li><a href="#what" class="text-violet-400 hover:underline">What the Builder is</a></li>
+        <li><a href="#composing" class="text-violet-400 hover:underline">Composing: the grid and the picker</a></li>
+        <li><a href="#arranging" class="text-violet-400 hover:underline">Arranging: drag, keys, preview</a></li>
+        <li><a href="#saving" class="text-violet-400 hover:underline">Saving: you get a plain static overlay</a></li>
+        <li><a href="#controls" class="text-violet-400 hover:underline">Controls come along</a></li>
+        <li><a href="#editing" class="text-violet-400 hover:underline">Editing later, refreshing blocks, ejecting</a></li>
+      </ol>
+    </div>
+
+    <!-- 1. What -->
+    <section class="mb-14" id="what">
+      <h2 class="mb-4 text-2xl font-bold">1. What the Builder is</h2>
+      <p class="mb-4 text-foreground">
+        The Builder is a visual composer for static overlays. You place
+        <Link href="/help/blocks" class="text-violet-400 hover:underline">blocks</Link> - small, reusable overlay
+        pieces made by you or by the community - on a CSS grid sized to a 1920x1080 canvas, exactly the frame OBS
+        renders. Every block already knows how to show live data: follower counts, donation goals, timers, whatever
+        its author wired up.
+      </p>
+      <p class="text-foreground">
+        The important part is what the Builder is <em>not</em>: it's not a separate kind of overlay with its own
+        runtime. When you save, your composition compiles down to the same HTML and CSS every hand-written overlay is
+        made of. Everything that works for a hand-written static overlay works for a composed one, automatically.
+      </p>
+    </section>
+
+    <!-- 2. Composing -->
+    <section class="mb-14" id="composing">
+      <h2 class="mb-4 text-2xl font-bold">2. Composing: the grid and the picker</h2>
+      <p class="mb-4 text-foreground">
+        Open the Builder from the templates page (the <strong>Builder</strong> button) or the command palette. You
+        start with a 12x8 grid - presets for 6x4 and 16x9 are one click away, and you can set anything up to 24x24
+        plus the gap between cells. The canvas behind the grid is always 1920x1080, so what you see is
+        pixel-true to what OBS will render.
+      </p>
+      <p class="mb-4 text-foreground">
+        Click any empty cell and the block picker opens: your own blocks plus every public block from the community,
+        searchable. Pick one and it lands on that cell at its suggested size, shrunk if needed to fit the free space.
+        Each placed block shows a live preview with sample data, so the canvas always looks like a real overlay
+        instead of a wireframe.
+      </p>
+      <div class="rounded-lg border border-violet-400/40 bg-violet-400/5 p-5">
+        <p class="text-foreground">
+          Saw a full static overlay you like? Its <strong>Copy</strong> action can copy it <em>as a block</em> - which
+          means the entire public overlay library is potential Builder material, not just things that were born as
+          blocks.
+        </p>
+      </div>
+    </section>
+
+    <!-- 3. Arranging -->
+    <section class="mb-14" id="arranging">
+      <h2 class="mb-4 text-2xl font-bold">3. Arranging: drag, keys, preview</h2>
+      <ul class="mb-4 list-disc space-y-2 pl-6 text-foreground">
+        <li><strong>Drag</strong> a block to move it. It snaps cell to cell and refuses to overlap another block - it simply stops at the last valid spot.</li>
+        <li><strong>Click</strong> a block to select it. The side panel shows move and resize buttons plus Remove.</li>
+        <li><strong>Arrow keys</strong> move the selected block, <strong>Shift + arrows</strong> resize it, <strong>Delete</strong> removes it.</li>
+        <li><strong>Preview</strong> renders the actual compiled output with sample data in a dialog - the same code that will ship to OBS.</li>
+      </ul>
+      <p class="text-foreground">
+        Blocks can never overlap, by design. Every position and size runs through the same occupancy check, whether
+        it came from a drag, a button, or a keyboard shortcut. A composed overlay is always a clean, gap-respecting
+        grid.
+      </p>
+    </section>
+
+    <!-- 4. Saving -->
+    <section class="mb-14" id="saving">
+      <h2 class="mb-4 text-2xl font-bold">4. Saving: you get a plain static overlay</h2>
+      <p class="mb-4 text-foreground">
+        Hitting Save compiles the grid and every placed block into one static overlay. The output is genuinely simple -
+        a fixed 1920x1080 grid container and one wrapper per block:
+      </p>
+      <pre class="mb-4 overflow-x-auto rounded border border-sidebar-border bg-card p-4 font-mono text-sm text-foreground"><code>{{ compiledExample }}</code></pre>
+      <p class="mb-4 text-foreground">
+        Because the result is an ordinary static overlay, the whole platform just works on it:
+        <strong>Add to OBS</strong> gives you the browser-source URL with your access token,
+        <Link href="/help/overlays-vs-alerts" class="text-violet-400 hover:underline">alerts</Link> can target it,
+        live values update over WebSockets, and it shows up in your overlay list like any other. There is no
+        "Builder runtime" - just HTML and CSS you could have written by hand, if you had the time and the inclination.
+      </p>
+    </section>
+
+    <!-- 5. Controls -->
+    <section class="mb-14" id="controls">
+      <h2 class="mb-4 text-2xl font-bold">5. Controls come along</h2>
+      <p class="mb-4 text-foreground">
+        Blocks that use <Link href="/help/controls" class="text-violet-400 hover:underline">Controls</Link> bring them
+        with them: when you save, any control a placed block needs is created on your overlay automatically. On the
+        overlay's Controls tab, each of those controls wears a little pill naming the block that uses it, so you always
+        know which control drives what.
+      </p>
+      <ul class="mb-4 list-disc space-y-2 pl-6 text-foreground">
+        <li>
+          <strong>Blocks sharing a control key stay in sync.</strong> Place two blocks that both use
+          <code class="rounded bg-background px-1.5 py-0.5 font-mono text-sm">donation_total</code> and they share one
+          control - update it once, both blocks update. That's a feature, not an accident.
+        </li>
+        <li>
+          <strong>Removing a block keeps its controls.</strong> Your counter at 500 survives a layout experiment.
+          Leftovers are flagged "Not used by any block" on the Controls tab, where deleting them is one click - your
+          call, never automatic.
+        </li>
+      </ul>
+    </section>
+
+    <!-- 6. Editing later -->
+    <section class="mb-14" id="editing">
+      <h2 class="mb-4 text-2xl font-bold">6. Editing later, refreshing blocks, ejecting</h2>
+      <p class="mb-4 text-foreground">
+        Reopen a composed overlay's edit page and the Code tab shows the grid editor again, with your layout exactly
+        as you left it. Two things worth knowing:
+      </p>
+      <ul class="mb-4 list-disc space-y-2 pl-6 text-foreground">
+        <li>
+          <strong>Refresh from source.</strong> Placing a block copies its code at that moment, so a block author
+          editing their block can never silently change your overlay. When a source block <em>has</em> changed, the
+          editor tells you - a "Source updated" badge on the placement and a sync bar above the canvas - and updating
+          to the new version is one click, keeping the block's position and size. Nothing changes until you save.
+        </li>
+        <li>
+          <strong>Open in code editor.</strong> The overlay's actions menu can convert a composed overlay to a
+          hand-edited one: you get the full compiled HTML and CSS in the regular code editor, and the grid tools go
+          away for that overlay. It's a one-way door - great when you've outgrown the grid, permanent once you walk
+          through it.
+        </li>
+      </ul>
+      <div class="rounded-lg border border-yellow-500/40 bg-yellow-500/5 p-5">
+        <p class="text-foreground">
+          <strong>Heads up:</strong> ejecting to the code editor cannot be undone. The compiled code stays exactly as
+          it was - you lose nothing except the grid editing tools for that overlay.
+        </p>
+      </div>
+    </section>
+
+    <!-- Bottom line -->
+    <div class="mb-14 rounded-lg border border-violet-400/40 bg-violet-400/5 p-6">
+      <p class="mb-3 text-lg font-medium text-foreground">Bottom line</p>
+      <p class="text-foreground">
+        The Builder is assembly, not magic: blocks on a grid, compiled to the same plain HTML and CSS everything else
+        in Overlabels runs on. Compose in minutes, keep every power feature, and if you ever want to see how the
+        sausage is made - preview it, or eject and read the code. Want to make blocks of your own? That's the
+        <Link href="/help/blocks" class="text-violet-400 hover:underline">Blocks</Link> page.
+      </p>
+    </div>
+  </HelpLayout>
+</template>

--- a/resources/js/pages/help/Index.vue
+++ b/resources/js/pages/help/Index.vue
@@ -2,7 +2,7 @@
 import type { BreadcrumbItem } from '@/types';
 import HelpLayout from '@/layouts/HelpLayout.vue';
 import HelpCardGrid from '@/components/help/HelpCardGrid.vue';
-import { Bot, BookOpen, Brackets, FunctionSquare, Heart, FileText, Layers, Lightbulb, Library, ListChecks, Palette, Pipette, Plug, Radio, Sigma, SlidersHorizontal, Sparkles, Swords } from '@lucide/vue';
+import { Blocks, Bot, BookOpen, Brackets, FunctionSquare, Heart, FileText, Layers, LayoutGrid, Lightbulb, Library, ListChecks, Palette, Pipette, Plug, Radio, Sigma, SlidersHorizontal, Sparkles, Swords } from '@lucide/vue';
 import Heading from '@/components/Heading.vue';
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -33,6 +33,18 @@ const pages = [
     description: 'The two kinds of overlay and how they fit together: why alerts are most powerful rendered inside a static overlay\'s DOM, plus Targeting vs Triggers.',
     href: '/help/overlays-vs-alerts',
     icon: Layers,
+  },
+  {
+    title: 'The Builder',
+    description: 'Compose an overlay without writing code: set up a grid, click a cell, pick a block, save. Compiles to a plain static overlay that works with everything else.',
+    href: '/help/builder',
+    icon: LayoutGrid,
+  },
+  {
+    title: 'Blocks',
+    description: 'Reusable building pieces for the Builder: how to author one, how CSS scoping and snapshots keep everyone safe, and how controls travel with your block.',
+    href: '/help/blocks',
+    icon: Blocks,
   },
   {
     title: 'Why Ko-fi',

--- a/routes/web.php
+++ b/routes/web.php
@@ -134,6 +134,14 @@ Route::get('/help/overlays-vs-alerts', function () {
     return Inertia::render('help/OverlaysVsAlerts');
 })->name('help.overlays-vs-alerts');
 
+Route::get('/help/builder', function () {
+    return Inertia::render('help/Builder');
+})->name('help.builder');
+
+Route::get('/help/blocks', function () {
+    return Inertia::render('help/Blocks');
+})->name('help.blocks');
+
 Route::get('/help/formatting', function () {
     return Inertia::render('help/Formatting');
 })->name('help.formatting');


### PR DESCRIPTION
## Summary

Two new help pages covering the block-based composing story, in the established help-page format (HelpLayout, TOC, numbered sections, callouts, bottom line), cross-linking each other as two sides of one handshake.

### /help/builder - The Builder (for composers)

What the Builder is (assembly, not a separate runtime - the actual compiled `#builder-root` CSS is shown so readers see there is no magic), the grid and picker, arranging via drag/keyboard/preview and why overlap is impossible, why saving yields a plain static overlay that all existing machinery works on (Add to OBS, alerts, WebSockets), how controls come along (shared keys sync as a feature, removal keeps values), refresh from source, and the one-way eject door with a heads-up callout.

### /help/blocks - Blocks (for block authors)

The third template type, both creation paths (from scratch, Copy-as-Block), the fill-the-box CSS pattern (`width/height: 100%` against the definite-size wrapper), a before/after of compile-time selector scoping (`:root`/`body` mapping onto the wrapper), the `@keyframes`/`@font-face` global passthrough caveat, controls traveling with defaults plus key-naming advice (generic keys invite sharing, specific keys keep to themselves), snapshot semantics framed as a two-way trust promise, and publishing guidelines for good public blocks.

### Wiring

- Routes registered as `help.builder` and `help.blocks`
- Two new cards on the help index (LayoutGrid and Blocks icons), placed after Overlays vs Alerts
- Plus a tiny copy fix from Jasper

## Test plan

- /help/builder and /help/blocks render with correct meta/OG tags via HelpLayout
- Help index shows both new cards; TOC anchors and cross-links work
- ESLint + vue-tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)