### PR TITLE
chore(deps): dependency audit and in-range updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1139,16 +1139,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -1247,7 +1247,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -1263,7 +1263,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1772,16 +1772,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.21.1",
+            "version": "v13.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "303b5f8dc899f89e8c38c350b639b8fbd193ed16"
+                "reference": "92a707229148e57f08a249211c8a5a194159c619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/303b5f8dc899f89e8c38c350b639b8fbd193ed16",
-                "reference": "303b5f8dc899f89e8c38c350b639b8fbd193ed16",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/92a707229148e57f08a249211c8a5a194159c619",
+                "reference": "92a707229148e57f08a249211c8a5a194159c619",
                 "shasum": ""
             },
             "require": {
@@ -1807,7 +1807,7 @@
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
-                "monolog/monolog": "^3.0",
+                "monolog/monolog": "^3.10",
                 "nesbot/carbon": "^3.8.4",
                 "nunomaduro/termwind": "^2.0",
                 "php": "^8.3",
@@ -1995,7 +1995,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-07-21T14:27:35+00:00"
+            "time": "2026-07-27T14:48:58+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,15 @@
 # CHANGELOG JULY 2026
 
+## July 27th, 2026 - chore(deps): dependency audit and in-range updates
+
+A security sweep across both dependency trees. `npm audit` and `composer audit` both report zero advisories against 366 npm packages and the full Composer tree, so nothing here was a fix - these are routine currency updates applied while the trees were clean.
+
+- **Composer**: `laravel/framework` v13.21.1 -> v13.23.0 (the only outdated direct dependency; everything else was already current).
+- **npm**: 12 packages moved within their existing semver ranges - `@codemirror/view` 6.43.7, `@lucide/vue` 1.27.0, `@vue/devtools-api` 8.2.1 (plus devtools-kit/shared), `eslint` 10.8.0, `concurrently` 10.0.4, `@types/node` 26.1.2, and transitive bumps to `postcss`, `minimatch`, `es-toolkit`, and `@eslint/config-helpers`.
+- **Manifests unchanged**: only `composer.lock` and `package-lock.json` moved. No declared ranges were widened, so nothing new entered either tree.
+- **Held back**: `typescript` 6.0.3 -> 7.0.2 is a major and stays pinned at `^6.0.3` pending a deliberate upgrade pass (it drags `vue-tsc` and `typescript-eslint` compatibility with it). The two `MISSING` optional deps in `npm outdated` (`@tailwindcss/oxide-linux-x64-gnu`, `lightningcss-linux-x64-gnu`) are Linux-only binaries that correctly skip installation on the Windows dev machine and resolve in the production image.
+- Verified with a production Vite build, ESLint, and the full Pest suite: 1036 passed, 2900 assertions.
+
 ## July 26th, 2026 - docs(help): The Builder and Blocks help pages
 
 Two new help docs covering the block-based composing story, both in the established help-page format (TOC, numbered sections, callouts, bottom line) and linked from the help index:

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,9 +249,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.43.6",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
-            "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+            "version": "6.43.7",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
+            "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.7.0",
@@ -425,9 +425,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+            "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -800,9 +800,9 @@
             }
         },
         "node_modules/@lucide/vue": {
-            "version": "1.26.0",
-            "resolved": "https://registry.npmjs.org/@lucide/vue/-/vue-1.26.0.tgz",
-            "integrity": "sha512-jz00zLm8+i7VzBuQTbmjChIvIKehaIK5YbOVC+bab7qTh4JTkCd0XJQ4l5TY57gT08fMPVlvUITROB/vm/xImA==",
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@lucide/vue/-/vue-1.27.0.tgz",
+            "integrity": "sha512-LKDEZJ0Uo9UaT4vxBMYVwXeK/0dGcWCTdav1AK/aGD/jYsDPtiVvOgfM7jPlx9BVeyGZ1Uf0aQhHA++rmbe7rw==",
             "license": "ISC",
             "peerDependencies": {
                 "vue": ">=3.0.1"
@@ -1568,9 +1568,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.1.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -2013,30 +2013,30 @@
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.5.tgz",
-            "integrity": "sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.2.1.tgz",
+            "integrity": "sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^8.1.5"
+                "@vue/devtools-kit": "^8.2.1"
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-            "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+            "integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-shared": "^8.1.5",
+                "@vue/devtools-shared": "^8.2.1",
                 "birpc": "^2.6.1",
                 "hookable": "^5.5.3",
                 "perfect-debounce": "^2.0.0"
             }
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-            "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+            "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
             "license": "MIT"
         },
         "node_modules/@vue/eslint-config-typescript": {
@@ -2477,15 +2477,15 @@
             }
         },
         "node_modules/concurrently": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-            "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+            "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "5.6.2",
                 "rxjs": "7.8.2",
-                "shell-quote": "1.8.4",
+                "shell-quote": "1.9.0",
                 "supports-color": "10.2.2",
                 "tree-kill": "1.2.2",
                 "yargs": "18.0.0"
@@ -2718,13 +2718,14 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
-            "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
             "license": "MIT",
             "workspaces": [
                 "docs",
-                "benchmarks"
+                "benchmarks",
+                "tests/types"
             ]
         },
         "node_modules/escalade": {
@@ -2751,9 +2752,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.7.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-            "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+            "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -2763,7 +2764,7 @@
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
                 "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.6.0",
+                "@eslint/config-helpers": "^0.7.0",
                 "@eslint/core": "^1.2.1",
                 "@eslint/plugin-kit": "^0.7.2",
                 "@humanfs/node": "^0.16.6",
@@ -2787,7 +2788,7 @@
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "minimatch": "^10.2.4",
+                "minimatch": "^10.2.5",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -3926,13 +3927,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -4175,9 +4176,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.22",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-            "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",


### PR DESCRIPTION
## Security status

Both dependency trees are **clean**. No advisories, so nothing in this PR is a fix - these are routine currency updates applied while the trees were already green.

| Audit | Result |
| --- | --- |
| `npm audit` | 0 vulnerabilities across 366 packages |
| `composer audit` | No security vulnerability advisories found |

## What changed

**Composer**
- `laravel/framework` v13.21.1 -> v13.23.0 - the only outdated direct dependency

**npm** - 12 packages, all within their existing semver ranges:
- `eslint` 10.7.0 -> 10.8.0
- `@codemirror/view` 6.43.6 -> 6.43.7
- `@lucide/vue` 1.26.0 -> 1.27.0
- `@vue/devtools-api` 8.1.5 -> 8.2.1 (plus `devtools-kit` / `devtools-shared`)
- `concurrently` 10.0.3 -> 10.0.4
- `@types/node` 26.1.1 -> 26.1.2
- transitive: `postcss` 8.5.23, `minimatch` 10.2.6, `es-toolkit` 1.50.0, `@eslint/config-helpers` 0.7.0

Only `composer.lock` and `package-lock.json` moved. No declared range in `package.json` or `composer.json` was widened, so nothing new entered either tree.

## Deliberately held back

- **`typescript` 6.0.3 -> 7.0.2** stays pinned at `^6.0.3`. A major that drags `vue-tsc` and `typescript-eslint` compatibility with it, and there is no reported problem driving it. Revisit around 7.1, or sooner if something actually breaks.
- The `MISSING` rows for `@tailwindcss/oxide-linux-x64-gnu` and `lightningcss-linux-x64-gnu` in `npm outdated` are expected - Linux-only binaries that correctly skip installation on the Windows dev machine and resolve in the production image.

## Verification

- `npm run build` - production Vite build green
- `npm run lint` - ESLint clean
- `php artisan test` - **1036 passed, 2900 assertions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)