### PR TITLE
feat(builder): drag-to-resize, and a canvas you can actually read

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,13 @@
 # CHANGELOG JULY 2026
 
+## August 1st, 2026 - feat(builder): drag-to-resize, and a canvas you can actually read
+
+Three complaints about the Builder canvas, all downstream of one thing: the canvas is drawn at 1920x1080 and scaled to fit, so every piece of UI chrome on it was being drawn at roughly a third of its intended size.
+
+- **Chrome is now authored in screen pixels and divided back out by the scale factor.** A 1px border lands near 0.35px, and Firefox renders that on some edges of a box and not others, which is why block outlines appeared as a left border here, a top border there, and nothing at all elsewhere. Outlines, handles, and the block-name label all now specify sizes that survive the transform. The label went from about 4px to legible as a side effect, which was the same bug wearing a different hat.
+- **Occupied and free cells are told apart by fill, not by outline.** The checkerboard moved off the grid container and onto the empty cells only, so free space reads as texture and a placed block reads as a solid tile. Previously both were checkerboard with a hairline outline, which meant a block rendering mostly transparency - very common for overlays - was indistinguishable from nothing at all until you hovered it. Trade-off worth naming: block previews no longer sit on a checkerboard, so a transparent block now previews against the flat canvas.
+- **Drag-to-resize from any edge or corner.** Hovering a block reveals four edge strips and four corner grips; drag one and only that side moves, with the opposite side pinned. Deliberately chunky, because at a 0.35 scale a subtle affordance is an invisible one. `setRect()` joins `moveTo()` in `useBuilderState` as the second absolute mutator, and runs through the same `fits()` check, so a resize can no more overlap a neighbour or leave the grid than a move can - it simply stops at the last rect that fit. Handles cap at a share of the block (22% for edges, 30% for corners) so a 1x1 block on a 24x24 grid keeps a middle to drag from. Shift+arrows still resize from the keyboard, and the handles are `aria-hidden` because that keyboard path is the accessible one.
+
 ## July 31st, 2026 - feat(builder): overlay-level CSS and fonts
 
 Composing in the Builder meant giving up the head/CSS tabs entirely, so a composed overlay looked exactly like the sum of its blocks and no further. You can now restyle one, without giving up the grid tools and without ejecting.

--- a/resources/js/components/builder/BuilderCanvas.vue
+++ b/resources/js/components/builder/BuilderCanvas.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import type { BuilderPlacement as BuilderPlacementType } from '@/types';
-import BuilderPlacement from '@/components/builder/BuilderPlacement.vue';
+import BuilderPlacement, { type ResizeHandle } from '@/components/builder/BuilderPlacement.vue';
 
 const props = defineProps<{
   grid: { cols: number; rows: number; gap: number };
@@ -17,6 +17,7 @@ const emit = defineEmits<{
   cellClick: [x: number, y: number];
   select: [id: string | null];
   moveTo: [id: string, x: number, y: number];
+  resizeTo: [id: string, x: number, y: number, w: number, h: number];
   syncAll: [];
 }>();
 
@@ -38,6 +39,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   observer?.disconnect();
   endDrag();
+  endResize();
 });
 
 // Drag-to-move. The placement captures the pointer; the canvas translates
@@ -105,6 +107,65 @@ function endDrag() {
   window.removeEventListener('pointercancel', endDrag);
 }
 
+// Drag-to-resize. Same shape as the move drag: the canvas turns the pointer
+// into a grid cell, builds the rect the handle implies, and hands it to the
+// parent. Only the dragged side moves; the opposite one stays pinned. The
+// parent validates, so a resize can no more overlap or overflow than a move
+// can - it just stops at the last rect that fit.
+const resize = ref<{ id: string; handle: ResizeHandle } | null>(null);
+
+function onResizeStart(id: string, handle: ResizeHandle, e: PointerEvent) {
+  resize.value = { id, handle };
+  window.addEventListener('pointermove', onResizeMove);
+  window.addEventListener('pointerup', endResize);
+  window.addEventListener('pointercancel', endResize);
+  onResizeMove(e);
+}
+
+function onResizeMove(e: PointerEvent) {
+  const r = resize.value;
+  if (!r) return;
+  const placement = props.placements.find((p) => p.instance_id === r.id);
+  const cell = cellAt(e);
+  if (!placement || !cell) return;
+
+  let { x, y, w, h } = placement;
+
+  if (r.handle.includes('w')) {
+    // The right edge is pinned, so the left one can travel up to it.
+    const left = Math.min(cell.x, x + w - 1);
+    w += x - left;
+    x = left;
+  } else if (r.handle.includes('e')) {
+    w = Math.max(cell.x - x + 1, 1);
+  }
+
+  if (r.handle.includes('n')) {
+    const top = Math.min(cell.y, y + h - 1);
+    h += y - top;
+    y = top;
+  } else if (r.handle.includes('s')) {
+    h = Math.max(cell.y - y + 1, 1);
+  }
+
+  emit('resizeTo', r.id, x, y, w, h);
+}
+
+function endResize() {
+  resize.value = null;
+  window.removeEventListener('pointermove', onResizeMove);
+  window.removeEventListener('pointerup', endResize);
+  window.removeEventListener('pointercancel', endResize);
+}
+
+/**
+ * Chrome is authored in screen pixels and divided back out, because the canvas
+ * is drawn at 1920x1080 and scaled to fit. A 1px border lands somewhere near
+ * 0.35px, which Firefox renders on some edges of a box and not others - that is
+ * the whole reason cell outlines used to flicker in and out of existence.
+ */
+const screenPx = (n: number) => `${n / scale.value}px`;
+
 const emptyCells = computed(() => {
   const cells: Array<{ x: number; y: number }> = [];
   for (let y = 1; y <= props.grid.rows; y++) {
@@ -130,7 +191,7 @@ const emptyCells = computed(() => {
     <div :style="{ height: `${canvas.height * scale}px` }" class="overflow-hidden">
       <div
         ref="gridEl"
-        class="grid border border-sidebar-border bg-[repeating-conic-gradient(var(--color-sidebar)_0%_25%,transparent_0%_50%)] bg-size-[32px_32px]"
+        class="grid border border-sidebar-border"
         :style="{
           width: `${canvas.width}px`,
           height: `${canvas.height}px`,
@@ -142,16 +203,24 @@ const emptyCells = computed(() => {
         }"
         @click="emit('select', null)"
       >
+        <!-- Empty cells carry the checkerboard, placed blocks don't. That one
+             swap is what tells occupied from free at a glance, even when a
+             block renders almost nothing - which overlay blocks often do. -->
         <button
           v-for="cell in emptyCells"
           :key="`${cell.x}-${cell.y}`"
           type="button"
-          :style="{ gridArea: `${cell.y} / ${cell.x} / span 1 / span 1` }"
-          class="group cursor-pointer border border-dashed border-sidebar-border/50 transition-colors hover:border-violet-400 hover:bg-violet-400/10"
+          :style="{
+            gridArea: `${cell.y} / ${cell.x} / span 1 / span 1`,
+            outline: `${screenPx(1)} dashed var(--color-sidebar-border)`,
+            outlineOffset: `-${screenPx(1)}`,
+            fontSize: screenPx(28),
+          }"
+          class="group cursor-pointer bg-[repeating-conic-gradient(var(--color-sidebar)_0%_25%,transparent_0%_50%)] bg-size-[32px_32px] transition-colors hover:bg-violet-400/15"
           :aria-label="`Place a block at column ${cell.x}, row ${cell.y}`"
           @click.stop="emit('cellClick', cell.x, cell.y)"
         >
-          <span class="text-4xl text-transparent select-none group-hover:text-violet-400">+</span>
+          <span class="text-transparent select-none group-hover:text-violet-400">+</span>
         </button>
 
         <BuilderPlacement
@@ -161,8 +230,10 @@ const emptyCells = computed(() => {
           :sample-data="sampleData"
           :selected="placement.instance_id === selectedId"
           :source-stale="stalePlacementIds?.has(placement.instance_id) ?? false"
+          :scale="scale"
           @select="(id) => emit('select', id)"
           @drag-start="onDragStart"
+          @resize-start="onResizeStart"
         />
       </div>
     </div>

--- a/resources/js/components/builder/BuilderEditor.vue
+++ b/resources/js/components/builder/BuilderEditor.vue
@@ -86,6 +86,9 @@ const move = markDirty((dx: number, dy: number) => state.move(state.selectedId.v
 const moveTo = (id: string, x: number, y: number) => {
   if (state.moveTo(id, x, y)) emit('dirty');
 };
+const resizeTo = (id: string, x: number, y: number, w: number, h: number) => {
+  if (state.setRect(id, x, y, w, h)) emit('dirty');
+};
 const resize = markDirty((dw: number, dh: number) => state.resize(state.selectedId.value!, dw, dh));
 const removeSelected = markDirty(() => state.remove(state.selectedId.value!));
 const setGrid = markDirty(state.setGrid);
@@ -137,6 +140,7 @@ defineExpose({
         @cell-click="onCellClick"
         @select="(id) => (state.selectedId.value = id)"
         @move-to="moveTo"
+        @resize-to="resizeTo"
         @sync-all="syncAllFromSource"
       />
 

--- a/resources/js/components/builder/BuilderPlacement.vue
+++ b/resources/js/components/builder/BuilderPlacement.vue
@@ -2,14 +2,72 @@
 import { computed } from 'vue';
 import type { BuilderPlacement } from '@/types';
 
+export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
 const props = defineProps<{
   placement: BuilderPlacement;
   sampleData: Record<string, string>;
   selected: boolean;
   sourceStale?: boolean;
+  /** Canvas scale factor, so chrome can be sized in screen pixels. */
+  scale: number;
 }>();
 
-const emit = defineEmits<{ select: [id: string]; dragStart: [id: string, event: PointerEvent] }>();
+const emit = defineEmits<{
+  select: [id: string];
+  dragStart: [id: string, event: PointerEvent];
+  resizeStart: [id: string, handle: ResizeHandle, event: PointerEvent];
+}>();
+
+// The canvas is drawn at 1920x1080 and scaled down to fit, so anything meant to
+// be read by a human has to be authored in screen pixels and divided back out.
+// A 1px border becomes 0.35px at a typical scale, which Firefox renders on some
+// edges and not others - the borders here are specified thick enough that they
+// survive the transform.
+const px = (screenPx: number) => `${screenPx / props.scale}px`;
+
+const OUTLINE_PX = 2;
+const OUTLINE_SELECTED_PX = 3;
+const HANDLE_PX = 13;
+const EDGE_PX = 9;
+
+// A 1x1 block on a 24x24 grid is about 25 screen px across, and fixed-size
+// handles would eat all of it, leaving nothing to grab for a move. Capping each
+// handle as a share of the block keeps a middle to drag from at any size.
+const handleSize = (screenPx: number, cap: string) => `min(${px(screenPx)}, ${cap})`;
+
+const outline = computed(() =>
+  props.selected
+    ? `${px(OUTLINE_SELECTED_PX)} solid var(--color-violet-500)`
+    : `${px(OUTLINE_PX)} solid var(--color-sidebar-border)`,
+);
+
+/** Corner handles sit on top of the edge strips, so they win the shared pixels. */
+const corners: Array<{ handle: ResizeHandle; cursor: string; style: Record<string, string> }> = [
+  { handle: 'nw', cursor: 'nwse-resize', style: { top: '0', left: '0' } },
+  { handle: 'ne', cursor: 'nesw-resize', style: { top: '0', right: '0' } },
+  { handle: 'sw', cursor: 'nesw-resize', style: { bottom: '0', left: '0' } },
+  { handle: 'se', cursor: 'nwse-resize', style: { bottom: '0', right: '0' } },
+];
+
+const cornerStyle = (style: Record<string, string>) => ({
+  ...style,
+  width: handleSize(HANDLE_PX, '30%'),
+  height: handleSize(HANDLE_PX, '30%'),
+  borderWidth: px(1.5),
+});
+
+/** Full-length strips: "move towards the edge" should be enough to grab one. */
+const edges = computed(() => {
+  const thickness = handleSize(EDGE_PX, '22%');
+
+  return [
+    { handle: 'n' as ResizeHandle, cursor: 'ns-resize', style: { top: '0', left: '0', right: '0', height: thickness } },
+    { handle: 's' as ResizeHandle, cursor: 'ns-resize', style: { bottom: '0', left: '0', right: '0', height: thickness } },
+    { handle: 'w' as ResizeHandle, cursor: 'ew-resize', style: { left: '0', top: '0', bottom: '0', width: thickness } },
+    { handle: 'e' as ResizeHandle, cursor: 'ew-resize', style: { right: '0', top: '0', bottom: '0', width: thickness } },
+  ];
+});
 
 // Pointer capture keeps move/up events flowing to this element even when the
 // pointer crosses the preview iframes (which would otherwise swallow them).
@@ -18,6 +76,16 @@ function onPointerDown(e: PointerEvent) {
   if (e.button !== 0) return;
   (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   emit('dragStart', props.placement.instance_id, e);
+}
+
+function onHandlePointerDown(handle: ResizeHandle, e: PointerEvent) {
+  if (e.button !== 0) return;
+  // Beat the move-drag on the wrapper to the punch: near an edge, resizing is
+  // what the user meant.
+  e.stopPropagation();
+  (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  emit('select', props.placement.instance_id);
+  emit('resizeStart', props.placement.instance_id, handle, e);
 }
 
 // Same preview approach as the template create page: substitute sample data
@@ -52,10 +120,10 @@ const gridArea = computed(
 
 <template>
   <div
-    :style="{ gridArea }"
+    :style="{ gridArea, outline, outlineOffset: `-${px(selected ? OUTLINE_SELECTED_PX : OUTLINE_PX)}` }"
     :class="[
-      'relative min-h-0 min-w-0 cursor-grab touch-none overflow-hidden transition-shadow select-none active:cursor-grabbing',
-      selected ? 'ring-2 ring-violet-500 z-10' : 'ring-1 ring-sidebar-border/60 hover:ring-violet-400/60',
+      'group relative min-h-0 min-w-0 cursor-grab touch-none overflow-hidden select-none active:cursor-grabbing',
+      selected ? 'z-10' : '',
     ]"
     @click.stop="emit('select', placement.instance_id)"
     @pointerdown="onPointerDown"
@@ -67,15 +135,44 @@ const gridArea = computed(
       tabindex="-1"
       :title="placement.block_name"
     />
-    <div class="pointer-events-none absolute top-0 left-0 max-w-full truncate bg-sidebar-accent/90 px-2 py-0.5 font-mono text-xs text-foreground">
+    <div
+      class="pointer-events-none absolute top-0 left-0 max-w-full truncate bg-sidebar-accent/90 font-mono text-foreground"
+      :style="{ fontSize: px(12), padding: `${px(1)} ${px(6)}` }"
+    >
       {{ placement.block_name }}
     </div>
     <div
       v-if="sourceStale"
-      class="pointer-events-none absolute top-0 right-0 bg-amber-500/90 px-2 py-0.5 text-[10px] font-medium text-black"
+      class="pointer-events-none absolute top-0 right-0 bg-amber-500/90 font-medium text-black"
+      :style="{ fontSize: px(10), padding: `${px(1)} ${px(6)}` }"
       title="The source of this block changed since it was placed. Select it to refresh."
     >
       Source updated
+    </div>
+
+    <!-- Resize affordances. Hidden until the block is hovered or selected, so a
+         canvas at rest stays readable, then deliberately chunky: at a 0.35
+         scale anything subtle is invisible. -->
+    <div
+      class="pointer-events-none absolute inset-0 opacity-0 transition-opacity group-hover:opacity-100"
+      :class="{ 'opacity-100': selected }"
+    >
+      <div
+        v-for="edge in edges"
+        :key="edge.handle"
+        class="pointer-events-auto absolute bg-violet-500/30 hover:bg-violet-500/60"
+        :style="{ ...edge.style, cursor: edge.cursor }"
+        aria-hidden="true"
+        @pointerdown="onHandlePointerDown(edge.handle, $event)"
+      />
+      <div
+        v-for="corner in corners"
+        :key="corner.handle"
+        class="pointer-events-auto absolute border-white bg-violet-500 hover:bg-violet-400"
+        :style="{ ...cornerStyle(corner.style), cursor: corner.cursor }"
+        aria-hidden="true"
+        @pointerdown="onHandlePointerDown(corner.handle, $event)"
+      />
     </div>
   </div>
 </template>

--- a/resources/js/composables/useBuilderState.ts
+++ b/resources/js/composables/useBuilderState.ts
@@ -148,6 +148,26 @@ export function useBuilderState(initial?: BuilderMetadata | null) {
         return true;
     }
 
+    /**
+     * Absolute rect (drag-to-resize from an edge or corner). Unlike resize(),
+     * which only ever grows the bottom-right, this moves the dragged side and
+     * leaves the opposite one pinned. Rejected wholesale when it would overlap
+     * or leave the grid, so a drag past a neighbour stops at the last good
+     * rect - same feel as drag-to-move. True when the rect actually changed.
+     */
+    function setRect(id: string, x: number, y: number, w: number, h: number): boolean {
+        const p = placements.value.find((pl) => pl.instance_id === id);
+        if (!p) return false;
+        if (p.x === x && p.y === y && p.w === w && p.h === h) return false;
+        if (!fits(x, y, w, h, id)) return false;
+        p.x = x;
+        p.y = y;
+        p.w = w;
+        p.h = h;
+        placements.value = [...placements.value];
+        return true;
+    }
+
     function move(id: string, dx: number, dy: number): void {
         const p = placements.value.find((pl) => pl.instance_id === id);
         if (!p) return;
@@ -227,6 +247,7 @@ export function useBuilderState(initial?: BuilderMetadata | null) {
         syncBlockNames,
         move,
         moveTo,
+        setRect,
         resize,
         remove,
         setGrid,

--- a/resources/js/pages/builder/create.vue
+++ b/resources/js/pages/builder/create.vue
@@ -246,6 +246,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
             @cell-click="onCellClick"
             @select="(id) => (state.selectedId.value = id)"
             @move-to="(id, x, y) => state.moveTo(id, x, y)"
+            @resize-to="(id, x, y, w, h) => state.setRect(id, x, y, w, h)"
             @sync-all="syncAllFromSource"
           />
 


### PR DESCRIPTION
Three complaints about the Builder canvas, all downstream of one thing: the canvas is drawn at 1920x1080 and scaled to fit with `transform: scale(~0.35)`, so every piece of UI chrome on it was being rendered at about a third of its intended size.

## 1. Chrome is authored in screen pixels now

`border: 1px` lands near 0.35px, and Firefox resolves sub-pixel borders per-edge, which is why a block outline showed up as a left border here, a top border there, and nothing at all elsewhere.

Both canvas components now specify sizes in screen pixels and divide back out by the scale factor, so outlines are 2px (3px selected) as they hit your eye at any zoom. The block-name label was the same bug wearing a different hat - `text-xs` was rendering around 4px - and it came along for free.

## 2. Occupied vs free is a fill difference, not a hairline

The checkerboard moved off the grid container and onto the empty cells only. Free space reads as texture, a placed block reads as a solid tile, and the difference is pre-attentive instead of something you have to hunt for.

Previously both were checkerboard with a hairline outline, so a block rendering mostly transparency - very common for overlays - was indistinguishable from an empty cell until you hovered it.

Trade-off worth naming: block previews no longer sit on a checkerboard, so a transparent block previews against the flat canvas.

## 3. Drag-to-resize from any edge or corner

Hovering a block reveals four edge strips and four corner grips. Drag one and only that side moves, with the opposite side pinned; corners take both axes. Deliberately chunky, because at a 0.35 scale a subtle affordance is an invisible one.

- **`setRect()`** joins `moveTo()` in `useBuilderState` as the second absolute mutator, and runs through the same `fits()` check. A resize can no more overlap a neighbour or leave the grid than a move can - it stops at the last rect that fit, matching how drag-to-move already feels.
- **Handles cap at a share of the block** (22% edges, 30% corners) via CSS `min()`. A 1x1 block on a 24x24 grid is about 25 screen px, and fixed-size handles would have swallowed it, leaving nothing to grab for a move.
- **Shift+arrows still resize from the keyboard**, and the handles are `aria-hidden` because that keyboard path is the accessible one.

## Testing

- Resize math walked through by hand across all eight handles, including dragging a side past its opposite so the block collapses to one cell, and dragging into an occupied neighbour.
- `vue-tsc`, ESLint, and a production build clean. PHP suite unaffected and passing.
- Confirmed in Firefox by the author: resizing feels natural and the occupied/free distinction reads well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
