### PR TITLE
fix(help): links in help prose look like links

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,14 @@
 # CHANGELOG JULY 2026
 
+## July 28th, 2026 - fix(help): links in help prose look like links
+
+The `/help` index is built almost entirely from `- [**Page name**](/help/page) - description` list items, and not one of them read as a link. Two causes, both in `help-prose.css`, no markdown touched.
+
+- **`[**Bold**](url)` renders as `<a><strong>`**, and the `strong` rule repainted it `text-foreground` - stripping the violet off precisely the links meant to stand out most. `.help-prose a strong` now inherits the link colour.
+- **Links carry a permanent underline** instead of one that only appeared on hover. Colour alone is not an affordance: it is invisible to anyone with a colour vision deficiency, and it cannot be discovered without already suspecting there is something there to hover over. Same redundant-encoding rule the events feed follows for provider icons - the underline carries the meaning, colour reinforces it. It sits at 40% opacity so a paragraph with several links still reads as prose rather than as a fence, and firms up on hover.
+- The table-of-contents card is deliberately left alone. It is a numbered list under a "Table of contents" heading in its own bordered box, so it already reads as navigation, and underlining every entry would be heavy for no gain.
+- Markdown sources are byte-identical, so `/help/*.md` and the crawlable index are unchanged.
+
 ## July 28th, 2026 - feat(help): the help beacon
 
 The frontend half of contextual help. A round button in the bottom-right corner of every app page, with a dot when the current route has help behind it, opening a panel with the relevant pages.

--- a/resources/css/help-prose.css
+++ b/resources/css/help-prose.css
@@ -46,12 +46,34 @@
         @apply mt-2 mb-0;
     }
 
+    /*
+     * Links keep a permanent underline, not one that only appears on hover.
+     * Colour on its own is not an affordance - it is invisible to anyone with a
+     * colour vision deficiency, and it cannot be discovered without already
+     * suspecting there is something there to hover. This is the same redundant
+     * encoding rule the events feed follows for provider icons: shape (here,
+     * the underline) carries the meaning, colour reinforces it.
+     *
+     * The underline sits at 40% so a paragraph with several links still reads
+     * as prose rather than as a fence, and firms up on hover.
+     */
     .help-prose a {
-        @apply cursor-pointer text-violet-400 hover:underline;
+        @apply cursor-pointer text-violet-400 underline decoration-violet-400/40 underline-offset-2 transition-colors hover:decoration-violet-400;
     }
 
     .help-prose strong {
         @apply font-semibold text-foreground;
+    }
+
+    /*
+     * `[**Bold link**](...)` renders as <a><strong>, so the rule above would
+     * repaint the text `text-foreground` and strip the violet from exactly the
+     * links that were meant to stand out most. The /help index is built almost
+     * entirely from these, and every one of them read as plain bold text.
+     * Higher specificity wins here regardless of source order.
+     */
+    .help-prose a strong {
+        @apply text-inherit;
     }
 
     /* Inline code. Fenced blocks are handled below and must not inherit this. */


### PR DESCRIPTION
The `/help` index is built almost entirely from `- [**Page name**](/help/page) - description` list items, and not one of them read as a link. Two causes, both in `help-prose.css`.

## The bug

`[**Bold**](url)` renders as `<a><strong>`, and the `strong` rule repainted it `text-foreground` - stripping the violet off precisely the links meant to stand out most. Bolded links came out visually identical to bold prose. `.help-prose a strong` now inherits the link colour.

## The affordance

Links carry a permanent underline instead of one that only appeared on hover. Colour alone is not an affordance: it is invisible to anyone with a colour vision deficiency, and it cannot be discovered without already suspecting there is something there to hover over. Same redundant-encoding rule the events feed follows for provider icons - the underline carries the meaning, colour reinforces it.

It sits at 40% opacity so a paragraph with several links still reads as prose rather than as a fence, and firms up to full on hover.

## Scope

- **No markdown was touched.** `git diff` against main over `resources/help/` is empty, so the `.md` twins and the crawlable `/help.md` index are byte-identical and the byte-identity test still passes. Being CSS-only is also why this fixes all 170 links across every help page rather than just the index.
- **The table-of-contents card is deliberately left alone.** It is a numbered list under a "Table of contents" heading in its own bordered box, so it already reads as navigation, and WCAG's colour rule targets links inside blocks of text rather than nav lists. Underlining every entry would be heavy for no gain.
- Verified against the compiled CSS, not just the source: `.help-prose a strong{color:inherit}` and the decoration-colour transition both land as intended.

## Testing

`HelpPageTest` 15 passed. Vite build clean. Checked in a browser by @jasperfrontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
