### PR TITLE
fix(llms): make llms.txt reachable and findable

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -16,6 +16,9 @@ class SitemapController extends Controller
      */
     private const STATIC_PATHS = [
         ['path' => '/', 'priority' => '1.0', 'changefreq' => 'weekly'],
+        // Not an HTML page, but a sitemap may list any URL on the site, and this
+        // is the one file we most want a crawler to find on its own.
+        ['path' => '/llms.txt', 'priority' => '0.5', 'changefreq' => 'monthly'],
         ['path' => '/privacy', 'priority' => '0.3', 'changefreq' => 'yearly'],
         ['path' => '/terms', 'priority' => '0.3', 'changefreq' => 'yearly'],
         ['path' => '/help', 'priority' => '0.8', 'changefreq' => 'monthly'],

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -18,7 +18,17 @@ servers:
       - 172.235.171.209
     proxy:
       ssl: true
-      host: overlabels.com
+      # www is here only so kamal-proxy will terminate TLS for it; the Caddyfile
+      # 301s it straight to the apex. DNS points www at this box, so without the
+      # entry the name resolves and then fails the TLS handshake, which browsers
+      # present as a security warning - strictly worse than the old NXDOMAIN.
+      # Automatic Let's Encrypt covers both names: the single-host restriction in
+      # Kamal counts *servers* (role.rb `ensure_one_host_for_ssl`), not hostnames,
+      # and this role deploys to one. Use `hosts:` not `host:` - setting both is a
+      # validation error.
+      hosts:
+        - overlabels.com
+        - www.overlabels.com
       app_port: 80
       healthcheck:
         interval: 5

--- a/docker/frankenphp.Caddyfile
+++ b/docker/frankenphp.Caddyfile
@@ -23,5 +23,26 @@
 		format console
 	}
 
+	# www exists only to redirect. kamal-proxy terminates TLS for it (see the
+	# `hosts:` list in config/deploy.yml) and forwards here with the original
+	# Host header intact; without this the app would serve on a second hostname
+	# and split every canonical URL. {uri} keeps path and query, so
+	# www.overlabels.com/llms.txt lands on the file rather than the homepage.
+	@www host www.overlabels.com
+	redir @www https://overlabels.com{uri} 301
+
+	# Machine-readable docs are fetched cross-origin by browser-context agents
+	# (in-page tooling, extensions, sandboxed LLM clients), which get a CORS
+	# failure without this. Everything matched here is public and
+	# unauthenticated already, so `*` gives away nothing a plain GET doesn't.
+	# Note this does NOT help agents whose sandbox blocks the host outright -
+	# that is an egress allowlist on their side, not a header we can send.
+	# A regexp rather than a `path` list because Caddy's path wildcard does not
+	# cross a `/`: `/help/*.md` matches /help/controls.md but silently misses
+	# /help/bot/expressions.md and /help/bot/aliases.md. This holds at any depth,
+	# so a future nested page is covered without touching this file.
+	@machine_readable path_regexp ^/(llms\.txt|help(/[\w-]+)*\.md)$
+	header @machine_readable Access-Control-Allow-Origin "*"
+
 	php_server
 }

--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,18 @@
 # CHANGELOG JULY 2026
 
+## July 30th, 2026 - fix(llms): make llms.txt reachable and findable
+
+Two agents reported they were "not allowed" to read `https://overlabels.com/llms.txt`. The file was never the problem. It answers `200 text/plain` in 23,469 bytes to every user agent tried, including `Claude-User`, `ClaudeBot` and an empty one; `robots.txt` allows everything; there is no `X-Robots-Tag`; and `http://` does a clean same-host 301. Both refusals were client-side and unrelated to each other: one agent ran in a cloud sandbox whose default network policy is an allowlist of package registries and Anthropic hosts, so the request never left the VM, and the other hit a per-domain fetch permission prompt. Neither is fixable from this end.
+
+Auditing to prove that, though, turned up three gaps that were costing readers we could actually have had.
+
+- **No CORS header.** `Access-Control-Allow-Origin` was absent and `OPTIONS` returned 405, so any browser-context agent reading the guide cross-origin got a CORS failure. Now sent for `/llms.txt` and every `.md` help twin, which are public and unauthenticated anyway. This does nothing for sandbox egress blocks, which are somebody else's allowlist, and the Caddyfile comment says so to stop a future reader from expecting otherwise. The matcher is a `path_regexp`, not a `path` list, because Caddy's path wildcard does not cross a `/`: the obvious `/help/*.md` validated fine, served fine, and silently missed `/help/bot/expressions.md` and `/help/bot/aliases.md`. Caught by booting the real image and checking all 21 URLs rather than trusting the config to parse.
+- **Nothing pointed at the file.** It was not linked from the document head, not mentioned in `robots.txt`, and not in `sitemap.xml`. Anything that did not already know the URL had no way to find it. Added to all three. The head link uses `rel="llms-txt"` rather than `rel="alternate"`, because llms.txt is not an alternate representation of whatever page you happen to be on and saying so would be a lie to any crawler that understands the relation. The root path stays the actual contract; these are hints on top of it.
+- **`www.overlabels.com` did not resolve at all.** Not a redirect, `NXDOMAIN`, so anything guessing the `www` host got a dead name rather than the site. An `A` record now points it at the box, which means the redirect has to happen here: `www` is added to the web role's `hosts:` so kamal-proxy terminates TLS for it, and the Caddyfile 301s it to the apex with `{uri}` so the path survives. Worth knowing that Kamal's `ensure_one_host_for_ssl` sounds like it forbids this and does not - it counts *servers*, not hostnames, and this role deploys to one, so automatic Let's Encrypt covers both names. Verified the emitted args are `--host="overlabels.com" --host="www.overlabels.com" --tls`.
+
+> [!IMPORTANT]
+> Between the DNS record and this deploy, `www` resolves but has no certificate, so an https request to it fails the TLS handshake and a browser shows a security warning. That is worse than the `NXDOMAIN` it replaced. Deploy promptly.
+
 ## July 28th, 2026 - docs(llms): fix four defects a model found reading llms.txt
 
 Fed `public/llms.txt` to a fresh model with no repo access and asked what it could not resolve from the text alone. Every complaint it raised was legitimate, and each was verified against the implementation before being fixed.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,9 @@
 User-agent: *
 Disallow:
 
+# Writing an Overlabels template? The complete authoring guide, in one plain
+# text file: https://overlabels.com/llms.txt
+# (A comment on purpose - llms.txt has no ratified robots.txt directive, and an
+# invented one would just be ignored by every compliant parser anyway.)
+
 Sitemap: https://overlabels.com/sitemap.xml

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -34,6 +34,13 @@
             }
         </style>
         <link rel="icon" href="/favicon.png" sizes="any">
+        {{-- Discovery hint for the machine-readable authoring guide. The root
+             path is the real contract (llmstxt.org fixes /llms.txt and defines
+             no link relation), so this is a hint on top, not the contract.
+             `rel="llms-txt"` rather than `rel="alternate"` on purpose: llms.txt
+             is not an alternate representation of whatever page you are on, and
+             claiming so would be a lie to every crawler that understands it. --}}
+        <link rel="llms-txt" type="text/plain" href="/llms.txt" title="Overlabels authoring guide for LLMs">
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=albert-sans:300,400,500,600,700" rel="stylesheet" />
 


### PR DESCRIPTION
Two agents reported they were "not allowed" to read `https://overlabels.com/llms.txt`. **The file was never the problem.** It answers `200 text/plain` in 23,469 bytes to every user agent tried (`Claude-User`, `ClaudeBot`, `Claude-SearchBot`, `curl`, empty), `robots.txt` allows everything, there is no `X-Robots-Tag`, and `http://` does a clean same-host 301.

Both refusals were client-side and unrelated to each other: one agent ran in a cloud sandbox whose default network policy is an allowlist of package registries and Anthropic hosts, so the request never left the VM; the other hit a per-domain fetch permission prompt. Neither is fixable from this end.

Auditing to prove that turned up three gaps that *were* costing readers we could have had.

## 1. No CORS header

`Access-Control-Allow-Origin` was absent and `OPTIONS` returned 405, so any browser-context agent reading the guide cross-origin failed. Now sent for `/llms.txt` and every `.md` help twin. All of it is public and unauthenticated already, so `*` gives away nothing a plain GET doesn't.

The matcher is a `path_regexp`, not a `path` list, and that distinction is load-bearing. The obvious version:

```
@machine_readable path /llms.txt /help.md /help/*.md
```

validated fine, served fine, and **silently missed `/help/bot/expressions.md` and `/help/bot/aliases.md`** - Caddy's path wildcard does not cross a `/`. Caught only by booting the image and checking all 21 URLs.

## 2. Nothing pointed at the file

Not linked from the document head, not in `robots.txt`, not in `sitemap.xml`. Anything that did not already know the URL had no way to find it. Added to all three.

The head link uses `rel="llms-txt"` rather than `rel="alternate"`, because llms.txt is not an alternate representation of whatever page you are on and saying so would be a lie to any crawler that understands the relation. The root path stays the actual contract.

## 3. `www.overlabels.com` was NXDOMAIN

A guessed `www` host got a dead name. An `A` record now points it at the box, so the redirect has to happen server-side: `www` joins the web role's proxy `hosts:` for TLS, and the Caddyfile 301s it to the apex preserving `{uri}`.

Kamal's `ensure_one_host_for_ssl` sounds like it forbids this and does not - it counts **servers**, not hostnames, and this role deploys to one. Automatic Let's Encrypt covers both names.

> [!IMPORTANT]
> Between the DNS record and this deploy, `www` resolves without a certificate, so https to it fails the TLS handshake and browsers show a security warning. That is worse than the NXDOMAIN it replaced. This wants deploying promptly.

## Verification

Booted `docker/frankenphp.Caddyfile` in `dunglas/frankenphp:1-php8.4`, the tag the Dockerfile pins, with the real `public/` mounted:

- `frankenphp validate` -> `Valid configuration`
- `www` 301s to the apex; path and query survive (`/help/bot/expressions.md?a=1&b=2` arrives intact)
- All 21 doc URLs (20 `.md` twins enumerated from `route:list`, plus `/llms.txt`) carry the CORS header
- `/robots.txt`, `/sitemap.xml`, `/help`, `/help/controls`, `/helpxmd` correctly get none
- `kamal config` validates; emits `--host="overlabels.com" --host="www.overlabels.com" --tls`
- `HelpPageTest` 15/15 green, Pint clean, `/sitemap.xml` rendered to confirm the new entry

Not swept: `caddy fmt` flags a stray space on line 6, which predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
