### PR TITLE
fix(nav): stop guest logo clicks rendering the homepage in a dialog

### DIFF
--- a/docs/changelog/changelog-2026-07.md
+++ b/docs/changelog/changelog-2026-07.md
@@ -1,5 +1,18 @@
 # CHANGELOG JULY 2026
 
+## August 1st, 2026 - fix(nav): clicking the logo as a guest rendered the homepage in a dialog
+
+Visit `/help` logged out, click the Overlabels logo, and the entire homepage appeared inside a near-fullscreen box floating on top of the help page. The URL stayed on `/help`, because nothing had navigated anywhere.
+
+That box was never ours. It is `#inertia-error-dialog`, Inertia's "this response was not an Inertia response" panel, sized `calc(100vw - 100px)` by `calc(100vh - 100px)` with the raw response dropped into a sandboxed iframe. The chain: the help pages render through `AppLayout`, whose sidebar logo was an Inertia `<Link>` pointing at `/` for guests, and `/` returns `view('welcome')` - a plain Blade page with no `x-inertia` header. Inertia XHR'd it, got back a full HTML document, and did the only thing it knows how to do with one. Logged in it worked purely by accident, because that branch pointed at the dashboard, which is a real Inertia page.
+
+Worth knowing for anyone reading this later: Inertia 3 does not dev-gate that dialog. It ships to production, which is why this was visible on the live site rather than only on localhost.
+
+- **Eight links were pointing an Inertia `<Link>` at a Blade route**, not one. The sidebar logo was just the one that got noticed. The same trap sat in both auth layouts, both the Privacy and Terms nav logos and their "Back to Home" buttons, the public preview brand strip, and the guest "Connect" link in `UserInfo`. Privacy and Terms are `Inertia::render` and guest-reachable, so those were live too - confirmed by reproducing it on `/privacy` before touching anything. All eight are now plain `<a>` elements, which is what a link to a non-Inertia page has always needed to be.
+- **A global `httpException` handler in `app.ts` as the backstop.** A 2xx HTML response to an Inertia request means "this URL is a real page, not an Inertia endpoint", so it now does what the click intended and performs a real navigation instead of popping the dialog. That covers the ninth link, whenever someone adds it.
+- **Errors deliberately still get the dialog.** A blown-up server render in a full-page iframe is the one case where it earns its keep, so only successful HTML responses are intercepted.
+- **The pending URL comes from the visit, not the response.** `HttpExceptionResponse` is typed as status, data and headers only - the axios `config.url` is there at runtime but is not part of the contract, and Inertia's `HttpClient` interface reads like a client swap is coming. So the handler tracks the in-flight visit's typed `url` from the `start` event instead. Prefetches are skipped: they are speculative, and yanking the tab somewhere off the back of a link nobody clicked would be a worse bug than the one being fixed.
+
 ## August 1st, 2026 - ui(builder): move the block name out from under the resize grip
 
 Spotted by a friend of the author within seconds of seeing the canvas: the block-name chip sits flush in the top-left corner, which is now exactly where the northwest resize grip lives, so the grip reads as part of the label. The "Source updated" badge had the same problem in the top-right.

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,6 +1,6 @@
 import '../css/app.css';
 
-import { createInertiaApp } from '@inertiajs/vue3';
+import { createInertiaApp, router } from '@inertiajs/vue3';
 import { createPinia } from 'pinia'
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import type { DefineComponent } from 'vue';
@@ -38,6 +38,37 @@ axios.interceptors.response.use(
         return Promise.reject(error);
     },
 );
+
+// Inertia only recognises responses carrying the x-inertia header. Point an
+// Inertia <Link> at a plain Blade route (the marketing homepage at '/', say)
+// and the XHR comes back as a full HTML document, which Inertia answers by
+// popping #inertia-error-dialog - a calc(100vw-100px) <dialog> that renders
+// the entire response in an iframe on top of whatever page you were on. The
+// URL never changes, so it reads as a bug rather than a navigation. Inertia 3
+// does not dev-gate that dialog, so it ships to users.
+//
+// A 2xx HTML response just means "this URL is a real page, not an Inertia
+// endpoint", so do what the click intended and navigate to it for real.
+// Error responses still get the dialog - seeing a blown-up server render is
+// the one case where it earns its keep.
+// The httpException payload carries status/data/headers but no URL, so track
+// the visit that is in flight. Prefetches are skipped: they are speculative,
+// and hijacking the tab off the back of one nobody clicked would be worse than
+// the dialog. Errors intentionally fall through to Inertia's default.
+let pendingVisitUrl: URL | null = null;
+
+router.on('start', (event) => {
+    pendingVisitUrl = event.detail.visit.prefetch ? null : event.detail.visit.url;
+});
+
+router.on('httpException', (event) => {
+    const { status, data } = event.detail.response;
+
+    if (status >= 200 && status < 300 && typeof data === 'string' && pendingVisitUrl) {
+        event.preventDefault();
+        window.location.href = pendingVisitUrl.href;
+    }
+});
 
 const pinia = createPinia()
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -143,9 +143,15 @@ const adminNavItems = computed<NavItem[]>(() => {
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton as-child>
-            <Link :href="user ? route('dashboard.index') : '/'">
+            <!-- Guests land on '/', which is a plain Blade view rather than an
+                 Inertia page, so it needs a real anchor - an Inertia <Link>
+                 would XHR it and get the non-Inertia error dialog. -->
+            <Link v-if="user" :href="route('dashboard.index')">
               <AppLogo />
             </Link>
+            <a v-else href="/" class="cursor-pointer">
+              <AppLogo />
+            </a>
           </SidebarMenuButton>
         </SidebarMenuItem>
       </SidebarMenu>

--- a/resources/js/components/UserInfo.vue
+++ b/resources/js/components/UserInfo.vue
@@ -3,7 +3,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { useInitials } from '@/composables/useInitials';
 import { useStreamState } from '@/composables/useStreamState';
 import type { User } from '@/types';
-import { Link, usePage } from '@inertiajs/vue3';
+import { usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 
 const { isLive, isTransitioning, uptime } = useStreamState();
@@ -48,8 +48,9 @@ const showAvatar = computed(() => props?.user?.avatar && props?.user?.avatar !==
     <span v-else class="text-xs text-muted-foreground font-mono w-25">Not streaming</span>
   </div>
   <div v-else>
-    <Link href="/">
+    <!-- Plain anchor: '/' is a Blade view, not an Inertia page. -->
+    <a href="/" class="cursor-pointer">
       <span class="truncate text-xs text-muted-foreground">Connect</span>
-    </Link>
+    </a>
   </div>
 </template>

--- a/resources/js/layouts/auth/AuthCardLayout.vue
+++ b/resources/js/layouts/auth/AuthCardLayout.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Link } from '@inertiajs/vue3';
 
 defineProps<{
     title?: string;
@@ -12,11 +11,12 @@ defineProps<{
 <template>
     <div class="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
         <div class="flex w-full max-w-md flex-col gap-6">
-            <Link :href="route('home')" class="flex items-center gap-2 self-center font-medium">
+            <!-- Plain anchor: '/' is a Blade view, not an Inertia page. -->
+            <a :href="route('home')" class="flex cursor-pointer items-center gap-2 self-center font-medium">
                 <div class="flex h-9 w-9 items-center justify-center">
                     <AppLogoIcon className="hi" class="size-9 fill-current text-black dark:text-white" />
                 </div>
-            </Link>
+            </a>
 
             <div class="flex flex-col gap-6">
                 <Card class="rounded-xl">

--- a/resources/js/layouts/auth/AuthSplitLayout.vue
+++ b/resources/js/layouts/auth/AuthSplitLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
-import { Link, usePage } from '@inertiajs/vue3';
+import { usePage } from '@inertiajs/vue3';
 
 const page = usePage();
 const name = page.props.name;
@@ -16,10 +16,11 @@ defineProps<{
     <div class="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0">
         <div class="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r">
             <div class="absolute inset-0 bg-zinc-900" />
-            <Link :href="route('home')" class="relative z-20 flex items-center text-lg font-medium">
+            <!-- Plain anchor: '/' is a Blade view, not an Inertia page. -->
+            <a :href="route('home')" class="relative z-20 flex cursor-pointer items-center text-lg font-medium">
                 <AppLogoIcon className="hi" class="mr-2 size-8 fill-current text-white" />
                 {{ name }}
-            </Link>
+            </a>
             <div v-if="quote" class="relative z-20 mt-auto">
                 <blockquote class="space-y-2">
                     <p class="text-lg">&ldquo;{{ quote.message }}&rdquo;</p>

--- a/resources/js/pages/Privacy.vue
+++ b/resources/js/pages/Privacy.vue
@@ -21,11 +21,12 @@ const lastUpdated = 'May 14, 2026';
       <nav class="sticky top-0 z-50 backdrop-blur-lg bg-background/80 border-b border-border/50">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
           <div class="flex items-center justify-between h-16">
-            <Link href="/" class="flex items-center gap-2.5">
+            <!-- Plain anchor: '/' is a Blade view, not an Inertia page. -->
+            <a href="/" class="flex cursor-pointer items-center gap-2.5">
               <img src="/favicon.png" alt="" class="w-8 h-8" />
               <span class="text-lg font-bold tracking-tight">Overlabels</span>
               <Badge variant="outline" class="text-xs">Beta</Badge>
-            </Link>
+            </a>
             <div class="flex items-center gap-6">
               <Link href="/help"
                     class="hidden sm:block text-sm text-muted-foreground hover:text-foreground transition-colors">Docs
@@ -227,10 +228,10 @@ const lastUpdated = 'May 14, 2026';
 
         <div class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800">
           <Button variant="outline" asChild>
-            <Link href="/" class="gap-2">
+            <a href="/" class="cursor-pointer gap-2">
               <ArrowLeft class="h-4 w-4" />
               Back to Home
-            </Link>
+            </a>
           </Button>
         </div>
       </div>

--- a/resources/js/pages/Terms.vue
+++ b/resources/js/pages/Terms.vue
@@ -21,11 +21,12 @@ const effectiveDate = 'January 13, 2025';
       <nav class="sticky top-0 z-50 backdrop-blur-lg bg-background/80 border-b border-border/50">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
           <div class="flex items-center justify-between h-16">
-            <Link href="/" class="flex items-center gap-2.5">
+            <!-- Plain anchor: '/' is a Blade view, not an Inertia page. -->
+            <a href="/" class="flex cursor-pointer items-center gap-2.5">
               <img src="/favicon.png" alt="" class="w-8 h-8" />
               <span class="text-lg font-bold tracking-tight">Overlabels</span>
               <Badge variant="outline" class="text-xs">Beta</Badge>
-            </Link>
+            </a>
             <div class="flex items-center gap-6">
               <Link href="/help"
                     class="hidden sm:block text-sm text-muted-foreground hover:text-foreground transition-colors">Docs
@@ -306,10 +307,10 @@ const effectiveDate = 'January 13, 2025';
 
         <div class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800">
           <Button variant="outline" asChild>
-            <Link href="/" class="gap-2">
+            <a href="/" class="cursor-pointer gap-2">
               <ArrowLeft class="h-4 w-4" />
               Back to Home
-            </Link>
+            </a>
           </Button>
         </div>
       </div>

--- a/resources/js/pages/overlay/public-preview.vue
+++ b/resources/js/pages/overlay/public-preview.vue
@@ -156,11 +156,12 @@ const activeSource = computed(() => {
     <div class="mx-auto max-w-450 p-4 lg:p-6">
       <!-- Slim brand strip -->
       <div class="mb-4 flex items-center justify-between">
-        <Link href="/" class="flex items-center gap-2 text-sm font-bold tracking-tight text-foreground hover:text-violet-400">
+        <!-- Plain anchor: '/' is a Blade view, not an Inertia page. -->
+        <a href="/" class="flex cursor-pointer items-center gap-2 text-sm font-bold tracking-tight text-foreground hover:text-violet-400">
           <img src="/favicon-light.svg" alt="" class="h-6 w-6 dark:hidden" />
           <img src="/favicon.png" alt="" class="hidden h-6 w-6 dark:block" />
           Overlabels
-        </Link>
+        </a>
         <Link
           v-if="isAuthed"
           :href="route('dashboard.index')"


### PR DESCRIPTION
## What was happening

Visit `/help` logged out, click the Overlabels logo, and the entire homepage renders inside a near-fullscreen box on top of the help page. The URL stays on `/help`.

## What that box actually is

`#inertia-error-dialog` - Inertia's "the response wasn't an Inertia response" panel, sized `calc(100vw - 100px)` x `calc(100vh - 100px)`, with the raw response dropped into a sandboxed iframe.

The chain:

1. `/help` renders through `HelpLayout` -> `AppLayout` -> `AppSidebar`.
2. `AppSidebar.vue:146` had the logo as an Inertia `<Link>`: `:href="user ? route('dashboard.index') : '/'"`.
3. Logged out, that fires an Inertia XHR GET to `/`.
4. `routes/web.php:55` returns `view('welcome')` - plain Blade, no `x-inertia` header.
5. Inertia hits `handleNonInertiaResponse()` and shows the dialog.

Logged in it worked by accident: `route('dashboard.index')` is a real Inertia page, so the bad branch was never taken.

Note for reviewers: Inertia 3 does **not** dev-gate this dialog. It ships to production, which is why this was reproducible on the live site.

## Fix

**Eight links, not one.** Every Inertia `<Link>` pointing at `/` had the same trap: the sidebar logo (guest branch), both auth layouts, the Privacy and Terms nav logos plus their back-to-home buttons, the public preview brand strip, and the guest Connect link in `UserInfo`. Privacy and Terms are `Inertia::render` and guest-reachable, so those were live too - reproduced on `/privacy` before touching anything. All now plain `<a>`.

**Global backstop** in `app.ts`: an `httpException` handler that turns a 2xx HTML response into a real navigation instead of the dialog. Covers the ninth link whenever someone adds it.

Two deliberate constraints:

- **Errors still get the dialog.** Only successful HTML responses are intercepted - a blown-up server render in a full-page iframe is the one case where that dialog is useful.
- **The URL comes from the visit, not the response.** `HttpExceptionResponse` is typed as `status`/`data`/`headers` only. The axios `config.url` exists at runtime but isn't part of the contract, and the `HttpClient` interface reads like a client swap is planned, so the handler tracks the in-flight visit's typed `url` from the `start` event. Prefetches are skipped - navigating the tab off a speculative request nobody clicked would be worse than the dialog.

## Verification

- Reproduced live on both `/help` and `/privacy` before the fix, and confirmed the DOM contained `<dialog open id="inertia-error-dialog">` wrapping a `srcdoc` iframe.
- Fix verified on localhost by the author.
- `vue-tsc --noEmit` clean, ESLint clean, `npm run build` clean.
- `php artisan test`: 1169 passed (3442 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
