### PR TITLE
feat(updates): make the updates feed publicly accessible

### DIFF
--- a/config/ziggy.php
+++ b/config/ziggy.php
@@ -40,7 +40,7 @@ $hidden = [
 return [
     'groups' => [
         // Logged-out visitors: only the handful of genuinely public routes.
-        'guest' => ['login', 'home', 'help.*', 'privacy', 'terms'],
+        'guest' => ['login', 'home', 'help.*', 'updates.*', 'privacy', 'terms'],
         // Authenticated non-admins: everything except admin routes and the hidden set.
         'user' => array_merge(['*', '!admin.*'], $hidden),
         // Admins: everything except the hidden set (admin routes kept).

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,0 +1,12 @@
+# CHANGELOG AUGUST 2026
+
+## August 1st, 2026 - feat(updates): the updates feed is public
+
+`https://overlabels.com/updates/overlabels-development-highlights-july-2026` bounced anyone who was not logged in. That is the wrong shape for what these posts are: announcements, written to be linked from Twitch, from Discord, from anywhere someone might first hear about the project. A link that only works if you already have an account is not a link.
+
+Both routes moved out of the `auth.redirect` group and now sit with the other public routes, next to `/help`. Nothing else about them changed.
+
+- **No new visibility logic was needed.** `UpdateController` already queried through the `published()` scope on both actions, which is `published_at <= now()`, so a post dated into the future stays a 404 for guests exactly as it did for logged-in visitors. Moving the route did not open a hole, because the gate was never the middleware.
+- **`updates.*` joined the `guest` Ziggy group.** The index page calls `route('updates.index')` when you type in the search box or pick a tag, and the guest group is a whitelist, so without this the filters would have thrown for the exact visitors the change is for. Worth remembering for the next public page: making a route public is two edits, not one.
+- **Guests get an Updates item in the sidebar.** Logged-out visitors see their own nav list, so the page was reachable but not findable. It now sits under Learn, right below Help.
+- **A test pins all of it down**, including the future-dated 404, because "this page is public" is the kind of property that quietly stops being true.

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -99,6 +99,7 @@ const learnNavItems = computed<NavItem[]>(() =>
 
 const helpNavItems: NavItem[] = [
   { title: 'Help', href: '/help', icon: BookOpen },
+  { title: 'Updates', href: '/updates', icon: Newspaper },
   { title: 'Conditional Tags', href: '/help/conditionals', icon: Brackets },
   { title: 'Controls', href: '/help/controls', icon: SlidersHorizontal },
   { title: 'Math Engine', href: '/help/math', icon: Sigma },

--- a/routes/web.php
+++ b/routes/web.php
@@ -139,6 +139,15 @@ Route::get('/help/reference/{category?}/{slug?}', [HelpReferenceController::clas
     ->where(['category' => '[a-z0-9\-]+', 'slug' => '[a-zA-Z0-9_\-\.]+'])
     ->name('help.reference');
 
+// Updates (blog-style platform announcements). Public: these are announcement
+// posts we want linkable from anywhere and indexable, so a login wall would
+// defeat the point. The controller only ever queries the published() scope
+// (published_at <= now), so future-dated posts stay invisible to guests.
+Route::prefix('updates')->name('updates.')->group(function () {
+    Route::get('/', [UpdateController::class, 'index'])->name('index');
+    Route::get('/{slug}', [UpdateController::class, 'show'])->name('show')->where('slug', '[a-z0-9-]+');
+});
+
 Route::get('/sitemap.xml', SitemapController::class)->name('sitemap');
 
 // Dev-only tile-map builder. Guarded by admin.role + env=local check in the controller.
@@ -533,12 +542,6 @@ Route::middleware('auth.redirect')->group(function () {
         Route::put('/{template}/target-overlays', [OverlayTemplateController::class, 'updateTargetOverlays'])->name('target-overlays');
         Route::put('/{template}/triggers', [OverlayTemplateController::class, 'updateTriggers'])->name('triggers');
         Route::put('/{template}/screenshot', [OverlayTemplateController::class, 'updateScreenshot'])->name('screenshot');
-    });
-
-    // Updates (blog-style platform announcements)
-    Route::prefix('updates')->name('updates.')->group(function () {
-        Route::get('/', [UpdateController::class, 'index'])->name('index');
-        Route::get('/{slug}', [UpdateController::class, 'show'])->name('show')->where('slug', '[a-z0-9-]+');
     });
 
     // Cloudinary uploads - all image uploads route through here so we can

--- a/tests/Feature/PublicUpdatesTest.php
+++ b/tests/Feature/PublicUpdatesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Models\Update;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeUpdate(array $attributes = []): Update
+{
+    return Update::create(array_merge([
+        'title' => 'Overlabels development highlights July 2026',
+        'body' => 'Here is what shipped.',
+        'excerpt' => 'A month of shipping.',
+        'published_at' => now()->subDay(),
+    ], $attributes));
+}
+
+it('lets a guest read the updates index', function () {
+    makeUpdate();
+
+    $this->get('/updates')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->component('updates/index'));
+});
+
+it('lets a guest read a single update', function () {
+    $update = makeUpdate();
+
+    $this->get("/updates/{$update->slug}")
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('updates/show')
+            ->where('update.slug', $update->slug)
+        );
+});
+
+it('renders updates as a guest rather than redirecting to login', function () {
+    $update = makeUpdate();
+
+    $this->get("/updates/{$update->slug}")
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('auth.user', null)
+            ->where('isAdmin', false)
+        );
+});
+
+it('hides future-dated posts from guests', function () {
+    $scheduled = makeUpdate([
+        'title' => 'Not out yet',
+        'published_at' => now()->addWeek(),
+    ]);
+
+    $this->get("/updates/{$scheduled->slug}")->assertNotFound();
+});


### PR DESCRIPTION
Update posts are announcements meant to be linked from Twitch, Discord and anywhere else someone first hears about the project, but both routes sat behind `auth.redirect`, so a shared link like `/updates/overlabels-development-highlights-july-2026` bounced logged-out visitors to login.

## Changes

- **`routes/web.php`** - `updates.index` and `updates.show` moved out of the `auth.redirect` group, up next to the other public routes. `route:list` confirms they now carry only `web`.
- **`config/ziggy.php`** - added `updates.*` to the `guest` group. Load-bearing: `updates/index.vue` calls `route('updates.index')` from its search and tag filters, and the guest group is a whitelist, so those would have thrown for exactly the visitors this is for.
- **`AppSidebar.vue`** - Updates added to `helpNavItems`, the nav guests actually see, so the page is findable and not only reachable.
- **`tests/Feature/PublicUpdatesTest.php`** - 4 tests: guest reads the index, guest reads a post, the page renders with `auth.user` null instead of redirecting, and a future-dated post is still a 404.

## No new visibility logic

`UpdateController` already queried through the `published()` scope (`published_at <= now`) on both actions, so scheduled posts were never hidden by the middleware. Moving the route did not open a hole.

## Not included

Published updates are still absent from `SitemapController`, so crawlers only find posts that are linked from elsewhere. Separate call, happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)