### PR TITLE
feat(help): contextual help - pages declare where they are relevant, and a beacon that shows them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,8 @@ Critical variables:
 - Declared constraints must match; **undeclared query params are ignored** (so `search`/`sort`/`page` never break a match). There is no allowlist of meaningful params and none is needed.
 - `HelpContext::add(['type' => $template->type])` injects context the URL cannot carry (one route, three template types). It merges into the same bag as the query string - one matcher.
 - `HelpContext::for()` returns ALL matches, best first: exact-over-wildcard, then constraint count, then literal pattern length, then slug. No `priority:` key on purpose - specificity is the only currency.
-- Shared as the `help` Inertia prop (`HelpLink[]`). No UI consumes it yet.
+- Shared as the `help` Inertia prop (`HelpLink[]`: slug, title, lead, url). Card copy uses the page's `heading` + `lead`, NOT `title` + `description` - the latter are written for browser tabs and search results and run too long for a 375px panel. A test caps both at panel length.
+- `HelpBeacon.vue` renders it: floating bottom-right button on every app page (mounted once in `AppLayout`), dot when help matched, 375x650 panel. Links open in a new tab - the point is helping with the page you are on, so navigating away from it would undo the feature.
 - Two tests are load-bearing: every declared context must name a real route (catches renames), and no single context may resolve to more than 3 pages (stops generic routes rotting into a link farm). Both verified to fail when violated - keep them.
 
 ## Development Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,16 @@ Critical variables:
 - Adding a provider: pick an unused `uint16` with 4-8 filled cells, confirm `iconDistance() >= 6` against every existing icon. Current set's min pairwise distance is 8.
 - Icon SHAPE is keyed by `source` (twitch/kofi/streamlabs/streamelements/bmac/fourthwall/throne), NOT event type - all Twitch events share the Twitch ring. Icon COLOR is keyed by event type for Twitch (and by source for externals - see the reinforcement bullet). Event type is additionally carried by the adjacent text label. `TemplateTable.vue` still uses `eventTypeDotClass` in a different context (which event triggers a template).
 
+## Contextual Help (Implemented Jul 2026)
+
+- Help pages declare where they are relevant, in a flat `context:` frontmatter line: `context: templates.index?type=block, templates.show?type=block, builder.create`. The association lives in the markdown, NOT in a central route map - writing the page wires it up.
+- Key is the **route name**, not the URL. Optional `?k=v` constraints narrow one name down to a state (`/templates` is one route serving four filter states). Wildcards use `Str::is()`, so `settings.bot.*` works.
+- Declared constraints must match; **undeclared query params are ignored** (so `search`/`sort`/`page` never break a match). There is no allowlist of meaningful params and none is needed.
+- `HelpContext::add(['type' => $template->type])` injects context the URL cannot carry (one route, three template types). It merges into the same bag as the query string - one matcher.
+- `HelpContext::for()` returns ALL matches, best first: exact-over-wildcard, then constraint count, then literal pattern length, then slug. No `priority:` key on purpose - specificity is the only currency.
+- Shared as the `help` Inertia prop (`HelpLink[]`). No UI consumes it yet.
+- Two tests are load-bearing: every declared context must name a real route (catches renames), and no single context may resolve to more than 3 pages (stops generic routes rotting into a link farm). Both verified to fail when violated - keep them.
+
 ## Development Workflow
 
 ### Setting Up Twitch Integration

--- a/app/Http/Controllers/OverlayTemplateController.php
+++ b/app/Http/Controllers/OverlayTemplateController.php
@@ -18,6 +18,7 @@ use App\Services\TemplateDataMapperService;
 use App\Services\TwitchApiService;
 use App\Services\TwitchEventSubService;
 use App\Services\TwitchTokenService;
+use App\Support\HelpContext;
 use App\Support\ListItems;
 use Exception;
 use Illuminate\Http\RedirectResponse;
@@ -186,6 +187,10 @@ class OverlayTemplateController extends Controller
         $template->load(['owner:id,name,avatar', 'forkParent:id,name,slug']);
         $template->loadCount('forks');
         $template->loadExists('kits');
+
+        // One route serves blocks, alerts and static overlays, so the URL alone
+        // cannot say which help page belongs here. See App\Support\HelpContext.
+        HelpContext::add(['type' => $template->type]);
 
         $canEdit = auth()->id() === $template->owner_id;
         $controls = $canEdit

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -6,6 +6,7 @@ use App\Models\StreamState;
 use App\Models\User;
 use App\Services\LockdownService;
 use App\Services\TwitchScopeService;
+use App\Support\HelpContext;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -62,6 +63,10 @@ class HandleInertiaRequests extends Middleware
                 'fork_wizard' => fn () => $request->session()->get('fork_wizard'),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            // Help pages relevant to wherever the user is standing, best first.
+            // Declared by the pages themselves in `context:` frontmatter, so
+            // this stays empty until a page claims the route.
+            'help' => fn () => HelpContext::forRequest($request),
             'isAdmin' => fn () => $request->user()?->isAdmin() ?? false,
             'lockdown' => fn () => app(LockdownService::class)->getStatus(),
             'streamState' => function () use ($request) {

--- a/app/Support/HelpContext.php
+++ b/app/Support/HelpContext.php
@@ -35,8 +35,8 @@ final class HelpContext
     /** @var array<string,array<int,array{slug:string,pattern:string,constraints:array<string,string>}>>|null */
     private static ?array $index = null;
 
-    /** @var array<string,string> Slug to title, filled while indexing. */
-    private static array $titles = [];
+    /** @var array<string,array{title:string,lead:string}> Slug to card copy, filled while indexing. */
+    private static array $cards = [];
 
     /**
      * Add context the URL does not carry.
@@ -133,7 +133,8 @@ final class HelpContext
         return array_values(array_map(
             fn (array $match): array => [
                 'slug' => $match['slug'],
-                'title' => self::$titles[$match['slug']] ?? Str::headline($match['slug']),
+                'title' => self::$cards[$match['slug']]['title'] ?? Str::headline($match['slug']),
+                'lead' => self::$cards[$match['slug']]['lead'] ?? '',
                 'url' => HelpPage::url($match['slug']),
             ],
             $matches
@@ -192,11 +193,22 @@ final class HelpContext
         }
 
         $index = [];
-        self::$titles = [];
+        self::$cards = [];
 
         foreach (HelpPage::all() as $slug) {
             $meta = HelpPage::meta($slug);
-            self::$titles[$slug] = $meta['title'] ?? Str::headline($slug);
+
+            self::$cards[$slug] = [
+                // `heading` is the page's own short name ("Blocks"); `title` is
+                // written for a browser tab and search results ("Blocks -
+                // reusable building pieces for the Builder"), which is too long
+                // for a 375px panel. Prefer the heading, fall back to the title.
+                'title' => $meta['heading'] ?? $meta['title'] ?? Str::headline($slug),
+                // The lead is already the page's opening paragraph, authored to
+                // introduce it. That makes it the excerpt, at no render cost -
+                // no markdown pass, no body read, nothing to keep in sync.
+                'lead' => $meta['lead'] ?? $meta['description'] ?? '',
+            ];
 
             foreach (self::parse($slug, $meta['context'] ?? '') as $entry) {
                 $index[$entry['pattern']][] = $entry;

--- a/app/Support/HelpContext.php
+++ b/app/Support/HelpContext.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+/**
+ * Answers "which help pages are relevant to where the user is standing?"
+ *
+ * The association is declared by the help page itself, in a flat `context:`
+ * frontmatter line listing the route names it covers:
+ *
+ *   context: templates.index?type=block, templates.blocks.library, builder.create
+ *
+ * It lives in the markdown rather than in a central map for the same reason the
+ * prose does: writing the page wires it up, so there is no second file to keep
+ * in step. Reading blocks.md tells you where it surfaces. The index here is the
+ * inverse - route name to pages - built by scanning frontmatter.
+ *
+ * Route NAMES are the key, not URLs. They are already unique, they survive a
+ * URL being rewritten, and `$request->route()->getName()` hands one over for
+ * free. Query constraints narrow a name down to a state, because /templates is
+ * one route serving four filter states.
+ *
+ * Matching is deliberately dull. Nothing here guesses: a page is offered
+ * because it said it belonged, or it is not offered at all. A wrong contextual
+ * link is worse than no link, because it teaches people the help button lies.
+ */
+final class HelpContext
+{
+    /** Where controller-supplied context rides, per request. */
+    private const string ATTRIBUTE = 'help_context';
+
+    /** @var array<string,array<int,array{slug:string,pattern:string,constraints:array<string,string>}>>|null */
+    private static ?array $index = null;
+
+    /** @var array<string,string> Slug to title, filled while indexing. */
+    private static array $titles = [];
+
+    /**
+     * Add context the URL does not carry.
+     *
+     * /templates/{template} is one route serving blocks, alerts and static
+     * overlays - the discriminator is the model, not the query string. A
+     * controller that knows better says so:
+     *
+     *   HelpContext::add(['type' => $template->type]);
+     *
+     * and `context: templates.show?type=alert` then matches through the exact
+     * same code path as a real query parameter. One matcher, and the controller
+     * decides what the meaningful discriminator is.
+     *
+     * @param  array<string,mixed>  $params
+     */
+    public static function add(array $params): void
+    {
+        $request = request();
+
+        $request->attributes->set(self::ATTRIBUTE, [
+            ...$request->attributes->get(self::ATTRIBUTE, []),
+            ...$params,
+        ]);
+    }
+
+    /**
+     * Resolve help pages for the current request.
+     *
+     * @return array<int,array{slug:string,title:string,url:string}>
+     */
+    public static function forRequest(Request $request): array
+    {
+        $name = $request->route()?->getName();
+
+        if ($name === null) {
+            return [];
+        }
+
+        return self::for($name, [
+            ...$request->query(),
+            ...$request->attributes->get(self::ATTRIBUTE, []),
+        ]);
+    }
+
+    /**
+     * Resolve help pages for a route name and a bag of context parameters.
+     *
+     * Every match is returned, best first, because scoring has to happen to
+     * pick a winner anyway and collapsing to one here would throw away a
+     * decision the frontend has not made yet.
+     *
+     * @param  array<string,mixed>  $params
+     * @return array<int,array{slug:string,title:string,url:string}>
+     */
+    public static function for(string $routeName, array $params = []): array
+    {
+        $matches = [];
+
+        foreach (self::index() as $pattern => $entries) {
+            $exact = $pattern === $routeName;
+
+            if (! $exact && ! (str_contains($pattern, '*') && Str::is($pattern, $routeName))) {
+                continue;
+            }
+
+            foreach ($entries as $entry) {
+                if (! self::satisfies($entry['constraints'], $params)) {
+                    continue;
+                }
+
+                $candidate = [
+                    'slug' => $entry['slug'],
+                    'exact' => $exact,
+                    'constraints' => count($entry['constraints']),
+                    // A longer literal prefix is a more deliberate wildcard:
+                    // settings.bot.expressions.* beats settings.bot.*
+                    'literal' => strlen(str_replace('*', '', $pattern)),
+                ];
+
+                // A page may declare several contexts that all match at once
+                // (a bare route name plus a narrowed one). It earns its best
+                // score, not one entry per declaration.
+                $existing = $matches[$entry['slug']] ?? null;
+
+                if ($existing === null || self::compare($candidate, $existing) < 0) {
+                    $matches[$entry['slug']] = $candidate;
+                }
+            }
+        }
+
+        uasort($matches, self::compare(...));
+
+        return array_values(array_map(
+            fn (array $match): array => [
+                'slug' => $match['slug'],
+                'title' => self::$titles[$match['slug']] ?? Str::headline($match['slug']),
+                'url' => HelpPage::url($match['slug']),
+            ],
+            $matches
+        ));
+    }
+
+    /**
+     * Rank two candidates. Negative means the first one wins.
+     *
+     * Exactness first: naming the route outright is a stronger signal than a
+     * wildcard that happens to cover it. Then the number of constraints the
+     * page pinned down, then how literal its pattern was, then the slug so the
+     * order is stable and testable. There is deliberately no `priority:` key -
+     * a page cannot buy rank, it earns it by being more specific.
+     *
+     * @param  array{slug:string,exact:bool,constraints:int,literal:int}  $a
+     * @param  array{slug:string,exact:bool,constraints:int,literal:int}  $b
+     */
+    private static function compare(array $a, array $b): int
+    {
+        return [$b['exact'], $b['constraints'], $b['literal'], $a['slug']]
+            <=> [$a['exact'], $a['constraints'], $a['literal'], $b['slug']];
+    }
+
+    /**
+     * Declared constraints must all be present and equal. Anything undeclared
+     * is ignored, so `templates.index?type=block` still matches a URL carrying
+     * search, sort and pagination - and no allowlist of "meaningful" parameters
+     * has to be maintained anywhere.
+     *
+     * @param  array<string,string>  $constraints
+     * @param  array<string,mixed>  $params
+     */
+    private static function satisfies(array $constraints, array $params): bool
+    {
+        foreach ($constraints as $key => $value) {
+            $actual = $params[$key] ?? null;
+
+            if (! is_scalar($actual) || (string) $actual !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Route pattern to the pages claiming it.
+     *
+     * @return array<string,array<int,array{slug:string,pattern:string,constraints:array<string,string>}>>
+     */
+    public static function index(): array
+    {
+        if (self::$index !== null) {
+            return self::$index;
+        }
+
+        $index = [];
+        self::$titles = [];
+
+        foreach (HelpPage::all() as $slug) {
+            $meta = HelpPage::meta($slug);
+            self::$titles[$slug] = $meta['title'] ?? Str::headline($slug);
+
+            foreach (self::parse($slug, $meta['context'] ?? '') as $entry) {
+                $index[$entry['pattern']][] = $entry;
+            }
+        }
+
+        return self::$index = $index;
+    }
+
+    /**
+     * Parse one page's `context:` line.
+     *
+     * @return array<int,array{slug:string,pattern:string,constraints:array<string,string>}>
+     */
+    public static function declared(string $slug): array
+    {
+        return self::parse($slug, HelpPage::meta($slug)['context'] ?? '');
+    }
+
+    /**
+     * @return array<int,array{slug:string,pattern:string,constraints:array<string,string>}>
+     */
+    private static function parse(string $slug, string $line): array
+    {
+        $line = trim($line);
+
+        if ($line === '') {
+            return [];
+        }
+
+        $entries = [];
+
+        foreach (array_filter(array_map('trim', explode(',', $line))) as $context) {
+            [$pattern, $query] = array_pad(explode('?', $context, 2), 2, '');
+
+            parse_str($query, $constraints);
+
+            $entries[] = [
+                'slug' => $slug,
+                'pattern' => $pattern,
+                'constraints' => array_map(fn ($value): string => (string) $value, $constraints),
+            ];
+        }
+
+        return $entries;
+    }
+
+    /** Drop the memoised index. For tests that write help pages at runtime. */
+    public static function flush(): void
+    {
+        self::$index = null;
+        self::$titles = [];
+    }
+}

--- a/app/Support/HelpPage.php
+++ b/app/Support/HelpPage.php
@@ -78,6 +78,71 @@ final class HelpPage
     }
 
     /**
+     * The public URL for a slug.
+     *
+     * An `index` slug collapses to its parent path, so `index` is /help and
+     * `bot/index` is /help/bot. Route registration in routes/web.php derives
+     * URLs the same way and calls through here so the two cannot drift.
+     */
+    public static function url(string $slug): string
+    {
+        $path = trim((string) preg_replace('#(^|/)index$#', '', $slug), '/');
+
+        return '/help'.($path === '' ? '' : '/'.$path);
+    }
+
+    /**
+     * Frontmatter only, without rendering the body.
+     *
+     * Reads line by line and stops at the closing delimiter, because the only
+     * caller that needs this - the help-context index - reads every page on
+     * every request. Slurping whole files to get at their first ten lines would
+     * mean ~200KB of I/O to answer a question the first 1KB already answers.
+     *
+     * @return array<string,string>
+     */
+    public static function meta(string $slug): array
+    {
+        $path = self::path($slug);
+
+        if ($path === null) {
+            return [];
+        }
+
+        $handle = fopen($path, 'rb');
+
+        if ($handle === false) {
+            return [];
+        }
+
+        $lines = [];
+        $first = true;
+
+        while (($line = fgets($handle)) !== false) {
+            $line = rtrim(ltrim($line, "\xEF\xBB\xBF"), "\r\n");
+
+            if ($first) {
+                $first = false;
+                if ($line !== '---') {
+                    break;
+                }
+
+                continue;
+            }
+
+            if ($line === '---') {
+                break;
+            }
+
+            $lines[] = $line;
+        }
+
+        fclose($handle);
+
+        return self::parseFrontmatter(implode("\n", $lines));
+    }
+
+    /**
      * Render a page.
      *
      * @return array{
@@ -152,7 +217,18 @@ final class HelpPage
         $block = substr($normalized, 4, $end - 3);
         $body = ltrim(substr($normalized, $end + 4), "\n");
 
+        return [self::parseFrontmatter($block), $body];
+    }
+
+    /**
+     * Turn a frontmatter block into flat `key => value` pairs.
+     *
+     * @return array<string,string>
+     */
+    private static function parseFrontmatter(string $block): array
+    {
         $meta = [];
+
         foreach (explode("\n", $block) as $line) {
             $line = trim($line);
             if ($line === '' || ! str_contains($line, ':')) {
@@ -162,7 +238,7 @@ final class HelpPage
             $meta[trim($key)] = trim(trim(trim($value), '"\''));
         }
 
-        return [$meta, $body];
+        return $meta;
     }
 
     /**

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,18 @@
 # CHANGELOG JULY 2026
 
+## July 28th, 2026 - feat(help): help pages declare where they are relevant
+
+Help only helps if it turns up where the confusion is. The association between a place in the app and the page that explains it now lives in the help page's own frontmatter, and resolves server-side. This is the association layer only - nothing renders yet.
+
+- **`context:` frontmatter** - a flat, comma-separated list of the route names a page covers, optionally narrowed by query constraints: `context: templates.index?type=block, templates.show?type=block, templates.blocks.library, builder.create`. It lives in the markdown for the same reason the prose does: writing the page wires it up, so there is no second file to keep in step, and reading `blocks.md` tells you where it surfaces. Thirteen pages declare a context; the rest (manifesto, why-overlabels, resources) deliberately declare none.
+- **Route names, not URLs.** They are already unique, they survive a URL rewrite, and `$request->route()->getName()` hands one over. Constraints narrow a name down to a *state*, because `/templates` is one route serving four filter states.
+- **Undeclared query parameters are ignored**, so `templates.index?type=block` still matches a URL carrying `filter`, `search`, `sort` and `page`. No allowlist of "meaningful" parameters exists anywhere, because none is needed.
+- **`HelpContext::add()` for what the URL cannot say.** `/templates/{template}` serves blocks, alerts and static overlays alike - the discriminator is the model, not the query string. The controller injects `['type' => $template->type]` and `context: templates.show?type=alert` then matches through the identical code path as a real query parameter. One matcher; the controller decides what the meaningful discriminator is.
+- **Every match is returned, best first**, rather than collapsing to a single winner in the backend - ranked by exact-name-over-wildcard, then constraints pinned down, then how literal the pattern was, then slug for a stable order. There is deliberately no `priority:` key: a page cannot buy rank, it earns it by being more specific.
+- **Two guardrails, both verified to actually fail.** One asserts every declared context names a route that exists, which catches the rename that would otherwise kill contextual help silently. The other caps any single context at three pages, because left alone a generic route like `templates.index` accumulates every page that mentions templates until the help affordance is a link farm - now that is a test failure at authoring time, not a discovery two years later.
+- **Shared as the `help` Inertia prop** (`HelpLink[]`, often empty). `HelpPage` gained `meta()` - a frontmatter-only read that stops at the closing delimiter, since the index reads every page on every request and slurping whole files to get at their first ten lines would mean ~200KB of I/O per request - plus `url()`, which route registration now calls so URL derivation cannot drift.
+- **Tests:** 14 new (`HelpContextTest`), covering the matching rules, both guardrails, and end-to-end resolution of query-string and controller-injected context through real requests. Full suite **1098 passed**; Pint clean.
+
 ## July 28th, 2026 - feat(help): the help index is markdown too, so /help.md is a crawlable entry point
 
 The page conversion left the two navigation pages (`/help` and `/help/bot`) as Vue card grids, which meant a machine could read every individual help page but had no way to *discover* them - the index it would land on was still an empty shell. Both are markdown now.

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,16 @@
 # CHANGELOG JULY 2026
 
+## July 28th, 2026 - feat(help): the help beacon
+
+The frontend half of contextual help. A round button in the bottom-right corner of every app page, with a dot when the current route has help behind it, opening a panel with the relevant pages.
+
+- **`HelpBeacon.vue`**, mounted once in `AppLayout` beside the other global singletons, so all 60 app pages get it and no page opts in. Help pages themselves use `HelpLayout` and are untouched.
+- **The dot is the point.** It is the difference between a help button you learn to ignore and one that tells you, before you click, that there is something here worth reading. It only appears when the route actually resolved help.
+- **The excerpt is the page's own `lead`.** Every help page already opens with one, written to introduce it, running 94 to 275 characters - which is exactly a panel card. No markdown render, no body read, no second summary to keep in sync with the prose. `heading` is used over `title` for the same reason: "Blocks" fits a 375px panel, "Blocks - reusable building pieces for the Builder" does not. A test holds both to a length the panel can show.
+- **Links open in a new tab**, because the entire point is helping with the page you are already on - navigating away from it to read about it would undo the feature. The panel stays open behind them.
+- **375x650**, anchored to the button and shrinking to fit: `max-w-[calc(100vw-2rem)]` and `max-h-[calc(100dvh-7rem)]`, so it is a usable sheet on a phone rather than a clipped desktop panel. Escape and click-outside close it, focus moves in on open and returns to the button on close, and an Inertia navigation closes it since the answers it is showing belong to the previous route.
+- **Empty state is honest**: it says no page covers this screen yet and points at the help index, rather than dressing up nothing as something.
+
 ## July 28th, 2026 - feat(help): help pages declare where they are relevant
 
 Help only helps if it turns up where the confusion is. The association between a place in the app and the page that explains it now lives in the help page's own frontmatter, and resolves server-side. This is the association layer only - nothing renders yet.

--- a/resources/help/pages/blocks.md
+++ b/resources/help/pages/blocks.md
@@ -4,6 +4,7 @@ description: Blocks are the third template type in Overlabels: small, self-conta
 heading: Blocks
 lead: A block is a small, self-contained overlay piece: a follower counter, a donation goal, anything that can live within Overlabels. Build it once with the same HTML, CSS, and tags as any overlay - then anyone can place it on a grid in the Builder, no code required on their end.
 canonical: https://overlabels.com/help/blocks
+context: templates.index?type=block, templates.show?type=block, templates.blocks.library, builder.create
 ---
 
 ## 1. The third template type

--- a/resources/help/pages/bot/aliases.md
+++ b/resources/help/pages/bot/aliases.md
@@ -4,6 +4,7 @@ description: Short chat commands that rewrite to longer ones. Positional placeho
 heading: Bot Aliases
 lead: Short chat commands that rewrite to longer ones. Positional placeholders, one-hop guard, shared validation.
 canonical: https://overlabels.com/help/bot/aliases
+context: settings.bot.aliases.*
 section: Bot
 ---
 

--- a/resources/help/pages/bot/expressions.md
+++ b/resources/help/pages/bot/expressions.md
@@ -4,6 +4,7 @@ description: Every chat expression the @overlabels Twitch bot understands - cont
 heading: Bot Expressions
 lead: Every chat expression the @overlabels Twitch bot understands - controls, !ol chat-admin meta-expression, list operations, and built-ins.
 canonical: https://overlabels.com/help/bot/expressions
+context: settings.bot.expressions.*
 section: Bot
 ---
 

--- a/resources/help/pages/bot/index.md
+++ b/resources/help/pages/bot/index.md
@@ -4,6 +4,7 @@ description: How the @overlabels Twitch chat bot works - chat-driven controls, p
 heading: Twitch Chat Bot
 lead: The @overlabels bot joins your channel as a moderator and lets you - and optionally your mods, VIPs, or viewers - change overlay controls directly from chat. No tab-switching, no dashboards during a stream.
 canonical: https://overlabels.com/help/bot
+context: settings.bot.*
 section: Bot
 ---
 

--- a/resources/help/pages/builder.md
+++ b/resources/help/pages/builder.md
@@ -4,6 +4,7 @@ description: "Set up a grid, click a cell, pick a block, save. The Builder compi
 heading: The Builder
 lead: "Overlabels is HTML and CSS all the way down - but you don't have to write any of it. The Builder lets you compose a full overlay by placing ready-made blocks on a grid. Set up the grid, click a cell, pick a block, save. Done."
 canonical: https://overlabels.com/help/builder
+context: builder.create, templates.blocks.library
 ---
 
 ## 1. What the Builder is

--- a/resources/help/pages/conditionals.md
+++ b/resources/help/pages/conditionals.md
@@ -4,6 +4,7 @@ description: Complete reference for conditional template tags, event data, Ko-fi
 heading: Conditional Tags Reference
 lead: Complete reference for conditional template tags, event data, Ko-fi, StreamLabs, StreamElements, and Fourthwall integration tags in Overlabels overlays.
 canonical: https://overlabels.com/help/conditionals
+context: templates.edit, templates.create, tags.generator
 ---
 
 See your [static Template Tags](/tags) for your account. Need to format numbers, durations, or

--- a/resources/help/pages/controls.md
+++ b/resources/help/pages/controls.md
@@ -4,6 +4,7 @@ description: Learn how to create, manage, and use Controls in your Twitch overla
 heading: How to Use Controls
 lead: Learn how to create, manage, and use Controls in your Twitch overlays. Counters, timers, toggles, and more - all updated live during your stream.
 canonical: https://overlabels.com/help/controls
+context: settings.controls, controls.index
 ---
 
 You can also use Controls in CSS. This opens up possibilities for dynamic styling, which is incredibly

--- a/resources/help/pages/expressions.md
+++ b/resources/help/pages/expressions.md
@@ -4,6 +4,7 @@ description: "Expression Controls in Overlabels: math-powered live data with no 
 heading: Expression Controls
 lead: Math-powered live data, no code and no server. Build chained formulas like the Haversine distance and progress bars, evaluated live as your data changes.
 canonical: https://overlabels.com/help/expressions
+context: settings.controls, controls.index
 ---
 
 ## What is an Expression Control?

--- a/resources/help/pages/formatting.md
+++ b/resources/help/pages/formatting.md
@@ -4,6 +4,7 @@ description: Learn how to format numbers, durations, currencies, and dates in yo
 heading: Formatting Pipes
 lead: Learn how to format numbers, durations, currencies, and dates in your Twitch overlays using pipe syntax. Zero dependencies, fully locale-aware.
 canonical: https://overlabels.com/help/formatting
+context: templates.edit, templates.create, tags.generator
 ---
 
 No JavaScript required, no external libraries, no build step. Just add a pipe to your tag and you are

--- a/resources/help/pages/lists-realtime.md
+++ b/resources/help/pages/lists-realtime.md
@@ -4,6 +4,7 @@ description: "Build a live data page off an Overlabels List: get a token, read t
 heading: Lists in realtime
 lead: Build a page that reads one of your Lists and updates live - a wheel, a leaderboard, a ticker - and drop it into OBS. Step by step.
 canonical: https://overlabels.com/help/lists-realtime
+context: lists.index, tokens.index
 ---
 
 > [!NOTE]

--- a/resources/help/pages/lists.md
+++ b/resources/help/pages/lists.md
@@ -4,6 +4,7 @@ description: User-owned arrays of values that streamers manage from the dashboar
 heading: Lists in Overlabels
 lead: User-owned arrays of values that streamers manage from the dashboard or chat. Raffles, queues, quote walls, leaderboards, donation goals.
 canonical: https://overlabels.com/help/lists
+context: lists.index
 ---
 
 ## What is a List?

--- a/resources/help/pages/overlays-vs-alerts.md
+++ b/resources/help/pages/overlays-vs-alerts.md
@@ -4,6 +4,7 @@ description: The difference between a static overlay and an alert in Overlabels,
 heading: Overlays vs Alerts
 lead: "Overlabels has two kinds of overlay: the always-on static overlay, and the one-shot alert. They look similar in the editor, but they're meant to work together - and understanding how is the difference between a uniform, polished overlay and a bunch of disconnected boxes."
 canonical: https://overlabels.com/help/overlays-vs-alerts
+context: templates.index, templates.show?type=alert
 ---
 
 ## 1. The two kinds: static and alert

--- a/resources/help/pages/why-kofi.md
+++ b/resources/help/pages/why-kofi.md
@@ -4,6 +4,7 @@ description: Why Overlabels chose Ko-fi over PayPal for streamer donations. Zero
 heading: Overlabels ♥ Ko-fi
 lead: Why we chose Ko-fi as our first external integration - and why we think you should use it too.
 canonical: https://overlabels.com/help/why-kofi
+context: settings.integrations.kofi.show
 ---
 
 ## Ko-fi is amazing because it's a proper platform

--- a/resources/js/components/HelpBeacon.vue
+++ b/resources/js/components/HelpBeacon.vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+/**
+ * A floating help button that knows where the user is standing.
+ *
+ * The pages themselves declare which routes they cover, in a `context:`
+ * frontmatter line, and the server resolves that into the `help` shared prop
+ * (see App\Support\HelpContext). Nothing is guessed here: this component
+ * renders what matched, or says plainly that nothing did.
+ *
+ * The dot is the whole point. It is the difference between a help button you
+ * ignore and one that tells you, before you click, that there is something
+ * here worth reading.
+ */
+import { usePage } from '@inertiajs/vue3';
+import { CircleQuestionMark, ExternalLink, X } from '@lucide/vue';
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import type { AppPageProps, HelpLink } from '@/types';
+
+const page = usePage<AppPageProps>();
+
+const links = computed<HelpLink[]>(() => page.props.help ?? []);
+const hasHelp = computed(() => links.value.length > 0);
+
+const open = ref(false);
+const panel = ref<HTMLElement | null>(null);
+const trigger = ref<HTMLButtonElement | null>(null);
+
+function close(returnFocus = true) {
+    open.value = false;
+    if (returnFocus) {
+        trigger.value?.focus();
+    }
+}
+
+function onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+        close();
+    }
+}
+
+function onPointerDown(event: PointerEvent) {
+    const target = event.target as Node;
+
+    if (!panel.value?.contains(target) && !trigger.value?.contains(target)) {
+        close(false);
+    }
+}
+
+watch(open, async (isOpen) => {
+    if (isOpen) {
+        window.addEventListener('keydown', onKeydown);
+        window.addEventListener('pointerdown', onPointerDown);
+        await nextTick();
+        panel.value?.focus();
+    } else {
+        window.removeEventListener('keydown', onKeydown);
+        window.removeEventListener('pointerdown', onPointerDown);
+    }
+});
+
+// Navigating to a new page resolves different help, so the open panel would be
+// showing the previous route's answers. Close it and let the dot speak instead.
+watch(links, () => close(false));
+
+onBeforeUnmount(() => {
+    window.removeEventListener('keydown', onKeydown);
+    window.removeEventListener('pointerdown', onPointerDown);
+});
+</script>
+
+<template>
+  <div class="fixed right-4 bottom-4 z-40 print:hidden sm:right-6 sm:bottom-6">
+    <Transition
+      enter-active-class="transition duration-150 ease-out"
+      enter-from-class="translate-y-2 scale-95 opacity-0"
+      leave-active-class="transition duration-100 ease-in"
+      leave-to-class="translate-y-2 scale-95 opacity-0"
+    >
+      <div
+        v-if="open"
+        ref="panel"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="false"
+        aria-label="Help for this page"
+        class="absolute right-0 bottom-full mb-3 flex h-[650px] max-h-[calc(100dvh-7rem)] w-[375px] max-w-[calc(100vw-2rem)] origin-bottom-right flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl outline-none"
+      >
+        <header class="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
+          <div>
+            <h2 class="text-sm font-semibold text-foreground">Help for this page</h2>
+            <p class="text-xs text-muted-foreground">
+              {{ hasHelp ? 'Written for exactly where you are.' : 'Nothing specific here yet.' }}
+            </p>
+          </div>
+          <button
+            type="button"
+            class="-mr-1 cursor-pointer rounded-md p-1 text-muted-foreground transition hover:bg-accent hover:text-foreground"
+            aria-label="Close help"
+            @click="close()"
+          >
+            <X class="h-4 w-4" />
+          </button>
+        </header>
+
+        <div class="min-h-0 flex-1 overflow-y-auto">
+          <ul v-if="hasHelp" class="divide-y divide-border">
+            <li v-for="link in links" :key="link.slug">
+              <a
+                :href="link.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="block cursor-pointer px-4 py-4 transition hover:bg-accent/50"
+              >
+                <h3 class="text-sm font-medium text-foreground">{{ link.title }}</h3>
+                <p v-if="link.lead" class="mt-1.5 text-sm leading-relaxed text-foreground/80">
+                  {{ link.lead }}
+                </p>
+                <span class="mt-2 inline-flex items-center gap-1 text-xs font-medium text-violet-500 dark:text-violet-400">
+                  Read the full page
+                  <ExternalLink class="h-3 w-3" aria-hidden="true" />
+                  <span class="sr-only">(opens in a new tab)</span>
+                </span>
+              </a>
+            </li>
+          </ul>
+
+          <div v-else class="px-4 py-8 text-center">
+            <p class="text-sm text-foreground">
+              No help page covers this screen yet.
+            </p>
+            <p class="mt-1 text-xs text-muted-foreground">
+              The full help section is still a good place to look.
+            </p>
+          </div>
+        </div>
+
+        <footer class="shrink-0 border-t border-border px-4 py-3">
+          <a
+            href="/help"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex cursor-pointer items-center gap-1 text-xs font-medium text-foreground hover:text-violet-500 dark:hover:text-violet-400"
+          >
+            Browse all help
+            <ExternalLink class="h-3 w-3" aria-hidden="true" />
+            <span class="sr-only">(opens in a new tab)</span>
+          </a>
+        </footer>
+      </div>
+    </Transition>
+
+    <button
+      ref="trigger"
+      type="button"
+      class="relative flex h-11 w-11 cursor-pointer items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-lg transition hover:text-foreground hover:shadow-xl focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:outline-none"
+      :aria-label="hasHelp ? `Help for this page, ${links.length} page${links.length === 1 ? '' : 's'} available` : 'Help'"
+      :aria-expanded="open"
+      @click="open ? close() : (open = true)"
+    >
+      <CircleQuestionMark class="h-5 w-5" />
+      <span
+        v-if="hasHelp"
+        class="absolute top-0 right-0 h-2.5 w-2.5 rounded-full bg-violet-500 ring-2 ring-background"
+        aria-hidden="true"
+      />
+    </button>
+  </div>
+</template>

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import AppLayout from '@/layouts/app/AppSidebarLayout.vue';
 import CommandPalette from '@/components/CommandPalette.vue';
+import HelpBeacon from '@/components/HelpBeacon.vue';
 import ReferencePalette from '@/components/ReferencePalette.vue';
 import KeyboardShortcutsDialog from '@/components/KeyboardShortcutsDialog.vue';
 import LinkWarningModal from '@/components/LinkWarningModal.vue';
@@ -34,6 +35,7 @@ onMounted(() => {
     <CommandPalette />
     <ReferencePalette />
     <KeyboardShortcutsDialog :show="showKeyboardShortcuts" :shortcuts="keyboardShortcutsList" @close="showKeyboardShortcuts = false" />
+    <HelpBeacon />
     <TooltipProvider>
       <slot />
     </TooltipProvider>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -38,11 +38,20 @@ export interface UsageSummary {
     period: string;
 }
 
+/** A help page that declared the current route in its `context:` frontmatter. */
+export interface HelpLink {
+    slug: string;
+    title: string;
+    url: string;
+}
+
 export type AppPageProps<T extends Record<string, unknown> = Record<string, unknown>> = T & {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;
     sidebarOpen: boolean;
+    /** Contextual help for the current route, best match first. Often empty. */
+    help: HelpLink[];
     flash: FlashMessage;
     isAdmin: boolean;
     impersonating: { real_admin_id: number; target_user_id: number; target_name: string | null } | null;

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -41,7 +41,10 @@ export interface UsageSummary {
 /** A help page that declared the current route in its `context:` frontmatter. */
 export interface HelpLink {
     slug: string;
+    /** The page's short name, from its `heading` frontmatter. */
     title: string;
+    /** The page's own opening paragraph, used as the excerpt. */
+    lead: string;
     url: string;
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -108,7 +108,7 @@ Route::get('/kaylin', fn () => response('Kaylin is the voice of Overlabels.', 20
 foreach (HelpPage::all() as $helpSlug) {
     $helpPath = trim((string) preg_replace('#(^|/)index$#', '', $helpSlug), '/');
 
-    $helpUrl = '/help'.($helpPath === '' ? '' : '/'.$helpPath);
+    $helpUrl = HelpPage::url($helpSlug);
     $helpName = 'help'.($helpPath === '' ? '' : '.'.str_replace('/', '.', $helpPath));
 
     Route::get($helpUrl, [HelpController::class, 'show'])

--- a/tests/Feature/HelpContextTest.php
+++ b/tests/Feature/HelpContextTest.php
@@ -1,0 +1,178 @@
+<?php
+
+use App\Models\OverlayTemplate;
+use App\Models\User;
+use App\Support\HelpContext;
+use App\Support\HelpPage;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+
+/**
+ * Contextual help is declared by the help pages themselves, in a `context:`
+ * frontmatter line naming the route names they cover. These tests pin the
+ * matching rules, and - more usefully - guard the two ways the association rots
+ * over time: a route gets renamed and a page quietly points at nothing, or
+ * generic routes slowly accumulate every page that mentions them until the help
+ * affordance is a link farm.
+ */
+it('matches a page that named the route outright', function () {
+    $slugs = array_column(HelpContext::for('lists.index'), 'slug');
+
+    expect($slugs)->toContain('lists')
+        ->and(HelpContext::for('lists.index')[0])->toHaveKeys(['slug', 'title', 'url']);
+});
+
+it('returns nothing for a route no page claimed', function () {
+    expect(HelpContext::for('privacy'))->toBeEmpty()
+        ->and(HelpContext::for('does.not.exist'))->toBeEmpty();
+});
+
+it('ranks a page that pinned down a query constraint above one that did not', function () {
+    // /templates?type=block: blocks.md declared the type, overlays-vs-alerts
+    // only declared the bare route, so blocks leads.
+    $slugs = array_column(HelpContext::for('templates.index', ['type' => 'block']), 'slug');
+
+    expect($slugs[0])->toBe('blocks')
+        ->and($slugs)->toContain('overlays-vs-alerts');
+});
+
+it('ignores query parameters no page constrained on', function () {
+    // Declared constraints must match; everything else in the URL is noise, so
+    // search, sort and pagination can never break a match.
+    $slugs = array_column(HelpContext::for('templates.index', [
+        'type' => 'block',
+        'filter' => 'mine',
+        'search' => 'goal',
+        'sort' => 'name',
+        'page' => '2',
+    ]), 'slug');
+
+    expect($slugs[0])->toBe('blocks');
+});
+
+it('withholds a constrained page when the constraint is absent or different', function () {
+    $bare = array_column(HelpContext::for('templates.index'), 'slug');
+    $alert = array_column(HelpContext::for('templates.index', ['type' => 'alert']), 'slug');
+
+    expect($bare)->not->toContain('blocks')
+        ->and($alert)->not->toContain('blocks');
+});
+
+it('offers a page once even when several of its contexts match', function () {
+    // A page may declare a bare route and a narrowed one. It earns its best
+    // score, not one entry per declaration.
+    $slugs = array_column(HelpContext::for('templates.blocks.library'), 'slug');
+
+    expect($slugs)->toBe(array_unique($slugs));
+});
+
+it('prefers the more literal wildcard', function () {
+    // settings.bot.expressions.* is a more deliberate claim on the expressions
+    // pages than the settings.bot.* catch-all.
+    $slugs = array_column(HelpContext::for('settings.bot.expressions.index'), 'slug');
+
+    expect($slugs[0])->toBe('bot/expressions')
+        ->and($slugs)->toContain('bot/index');
+});
+
+it('reads context the URL does not carry', function () {
+    // /templates/{template} serves blocks, alerts and static overlays alike;
+    // the discriminator is the model. A controller injects it, and it matches
+    // through the same path as a real query parameter.
+    $slugs = array_column(HelpContext::for('templates.show', ['type' => 'alert']), 'slug');
+
+    expect($slugs)->toContain('overlays-vs-alerts')
+        ->and(array_column(HelpContext::for('templates.show', ['type' => 'block']), 'slug'))
+        ->toContain('blocks')
+        ->and(HelpContext::for('templates.show', ['type' => 'static']))->toBeEmpty();
+});
+
+it('points every declared context at a route that exists', function () {
+    // The failure this catches: a route is renamed, and contextual help goes
+    // silently dead. A central route-to-page map would catch it too; this is
+    // the price of keeping the association in the markdown.
+    $names = collect(Route::getRoutes()->getRoutesByName())->keys();
+
+    foreach (HelpPage::all() as $slug) {
+        foreach (HelpContext::declared($slug) as $entry) {
+            $pattern = $entry['pattern'];
+
+            $matched = str_contains($pattern, '*')
+                ? $names->contains(fn (string $name): bool => Str::is($pattern, $name))
+                : $names->contains($pattern);
+
+            expect($matched)->toBeTrue("{$slug} declares context '{$pattern}', which matches no route");
+        }
+    }
+});
+
+it('keeps any single context down to three pages', function () {
+    // Left alone, a generic route like templates.index accumulates every page
+    // that mentions templates until the help affordance is a link farm. Making
+    // that a test failure means a loose `context:` line is caught when it is
+    // written, not two years later.
+    foreach (HelpPage::all() as $slug) {
+        foreach (HelpContext::declared($slug) as $entry) {
+            if (str_contains($entry['pattern'], '*')) {
+                continue;
+            }
+
+            $resolved = HelpContext::for($entry['pattern'], $entry['constraints']);
+
+            expect(count($resolved))->toBeLessThanOrEqual(
+                3,
+                "context '{$entry['pattern']}' resolves to ".count($resolved).' pages'
+            );
+        }
+    }
+});
+
+it('shares contextual help with the frontend', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/dashboard/lists');
+
+    $response->assertOk();
+    $help = $response->viewData('page')['props']['help'] ?? null;
+
+    expect($help)->toBeArray()
+        ->and(array_column($help, 'slug'))->toContain('lists')
+        ->and($help[0]['url'])->toStartWith('/help/');
+});
+
+it('resolves controller-injected context over a real request', function () {
+    // The end-to-end path for the case the URL cannot express: the template
+    // page pushes the model's type in, and an alert gets the alert page.
+    $user = User::factory()->create();
+
+    $alert = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'type' => 'alert',
+        'fork_of_id' => null,
+    ]);
+
+    $response = $this->actingAs($user)->get("/templates/{$alert->id}");
+
+    $response->assertOk();
+
+    expect(array_column($response->viewData('page')['props']['help'], 'slug'))
+        ->toContain('overlays-vs-alerts');
+});
+
+it('resolves query-string context over a real request', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/templates?filter=mine&type=block&sort=name');
+
+    $response->assertOk();
+
+    expect($response->viewData('page')['props']['help'][0]['slug'])->toBe('blocks');
+});
+
+it('shares an empty list on a route with no help', function () {
+    $response = $this->get('/privacy');
+
+    $response->assertOk();
+
+    expect($response->viewData('page')['props']['help'])->toBe([]);
+});

--- a/tests/Feature/HelpContextTest.php
+++ b/tests/Feature/HelpContextTest.php
@@ -19,7 +19,27 @@ it('matches a page that named the route outright', function () {
     $slugs = array_column(HelpContext::for('lists.index'), 'slug');
 
     expect($slugs)->toContain('lists')
-        ->and(HelpContext::for('lists.index')[0])->toHaveKeys(['slug', 'title', 'url']);
+        ->and(HelpContext::for('lists.index')[0])->toHaveKeys(['slug', 'title', 'lead', 'url']);
+});
+
+it('carries card copy short enough for a 375px panel', function () {
+    // The beacon shows the page's own `heading` and `lead`, not its `title` and
+    // `description` - those are written for a browser tab and a search result,
+    // and the title in particular runs long ("Blocks - reusable building pieces
+    // for the Builder"). Every page that claims a context has to be presentable.
+    foreach (HelpPage::all() as $slug) {
+        if (HelpContext::declared($slug) === []) {
+            continue;
+        }
+
+        $card = HelpContext::for(HelpContext::declared($slug)[0]['pattern'], HelpContext::declared($slug)[0]['constraints']);
+        $card = collect($card)->firstWhere('slug', $slug);
+
+        expect($card['title'])->not->toBeEmpty()
+            ->and(strlen($card['title']))->toBeLessThanOrEqual(40, "{$slug} has a long panel title")
+            ->and($card['lead'])->not->toBeEmpty("{$slug} has no lead to preview")
+            ->and(strlen($card['lead']))->toBeLessThanOrEqual(320, "{$slug} has a long panel lead");
+    }
 });
 
 it('returns nothing for a route no page claimed', function () {


### PR DESCRIPTION
Help only helps if it turns up where the confusion is. This wires the help docs into the app: each page declares which routes it covers, and a floating beacon surfaces the matches with a dot when there is something worth reading.

Two commits: the association layer, then the frontend.

## How the association works

The declaration lives in the help page's own frontmatter, not in a central route map:

```
context: templates.index?type=block, templates.show?type=block, templates.blocks.library, builder.create
```

Same reason the prose lives there: writing the page wires it up, so there is no second file to keep in step, and reading `blocks.md` tells you where it surfaces. Thirteen pages declare a context; manifesto, why-overlabels and resources deliberately declare none.

- **Route names, not URLs.** Already unique, they survive a URL rewrite, and the request hands one over. Query constraints narrow a name down to a *state*, because `/templates` is one route serving four filter states.
- **Undeclared query parameters are ignored**, so `templates.index?type=block` still matches a URL carrying `filter`, `search`, `sort` and `page`. No allowlist of "meaningful" params exists anywhere, because none is needed.
- **`HelpContext::add()` covers what the URL cannot say.** `/templates/{template}` serves blocks, alerts and static overlays alike and the discriminator is the model. The controller injects `['type' => $template->type]`, and `context: templates.show?type=alert` matches through the identical code path as a real query parameter. One matcher; the controller decides what the meaningful discriminator is.
- **Every match is returned, best first** rather than collapsing to a winner in the backend, ranked by exact-name-over-wildcard, then constraints pinned down, then how literal the pattern was, then slug for a stable order. There is deliberately no `priority:` key: a page cannot buy rank, it earns it by being more specific.

Explicitly not a plausibility engine. A wrong contextual link is worse than no link, because it teaches people the help button lies, and you cannot write a test that pins "guessed right."

## The beacon

`HelpBeacon.vue`, mounted once in `AppLayout` so all 60 app pages get it and none opts in. Help pages use `HelpLayout` and are untouched.

- **The dot only appears when the route resolved help.** That is the difference between a help button you learn to ignore and one that tells you, before you click, that there is something here.
- **The excerpt is each page's own `lead`** - already written to introduce the page, already 94 to 275 characters, which is exactly a panel card. No markdown render, no body read, no second summary to drift from the prose. `heading` is used over `title` for the same reason: "Blocks" fits a 375px panel, "Blocks - reusable building pieces for the Builder" does not.
- **Links open in a new tab.** The point is helping with the page you are already on, so navigating away from it to read about it would undo the feature. The panel stays open behind them.
- **375x650, shrinking to fit** via `max-w-[calc(100vw-2rem)]` and `max-h-[calc(100dvh-7rem)]`, so it is a usable sheet on a phone rather than a clipped desktop panel. Escape and click-outside close it, focus moves in on open and returns to the button on close, and an Inertia navigation closes it since the answers belong to the route just left.
- **Empty state says plainly** that no page covers this screen yet and points at the help index.

## Guardrails

Three tests are load-bearing, and the first two were each verified to actually fail before being kept:

- **Every declared context must name a route that exists.** Catches the rename that would otherwise kill contextual help silently. This is the price of keeping the association in the markdown instead of a central map, and it is paid.
- **No context may resolve to more than three pages.** Left alone, a generic route like `templates.index` accumulates every page that mentions templates until the panel is a link farm. Now that is a failure at authoring time, not a discovery two years later.
- **Card copy stays short enough for the panel**, so a future page with a 400-character lead fails the build rather than blowing out the layout.

## Also

`HelpPage` gained `meta()`, a frontmatter-only read that stops at the closing delimiter, because the index reads every page on every request and slurping whole files to get at their first ten lines would mean ~200KB of I/O per request. And `url()`, which route registration now calls so URL derivation cannot drift.

## Known, not addressed

`templates.edit` and `templates.create` each resolve to conditionals and formatting, tied on every ranking criterion, so the panel orders those two alphabetically. Fine for a list of two; worth a constraint if the panel is ever collapsed to a single link.

## Testing

15 new tests in `HelpContextTest` covering the matching rules, all three guardrails, and end-to-end resolution of query-string and controller-injected context through real requests. Full suite **1099 passed**. Pint, ESLint and vite build clean. The beacon was checked in a browser by @jasperfrontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
