### PR TITLE
ui(builder): move the block name out from under the resize grip

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,11 @@
 # CHANGELOG JULY 2026
 
+## August 1st, 2026 - ui(builder): move the block name out from under the resize grip
+
+Spotted by a friend of the author within seconds of seeing the canvas: the block-name chip sits flush in the top-left corner, which is now exactly where the northwest resize grip lives, so the grip reads as part of the label. The "Source updated" badge had the same problem in the top-right.
+
+Both chips now tuck in just past the corner grips. The inset reuses the same `min(px, %)` expression the handles are capped with rather than a fixed number, so on a small block - where a grip is a share of the block rather than 13px - the label insets by exactly as much as the grip actually took, instead of by more than the block is wide.
+
 ## August 1st, 2026 - feat(builder): drag-to-resize, and a canvas you can actually read
 
 Three complaints about the Builder canvas, all downstream of one thing: the canvas is drawn at 1920x1080 and scaled to fit, so every piece of UI chrome on it was being drawn at roughly a third of its intended size.

--- a/resources/js/components/builder/BuilderPlacement.vue
+++ b/resources/js/components/builder/BuilderPlacement.vue
@@ -36,6 +36,22 @@ const EDGE_PX = 9;
 // handle as a share of the block keeps a middle to drag from at any size.
 const handleSize = (screenPx: number, cap: string) => `min(${px(screenPx)}, ${cap})`;
 
+// Both corner caps are shares of the block, so the chips that tuck in beside
+// them have to be inset by the same expression rather than a fixed number -
+// otherwise a small block insets its label further than the block is wide.
+const cornerInset = computed(() => handleSize(HANDLE_PX, '30%'));
+const edgeInset = computed(() => handleSize(EDGE_PX, '22%'));
+
+/**
+ * The name chip and the stale badge sit just inside the top corner grips.
+ * Flush to the corner they were sitting *under* the grab handles, which reads
+ * as the handle being part of the label.
+ */
+const chipStyle = computed(() => ({
+  top: edgeInset.value,
+  maxWidth: `calc(100% - ${cornerInset.value} - ${cornerInset.value})`,
+}));
+
 const outline = computed(() =>
   props.selected
     ? `${px(OUTLINE_SELECTED_PX)} solid var(--color-violet-500)`
@@ -136,15 +152,15 @@ const gridArea = computed(
       :title="placement.block_name"
     />
     <div
-      class="pointer-events-none absolute top-0 left-0 max-w-full truncate bg-sidebar-accent/90 font-mono text-foreground"
-      :style="{ fontSize: px(12), padding: `${px(1)} ${px(6)}` }"
+      class="pointer-events-none absolute truncate bg-sidebar-accent/90 font-mono text-foreground"
+      :style="{ ...chipStyle, left: cornerInset, fontSize: px(12), padding: `${px(1)} ${px(6)}` }"
     >
       {{ placement.block_name }}
     </div>
     <div
       v-if="sourceStale"
-      class="pointer-events-none absolute top-0 right-0 bg-amber-500/90 font-medium text-black"
-      :style="{ fontSize: px(10), padding: `${px(1)} ${px(6)}` }"
+      class="pointer-events-none absolute truncate bg-amber-500/90 font-medium text-black"
+      :style="{ ...chipStyle, right: cornerInset, fontSize: px(10), padding: `${px(1)} ${px(6)}` }"
       title="The source of this block changed since it was placed. Select it to refresh."
     >
       Source updated


### PR DESCRIPTION
Follow-up to #176. The block-name chip sits flush in the top-left corner, which is now exactly where the northwest resize grip lives, so the grip reads as part of the label. The "Source updated" badge had the same problem in the top-right.

Both chips now tuck in just past the corner grips.

The detail worth noting: the inset reuses the same `min(px, %)` expression the handles are capped with rather than a fixed `13px`. On a small block a grip is a share of the block instead of its full size, so a hardcoded inset would push the label further in than the grip actually took - and on a very small block the chip's `max-width` calc would go negative and collapse the name entirely. Tying both to one expression means they can't disagree.

`vue-tsc`, ESLint and a production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
