### PR TITLE
Clear out the recent-events feed, and fix the search that made it hard to

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -69,22 +69,23 @@ class DashboardController extends Controller
     {
         $user = $request->user();
 
-        $recentTemplates = OverlayTemplate::where('owner_id', $user->id)
-            ->with('owner:id,name,avatar')
-            ->latest('updated_at')
-            ->limit(20)
-            ->get();
-
         $filters = $eventFeed->normalizeFilters($request);
         $paginator = $eventFeed->paginate($user->id, $filters, 20)->withQueryString();
-        $facets = $eventFeed->facets($user->id);
 
+        // Only the feed itself responds to a filter change, and search runs on
+        // every keystroke batch. The rest is deferred behind closures so a
+        // partial reload that asks for `recentEvents` alone does not also pay
+        // for the template list, the facet counts and the user's lists.
         return Inertia::render('dashboard/recents', [
-            'recentTemplates' => $recentTemplates,
+            'recentTemplates' => fn () => OverlayTemplate::where('owner_id', $user->id)
+                ->with('owner:id,name,avatar')
+                ->latest('updated_at')
+                ->limit(20)
+                ->get(),
             'recentEvents' => $paginator,
             'filters' => $filters,
-            'facets' => $facets,
-            'userLists' => $this->eventFeedLists($user->id),
+            'facets' => fn () => $eventFeed->facets($user->id),
+            'userLists' => fn () => $this->eventFeedLists($user->id),
         ]);
     }
 

--- a/app/Http/Controllers/EventDeletionController.php
+++ b/app/Http/Controllers/EventDeletionController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\UnifiedEventFeedService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Bulk removal of rows from the unified recent-events feed.
+ *
+ * Deliberately narrow: this cleans up the list and nothing else. Deleting a
+ * donation event does not roll back the counters it incremented, because those
+ * controls are running totals rather than a projection of the event tables.
+ * Users reset them with the per-integration seed actions.
+ *
+ * Session-authed only. The token-authed /events/feed shares the same table
+ * component but does not get this - overlay tokens live in an OBS browser
+ * source URL, and a destructive third ability on them is a bad trade.
+ */
+class EventDeletionController extends Controller
+{
+    public function __construct(
+        private readonly UnifiedEventFeedService $eventFeed,
+    ) {}
+
+    /**
+     * POST /events/bulk-delete
+     *
+     * Two modes:
+     *  - `all: true` deletes everything matching the filters on the query
+     *    string (the same ones the feed was rendered with).
+     *  - otherwise `events` carries the explicitly picked {source, id} pairs.
+     *
+     * Ids collide between twitch_events and external_events, so a pair without
+     * its source is ambiguous and would delete the wrong row.
+     */
+    public function destroy(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'all' => ['sometimes', 'boolean'],
+            'events' => ['sometimes', 'array', 'max:500'],
+            'events.*.source' => ['required_with:events', 'string', 'max:50'],
+            'events.*.id' => ['required_with:events', 'integer', 'min:1'],
+        ]);
+
+        $userId = $request->user()->id;
+
+        if ($validated['all'] ?? false) {
+            // Filters are re-read from the request rather than accepted as a
+            // client-supplied id list, so "delete all matching" can never widen
+            // beyond what the same filters would have displayed.
+            $filters = $this->eventFeed->normalizeFilters($request);
+            $deleted = $this->eventFeed->deleteMatching($userId, $filters);
+        } else {
+            $pairs = $validated['events'] ?? [];
+
+            if (empty($pairs)) {
+                return back()->with('message', 'No events were selected.')->with('type', 'warning');
+            }
+
+            $twitchIds = [];
+            $externalIds = [];
+            foreach ($pairs as $pair) {
+                if ($pair['source'] === 'twitch') {
+                    $twitchIds[] = (int) $pair['id'];
+                } else {
+                    $externalIds[] = (int) $pair['id'];
+                }
+            }
+
+            $deleted = $this->eventFeed->deleteByIds($userId, $twitchIds, $externalIds);
+        }
+
+        if ($deleted === 0) {
+            return back()->with('message', 'Nothing was deleted.')->with('type', 'warning');
+        }
+
+        return back()
+            ->with('message', $deleted === 1 ? 'Deleted 1 event.' : "Deleted {$deleted} events.")
+            ->with('type', 'success');
+    }
+}

--- a/app/Services/UnifiedEventFeedService.php
+++ b/app/Services/UnifiedEventFeedService.php
@@ -233,8 +233,24 @@ class UnifiedEventFeedService
 
         if ($filters['search'] !== '') {
             $like = '%'.addcslashes($filters['search'], '%_\\').'%';
-            $twitch->whereRaw('event_data::text ILIKE ?', [$like]);
-            $external->whereRaw('normalized_payload::text ILIKE ?', [$like]);
+
+            // The event type is searched alongside the payload, because the
+            // words people read in the feed often live only in the type. A poll
+            // payload never contains the string "poll" - so searching "poll"
+            // used to find nothing, while "po" found polls by accident, via the
+            // "po" in the payload's `channel_points_voting` key.
+            //
+            // Both branches must stay grouped: an ungrouped orWhere would climb
+            // out past the user_id scope and the gps exclusion, and this same
+            // method backs deleteMatching().
+            $twitch->where(function (QueryBuilder $q) use ($like): void {
+                $q->whereRaw('event_data::text ILIKE ?', [$like])
+                    ->orWhere('event_type', 'ilike', $like);
+            });
+            $external->where(function (QueryBuilder $q) use ($like): void {
+                $q->whereRaw('normalized_payload::text ILIKE ?', [$like])
+                    ->orWhere('event_type', 'ilike', $like);
+            });
         }
     }
 }

--- a/app/Services/UnifiedEventFeedService.php
+++ b/app/Services/UnifiedEventFeedService.php
@@ -128,6 +128,71 @@ class UnifiedEventFeedService
     }
 
     /**
+     * Delete explicitly picked rows. Ids are per-table and collide across the
+     * two sources, so callers pass them pre-split - `source === 'twitch'` picks
+     * twitch_events, every other source is a service name in external_events.
+     *
+     * The user_id scope is the authorization boundary, not a nicety:
+     * twitch_events.user_id is nullable (events for unknown broadcasters), so a
+     * bare whereIn would reach rows that belong to nobody.
+     *
+     * @param  array<int, int>  $twitchIds
+     * @param  array<int, int>  $externalIds
+     * @return int rows deleted
+     */
+    public function deleteByIds(int $userId, array $twitchIds, array $externalIds): int
+    {
+        return DB::transaction(function () use ($userId, $twitchIds, $externalIds): int {
+            $deleted = 0;
+
+            if (! empty($twitchIds)) {
+                $deleted += DB::table('twitch_events')
+                    ->where('user_id', $userId)
+                    ->whereIn('id', $twitchIds)
+                    ->delete();
+            }
+
+            if (! empty($externalIds)) {
+                $deleted += DB::table('external_events')
+                    ->where('user_id', $userId)
+                    // GPS rows never surface in this feed, so they can never be
+                    // picked from it either - guards a spoofed source value.
+                    ->where('service', '!=', 'gps')
+                    ->whereIn('id', $externalIds)
+                    ->delete();
+            }
+
+            return $deleted;
+        });
+    }
+
+    /**
+     * Delete every row matching the current feed filters, re-derived server-side
+     * rather than trusting a client-supplied id list. This is what backs
+     * "select all N matching these filters" - the filter UI doubles as the
+     * selector, so the user decides what counts as junk per cleanup.
+     *
+     * @param  array{search: string, source: string, event_type: string, hidden_types: array<int, string>, range: string}  $filters
+     * @return int rows deleted
+     */
+    public function deleteMatching(int $userId, array $filters): int
+    {
+        return DB::transaction(function () use ($userId, $filters): int {
+            $twitch = DB::table('twitch_events')->where('user_id', $userId);
+            $external = DB::table('external_events')
+                ->where('user_id', $userId)
+                ->where('service', '!=', 'gps');
+
+            // Same filter pass the read query uses, so what gets deleted is
+            // exactly what the page was showing. A source filter turns the other
+            // builder into `1 = 0`, which deletes nothing.
+            $this->applyFilters($twitch, $external, $filters);
+
+            return $twitch->delete() + $external->delete();
+        });
+    }
+
+    /**
      * @param  array{search: string, source: string, event_type: string, hidden_types: array<int, string>, range: string}  $filters
      */
     private function applyFilters(QueryBuilder $twitch, QueryBuilder $external, array $filters): void

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,14 @@
 # CHANGELOG AUGUST 2026
 
+## August 3rd, 2026 - ui(events): the list-feed card on Recent Activity is collapsed by default
+
+"Send these events to a list" occupied most of the first screen of Recent Activity: a title, an explanatory paragraph, a status block, a three-column configuration grid, an event-type fieldset and a save button, all above the events you came to look at. Since the hash-authed feed route landed, mirroring events into a list is a cool thing to have rather than something you need on the way in, and it was pushing the actual point of the page below the fold.
+
+It is now a disclosure. Collapsed you get the title and a chevron; expanded, everything it had before, unchanged.
+
+- **The heading is the toggle** - `<h3>` wrapping a `<button aria-expanded>`, which is the standard disclosure shape, so it keeps its heading semantics and announces its own state instead of being a div that happens to respond to clicks.
+- **One thing survives the collapse: whether a feed is actually running.** The old card deliberately kept "which lists are receiving events" always visible, and hiding that outright would mean a live feed with no sign of itself anywhere. Collapsed, a green dot and "2 lists receiving" sit next to the title - but only when something is on. If you have no feeds, which is the case for everyone this change is for, it really is just the title and the chevron.
+
 ## August 3rd, 2026 - fix(events): searching "poll" found nothing, searching "po" found polls
 
 Typing `Po` in the Recent Activity search returned Poll started, Poll updated and Poll ended. Typing `Poll` returned nothing. Being more specific made the results worse, which is the sort of thing that makes you distrust a search box entirely.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,23 @@
 # CHANGELOG AUGUST 2026
 
+## August 3rd, 2026 - feat(events): select and delete rows from the recent-events feed
+
+Every integration has a test button, and every test event lands in your feed and stays there. Fire a few Twitch CLI events while wiring up an alert and you are left with `testFromUser raid 56171 viewers` sitting in your history forever, next to the real raids.
+
+The obvious fix was to detect test events and hide them, and that turns out to be a trap. The donor name is the only thing the payloads have in common, and it is different for every service: Twitch CLI sends `testFromUser`, Ko-fi sends `Jo Example`, Throne sends `marie_123`, StreamLabs sends `Kevin`, Fourthwall sends `supporter username`, Buy Me a Coffee sends `John`, and StreamElements picks a fresh random name on every payload. Filtering on any of those means the day a real viewer called Kevin tips you, their donation quietly vanishes. There is no name-based rule that is safe.
+
+Test mode looked like the way out, since it already exists per integration and the webhook controller already branches on it - but it does not mean what the name suggests. It only tells the system to stop rejecting repeated UUIDs, so the *first* test event you fire lands identically whether test mode is on or off. Flagging on it would have missed the single test that most people fire, which is exactly the one that causes the clutter.
+
+So no detection. The feed just lets you select rows and delete them.
+
+- **Selection keys are `source:id`, not `id`.** The feed is a `UNION ALL` over `twitch_events` and `external_events`, whose ids both start at 1 and collide freely. A flat id list would have deleted a stranger's Ko-fi tip because it happened to share a number with the follow you picked. A test pins this down specifically.
+- **The filter bar is the bulk selector.** Alongside per-row checkboxes and select-all-on-page there is "select all N matching these filters", which re-derives the set server-side from the same `normalizeFilters()` the feed renders with. Filter to StreamLabs, search "Kevin", delete the 47 that match. It sidesteps the identification problem entirely by letting you define what junk means per cleanup, rather than shipping a rule that has to hold for seven services forever.
+- **Deleting a row takes its hidden rows with it.** Gift-sub bombs fold N recipient events under the gifter, and a resub hides the bare `channel.subscribe` that Twitch fires alongside it. Those rows exist but are not rendered, so deleting only what you can see would have left them behind to reappear ungrouped on the next load, looking like the delete had failed.
+- **`user_id` scoping is the authorization boundary, and it is load-bearing twice over.** `twitch_events.user_id` is nullable for events from broadcasters we do not know, so a delete scoped by id alone would reach rows belonging to nobody. GPS rows are excluded on the way out for the same reason they are excluded on the way in: they never appear in this feed, so they can never be picked from it, spoofed source or not.
+- **No delete on the token-authed `/events/feed`.** It shares the same table component, behind a prop the recents page passes and the feed does not. Overlay tokens live in an OBS browser source URL and are write-capable for exactly two actions today; a destructive third is a worse trade than the convenience is worth.
+- **Nothing is rolled back.** Deleting a donation event does not decrement `donations_received`, because those controls are running counters rather than a projection of the event tables. The confirm copy says so, and points at nothing, because the per-integration seed actions already exist for that.
+- **Deleting while live is allowed.** A lock would not have protected the numbers anyway: session stats are a time-window query computed at read time, so an event deleted thirty seconds after the stream ends moves them exactly as much as one deleted mid-stream. It would only have postponed the same mutation while blocking the case that actually needs it, which is clearing follow-bot spam in the middle of the raid. The confirm says the stats will move and gets out of the way.
+
 ## August 1st, 2026 - fix(auth): logging out landed on a 404 instead of the homepage
 
 Account > Log out did log you out, then dropped you on a 404 at `/logout`. Same day, same root cause as the dialog fix below it: `/` is a plain Blade view, and Inertia has no idea what to do with one.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,16 @@
 # CHANGELOG AUGUST 2026
 
+## August 3rd, 2026 - fix(events): the recents search box was eating characters
+
+Typing in the search filter on Recent Activity felt like it was fighting you. Pause for half a second reaching for Shift and the search would fire early; keep typing while it loaded and the letters you typed would vanish a beat later. It read as "the input is disabled while loading and skips keys", but the field was never disabled and never missed a keystroke. It was throwing them away afterwards.
+
+`recents.vue` kept a local copy of the filters and watched the server's copy to stay in sync, replacing the whole object on every response. The search input is bound to that object. So every response wrote the server's `search` value back into the box you were still typing in - and a response can only ever carry what you asked for one round trip ago. Type `test`, pause, request goes out; type `F`; the response for `test` lands and the box snaps back to `test`. The `F` is gone. The slower the response, the more characters it swallows, which is why it looked like loading was the thing blocking input.
+
+- **The watcher now ignores its own echo.** We remember the term we last dispatched, and when a response comes back carrying exactly that, we leave the box alone - local state is by definition at least as current. A value we did not ask for is real news (back/forward, someone else's link) and is still adopted. The dropdowns sync unconditionally, since you cannot be mid-edit in a `<select>`.
+- **The debounce went from 300ms to 500ms.** 300 is tuned for a search box that is the whole page. This one filters a table you are reading, and reaching for a modifier key routinely takes longer than that.
+- **Search stopped littering browser history.** The filter visit was pushing an entry per keystroke batch, so leaving the page meant pressing back through `t`, `te`, `tes`. It replaces now.
+- **A filter change only fetches the feed.** It was re-sending the template list, the facet counts and the user's lists on every keystroke. Those cannot change from a filter, so the visit asks for `recentEvents` and `filters`, and the controller defers the other three behind closures so their queries do not run either. Making the response smaller also shrinks the window the bug above lived in, which is why it was worth doing in the same pass rather than later.
+
 ## August 3rd, 2026 - feat(events): select and delete rows from the recent-events feed
 
 Every integration has a test button, and every test event lands in your feed and stays there. Fire a few Twitch CLI events while wiring up an alert and you are left with `testFromUser raid 56171 viewers` sitting in your history forever, next to the real raids.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,15 @@
 # CHANGELOG AUGUST 2026
 
+## August 3rd, 2026 - fix(events): searching "poll" found nothing, searching "po" found polls
+
+Typing `Po` in the Recent Activity search returned Poll started, Poll updated and Poll ended. Typing `Poll` returned nothing. Being more specific made the results worse, which is the sort of thing that makes you distrust a search box entirely.
+
+The search only ever looked at the stored payload - `event_data::text` for Twitch, `normalized_payload::text` for external services. A poll payload does not contain the word "poll" anywhere; the word lives in the event type (`channel.poll.end`) and in the label the feed renders in the browser, neither of which was being searched. The `Po` results were a coincidence: poll payloads carry a `channel_points_voting` key, and "po" is a substring of "points". Nothing about polls was ever actually matching.
+
+- **The event type is searched alongside the payload now.** That is where the words people actually type live - "poll", "raid", "cheer", "follow", "donation". Both event tables get it, so it works the same either side of the union.
+- **The two conditions are grouped, and that matters more than it looks.** An ungrouped `orWhere` would have escaped the surrounding `user_id` scope and the GPS exclusion, turning a search into a way to read every user's events. The same `applyFilters()` also backs the new bulk delete, so the identical mistake would have deleted other people's rows. There is a test on each path that fails if the grouping is ever removed.
+- **Still not searchable: the multi-word labels.** The feed renders "Poll updated" client-side while the server's catalogue calls the same event "Poll Progress", so there is no single string to match against. Searching "poll" finds it; searching "poll updated" does not. Worth fixing by making one of those the source of truth rather than by teaching the query about both.
+
 ## August 3rd, 2026 - fix(events): the recents search box was eating characters
 
 Typing in the search filter on Recent Activity felt like it was fighting you. Pause for half a second reaching for Shift and the search would fire early; keep typing while it loaded and the letters you typed would vanish a beat later. It read as "the input is disabled while loading and skips keys", but the field was never disabled and never missed a keystroke. It was throwing them away afterwards.

--- a/resources/js/components/EventsTable.vue
+++ b/resources/js/components/EventsTable.vue
@@ -15,11 +15,19 @@ const props = defineProps<{
   // session-authed dashboard routes; used by the events feed, which has no
   // session and no Inertia. Requires the token's `write` ability server-side.
   token?: string;
+  // Opt-in row selection for bulk delete. Only the session-authed recents page
+  // passes this - the token-authed feed shares this component but must not be
+  // able to destroy events.
+  selectable?: boolean;
+  // Selected row keys, `${source}:${id}`. Ids collide between twitch_events and
+  // external_events, so the source has to be part of the key.
+  selection?: string[];
 }>();
 
 const emit = defineEmits<{
   // Replay outcome for pages without Inertia flash messages (the events feed).
   'replay-result': [result: { message: string; type: string }];
+  'update:selection': [keys: string[]];
 }>();
 
 const replayingId = ref<number | null>(null);
@@ -37,6 +45,11 @@ const expandedGifts = ref<Set<number>>(new Set());
 interface DisplayRow {
   event: UnifiedEvent;
   recipients: UnifiedEvent[];
+  // Rows this one absorbed and that are therefore not rendered on their own:
+  // gift recipients, plus the bare sub that the resub pass hides. Selection has
+  // to carry them, otherwise deleting the visible row un-hides its leftovers
+  // and they reappear in the feed ungrouped.
+  covered: UnifiedEvent[];
 }
 
 const GIFT_EVENT = 'channel.subscription.gift';
@@ -56,6 +69,9 @@ const displayRows = computed<DisplayRow[]>(() => {
   const list = props.events;
   const claimed = new Set<number>();
   const recipientsByGift = new Map<number, UnifiedEvent[]>();
+  // Every hidden row, keyed by the visible row that swallowed it. All the
+  // grouping below is Twitch-only, so plain numeric ids are unambiguous here.
+  const coveredByOwner = new Map<number, UnifiedEvent[]>();
 
   // Walk oldest -> newest so "the next N recipients" reads naturally in time.
   const chronological = [...list].reverse();
@@ -82,7 +98,10 @@ const displayRows = computed<DisplayRow[]>(() => {
       recipients.push(sub);
     }
 
-    if (recipients.length > 0) recipientsByGift.set(gift.id, recipients);
+    if (recipients.length > 0) {
+      recipientsByGift.set(gift.id, recipients);
+      coveredByOwner.set(gift.id, [...recipients]);
+    }
   }
 
   // Second pass: drop the bare self-sub that Twitch emits alongside each resub.
@@ -97,7 +116,7 @@ const displayRows = computed<DisplayRow[]>(() => {
     const resubTime = Date.parse(resub.created_at);
 
     // Claim the closest unclaimed self-sub from the same user within the window.
-    let bestId = -1;
+    let best: UnifiedEvent | null = null;
     let bestDelta = Infinity;
     for (const sub of chronological) {
       if (claimed.has(sub.id)) continue;
@@ -109,19 +128,65 @@ const displayRows = computed<DisplayRow[]>(() => {
       const delta = Math.abs(Date.parse(sub.created_at) - resubTime);
       if (delta <= RESUB_DEDUP_WINDOW_MS && delta < bestDelta) {
         bestDelta = delta;
-        bestId = sub.id;
+        best = sub;
       }
     }
-    if (bestId >= 0) claimed.add(bestId);
+    if (best) {
+      claimed.add(best.id);
+      coveredByOwner.set(resub.id, [...(coveredByOwner.get(resub.id) ?? []), best]);
+    }
   }
 
   const rows: DisplayRow[] = [];
   for (const event of list) {
     if (claimed.has(event.id)) continue;
-    rows.push({ event, recipients: recipientsByGift.get(event.id) ?? [] });
+    rows.push({
+      event,
+      recipients: recipientsByGift.get(event.id) ?? [],
+      covered: coveredByOwner.get(event.id) ?? [],
+    });
   }
   return rows;
 });
+
+/* ----------------------------- Row selection ----------------------------- */
+
+function rowKey(event: UnifiedEvent): string {
+  return `${event.source}:${event.id}`;
+}
+
+// A row stands for itself plus everything it hid, so selecting it deletes the
+// whole visual group rather than stranding its recipients.
+function keysFor(event: UnifiedEvent, covered: UnifiedEvent[]): string[] {
+  return [rowKey(event), ...covered.map(rowKey)];
+}
+
+const selectedKeys = computed(() => new Set(props.selection ?? []));
+
+function isRowSelected(event: UnifiedEvent): boolean {
+  return selectedKeys.value.has(rowKey(event));
+}
+
+function toggleRow(event: UnifiedEvent, covered: UnifiedEvent[]) {
+  const next = new Set(selectedKeys.value);
+  const keys = keysFor(event, covered);
+  if (isRowSelected(event)) keys.forEach((k) => next.delete(k));
+  else keys.forEach((k) => next.add(k));
+  emit('update:selection', [...next]);
+}
+
+const pageKeys = computed(() => displayRows.value.flatMap((r) => keysFor(r.event, r.covered)));
+
+const allOnPageSelected = computed(
+  () => displayRows.value.length > 0 && displayRows.value.every((r) => isRowSelected(r.event)),
+);
+
+function togglePage() {
+  const next = new Set(selectedKeys.value);
+  if (allOnPageSelected.value) pageKeys.value.forEach((k) => next.delete(k));
+  else pageKeys.value.forEach((k) => next.add(k));
+  emit('update:selection', [...next]);
+}
 
 function isExpanded(id: number): boolean {
   return expandedGifts.value.has(id);
@@ -362,7 +427,25 @@ function relativeTime(iso: string): string {
 
 <template>
   <div class="flex flex-col gap-2 mt-4">
-    <div v-for="{ event, recipients } in displayRows" :key="`${event.source}-${event.id}`" class="flex flex-col gap-1">
+    <label
+      v-if="selectable && displayRows.length > 0"
+      class="mb-1 flex w-fit cursor-pointer items-center gap-2 text-xs text-foreground"
+    >
+      <input type="checkbox" class="cursor-pointer" :checked="allOnPageSelected" @change="togglePage" />
+      Select everything on this page
+    </label>
+
+    <div v-for="{ event, recipients, covered } in displayRows" :key="`${event.source}-${event.id}`" class="flex flex-col gap-1">
+    <div class="flex items-start gap-2">
+      <input
+        v-if="selectable"
+        type="checkbox"
+        class="mt-2 shrink-0 cursor-pointer"
+        :checked="isRowSelected(event)"
+        :aria-label="`Select ${who(event) ? who(event) + ' ' : ''}${label(event)}`"
+        @change="toggleRow(event, covered)"
+      />
+    <div class="min-w-0 flex-1">
     <Popover
       :open="confirmingId === event.id"
       @update:open="(open: boolean) => (confirmingId = open && canReplay(event) ? event.id : null)"
@@ -435,6 +518,8 @@ function relativeTime(iso: string): string {
         <span class="font-medium">{{ who(recipient) }}</span>
         <span v-if="details(recipient)" class="text-foreground/70">{{ details(recipient) }}</span>
       </div>
+    </div>
+    </div>
     </div>
     </div>
 

--- a/resources/js/pages/dashboard/recents.vue
+++ b/resources/js/pages/dashboard/recents.vue
@@ -7,7 +7,7 @@ import Pagination from '@/components/Pagination.vue';
 import RekaToast from '@/components/RekaToast.vue';
 import EmptyState from '@/components/EmptyState.vue';
 import EventsFeedLinkButton from '@/components/EventsFeedLinkButton.vue';
-import { Check, ListPlus, Radio, RefreshCw, Trash2 } from '@lucide/vue';
+import { Check, ChevronDown, ChevronRight, ListPlus, Radio, RefreshCw, Trash2 } from '@lucide/vue';
 import Heading from '@/components/Heading.vue';
 import debounce from 'lodash/debounce';
 import { EVENT_TYPE_LABELS } from '@/composables/useEventColors';
@@ -254,6 +254,10 @@ function eventTypeLabel(type: string): string {
 
 /* -------- Recent-events feed: point a list at this event stream -------- */
 
+// Collapsed by default: pointing a list at this stream is a nice-to-have, and
+// the page's job is letting you glance at what just happened.
+const feedPanelOpen = ref(false);
+
 const selectedListId = ref<number | null>(null);
 const feedEnabled = ref(false);
 const allTypes = ref(true);
@@ -464,21 +468,43 @@ const breadcrumbs = [
 
         <!-- Send these events to a list -->
         <div class="mb-4 border border-sidebar-border bg-sidebar-accent p-4">
-          <div class="flex items-start gap-3">
-            <ListPlus class="mt-0.5 h-5 w-5 shrink-0" />
-            <div class="min-w-0 flex-1 space-y-1">
-              <h3 class="font-semibold text-foreground">Send these events to a list</h3>
-              <p class="text-sm text-foreground">
-                Mirror your recent events into one of your Lists - a live "recent events" feed you can drop into any overlay
-                (loop it with <code class="rounded-sm bg-background px-1 py-0.5 text-xs">foreach</code> and cap with
-                <code class="rounded-sm bg-background px-1 py-0.5 text-xs">list.x.index</code>) or read from your own app
-                <a href="/help/lists-realtime" class="text-violet-400 hover:underline" target="_blank">over websockets</a>.
-                Turning it on backfills the list with events that already happened.
-              </p>
-            </div>
-          </div>
+          <h3>
+            <button
+              type="button"
+              class="flex w-full cursor-pointer items-center gap-3 text-left"
+              :aria-expanded="feedPanelOpen"
+              aria-controls="feed-panel"
+              @click="feedPanelOpen = !feedPanelOpen"
+            >
+              <ListPlus class="h-5 w-5 shrink-0" />
+              <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+                <span class="font-semibold text-foreground">Send these events to a list</span>
+                <!-- Collapsed, the one thing still worth surfacing is whether a
+                     feed is actually running, and only when one is - otherwise
+                     this is exactly the noise the collapse is here to remove. -->
+                <span
+                  v-if="!feedPanelOpen && activeFeeds.length > 0"
+                  class="flex items-center gap-1.5 text-xs text-foreground"
+                >
+                  <span class="h-2 w-2 shrink-0 rounded-full bg-green-500"></span>
+                  {{ activeFeeds.length }} {{ activeFeeds.length === 1 ? 'list' : 'lists' }} receiving
+                </span>
+              </span>
+              <ChevronDown v-if="feedPanelOpen" class="h-4 w-4 shrink-0" />
+              <ChevronRight v-else class="h-4 w-4 shrink-0" />
+            </button>
+          </h3>
 
-          <!-- Always-visible state: which lists are receiving events right now -->
+          <div v-if="feedPanelOpen" id="feed-panel">
+            <p class="mt-3 text-sm text-foreground">
+              Mirror your recent events into one of your Lists - a live "recent events" feed you can drop into any overlay
+              (loop it with <code class="rounded-sm bg-background px-1 py-0.5 text-xs">foreach</code> and cap with
+              <code class="rounded-sm bg-background px-1 py-0.5 text-xs">list.x.index</code>) or read from your own app
+              <a href="/help/lists-realtime" class="text-violet-400 hover:underline" target="_blank">over websockets</a>.
+              Turning it on backfills the list with events that already happened.
+            </p>
+
+          <!-- Which lists are receiving events right now -->
           <div class="mt-4 border-t border-sidebar-border pt-4">
             <div v-if="activeFeeds.length === 0" class="flex items-center gap-2 text-sm text-foreground">
               <span class="h-2 w-2 shrink-0 rounded-full bg-muted-foreground/50"></span>
@@ -633,6 +659,7 @@ const breadcrumbs = [
               </span>
               <span v-else-if="selectedList && feedDirty" class="text-sm text-amber-500">Unsaved changes</span>
             </div>
+          </div>
           </div>
         </div>
 

--- a/resources/js/pages/dashboard/recents.vue
+++ b/resources/js/pages/dashboard/recents.vue
@@ -7,7 +7,7 @@ import Pagination from '@/components/Pagination.vue';
 import RekaToast from '@/components/RekaToast.vue';
 import EmptyState from '@/components/EmptyState.vue';
 import EventsFeedLinkButton from '@/components/EventsFeedLinkButton.vue';
-import { Check, ListPlus, Radio, RefreshCw } from '@lucide/vue';
+import { Check, ListPlus, Radio, RefreshCw, Trash2 } from '@lucide/vue';
 import Heading from '@/components/Heading.vue';
 import debounce from 'lodash/debounce';
 import { EVENT_TYPE_LABELS } from '@/composables/useEventColors';
@@ -125,6 +125,73 @@ watch(
   },
   { immediate: true }
 );
+
+/* ------------------ Bulk delete: clearing out the feed ------------------ */
+
+// Keys are `${source}:${id}` - ids collide between the two event tables, so the
+// source has to travel with them all the way to the server.
+const selection = ref<string[]>([]);
+// Set by the "select all N matching" hatch. When on, the server re-derives the
+// set from the filters instead of taking the id list, so it can reach rows that
+// were never rendered on this page.
+const selectAllMatching = ref(false);
+const confirmingDelete = ref(false);
+const deleting = ref(false);
+
+const deleteCount = computed(() =>
+  selectAllMatching.value ? props.recentEvents.total : selection.value.length,
+);
+
+// Offer the filter-scoped escape hatch whenever the picks cannot already cover
+// everything the current filters match.
+const showSelectAllHatch = computed(
+  () => !selectAllMatching.value && selection.value.length > 0 && props.recentEvents.total > selection.value.length,
+);
+
+// Anything that changes which rows are on screen invalidates the picks, and a
+// stale key from a previous page would delete a row the user can no longer see.
+watch(
+  () => props.recentEvents.data,
+  () => {
+    selection.value = [];
+    selectAllMatching.value = false;
+    confirmingDelete.value = false;
+  },
+);
+
+function clearSelection() {
+  selection.value = [];
+  selectAllMatching.value = false;
+  confirmingDelete.value = false;
+}
+
+function performDelete() {
+  if (deleting.value || deleteCount.value === 0) return;
+  deleting.value = true;
+
+  // Filters ride on the query string so the server can run them through the
+  // same normalizeFilters() the feed itself uses.
+  const query = new URLSearchParams(buildQuery()).toString();
+  const url = `${route('events.bulk-delete')}${query ? `?${query}` : ''}`;
+
+  const payload = selectAllMatching.value
+    ? { all: true }
+    : {
+        events: selection.value.map((key) => {
+          const split = key.indexOf(':');
+          return { source: key.slice(0, split), id: Number(key.slice(split + 1)) };
+        }),
+      };
+
+  router.post(url, payload, {
+    preserveScroll: true,
+    preserveState: true,
+    onFinish: () => {
+      deleting.value = false;
+      clearSelection();
+    },
+  });
+}
 
 const refreshing = ref(false);
 
@@ -542,7 +609,68 @@ const breadcrumbs = [
         </div>
 
         <div class="transition-opacity duration-300" :class="refreshing ? 'opacity-40' : 'opacity-100'">
-          <EventsTable v-if="recentEvents.data.length > 0" :events="recentEvents.data" />
+          <!-- Selection action bar. Doubles as the confirm step so the whole
+               interaction stays in place instead of opening a dialog. -->
+          <div
+            v-if="deleteCount > 0"
+            class="mb-3 rounded-sm border border-sidebar-border bg-sidebar p-3"
+          >
+            <template v-if="!confirmingDelete">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="text-sm text-foreground">
+                  {{ deleteCount }} event{{ deleteCount === 1 ? '' : 's' }} selected
+                </span>
+                <button class="btn btn-danger btn-xs cursor-pointer" @click="confirmingDelete = true">
+                  <Trash2 class="h-3.5 w-3.5" />
+                  Delete
+                </button>
+                <button class="btn btn-chill btn-xs cursor-pointer" @click="clearSelection">Clear</button>
+              </div>
+              <button
+                v-if="showSelectAllHatch"
+                class="mt-2 cursor-pointer text-sm text-primary underline"
+                @click="selectAllMatching = true"
+              >
+                Select all {{ recentEvents.total }} events matching these filters
+              </button>
+            </template>
+
+            <div v-else class="flex flex-col gap-3">
+              <div>
+                <p class="text-sm font-medium text-foreground">
+                  Delete {{ deleteCount }} event{{ deleteCount === 1 ? '' : 's' }}?
+                </p>
+                <p class="mt-1 text-sm text-foreground">
+                  This permanently removes them from your event feed, and they will no longer count
+                  toward your stream stats. Controls like donation counters are not affected.
+                </p>
+              </div>
+              <div class="flex flex-wrap items-center gap-3">
+                <button
+                  class="btn btn-danger btn-xs cursor-pointer disabled:opacity-50"
+                  :disabled="deleting"
+                  @click="performDelete"
+                >
+                  {{ deleting ? 'Deleting...' : 'Yes, delete' }}
+                </button>
+                <button
+                  class="btn btn-chill btn-xs cursor-pointer disabled:opacity-50"
+                  :disabled="deleting"
+                  @click="confirmingDelete = false"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <EventsTable
+            v-if="recentEvents.data.length > 0"
+            :events="recentEvents.data"
+            selectable
+            :selection="selection"
+            @update:selection="selection = $event"
+          />
 
           <EmptyState
             v-else

--- a/resources/js/pages/dashboard/recents.vue
+++ b/resources/js/pages/dashboard/recents.vue
@@ -83,10 +83,27 @@ function normalizeFilters(input?: FiltersShape) {
 
 const filters = ref(normalizeFilters(props.filters));
 
+// The search term we last asked the server for. A response can only ever echo
+// something we already knew, so writing its `search` back into the box would
+// undo whatever has been typed since the request left - the network is always
+// at least one round trip behind the keyboard, and characters typed while a
+// request is in flight would disappear a beat after appearing. Anything that
+// does NOT match this is news (back/forward, a shared link), so we take it.
+let dispatchedSearch = filters.value.search;
+
 watch(
   () => props.filters,
   (newFilters) => {
-    filters.value = normalizeFilters(newFilters);
+    const incoming = normalizeFilters(newFilters);
+    const isOwnEcho = incoming.search === dispatchedSearch;
+
+    filters.value = {
+      ...incoming,
+      // The dropdowns can't be mid-edit, so they always take the server's word.
+      search: isOwnEcho ? filters.value.search : incoming.search,
+    };
+
+    if (!isOwnEcho) dispatchedSearch = incoming.search;
   },
   { deep: true },
 );
@@ -101,15 +118,26 @@ function buildQuery(): Record<string, string> {
 }
 
 function applyFilter() {
+  dispatchedSearch = filters.value.search;
+
   router.get(route('dashboard.recents'), buildQuery(), {
     preserveState: true,
     preserveScroll: true,
+    // Search-as-you-type would otherwise leave a history entry per keystroke
+    // batch, so going back walks you through `t`, `te`, `tes` before leaving.
+    replace: true,
+    // Templates, facets and lists cannot change from a filter, and the
+    // controller defers them behind closures, so leaving them out keeps their
+    // queries off every keystroke as well as their bytes off the wire.
+    only: ['recentEvents', 'filters'],
   });
 }
 
+// Long enough to sit through the pause for a modifier key. A filter on a table
+// you are reading can afford to wait; it is not the whole UI.
 const debounceSearch = debounce(() => {
   applyFilter();
-}, 300);
+}, 500);
 
 const page = usePage<AppPageProps>();
 const toastMessage = ref<string | null>(null);

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Events\UserRegistered;
 use App\Http\Controllers\AlertMuteController;
 use App\Http\Controllers\CloudinaryUploadController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\EventDeletionController;
 use App\Http\Controllers\EventTemplateMappingController;
 use App\Http\Controllers\ExternalEventController;
 use App\Http\Controllers\FreesoundController;
@@ -625,6 +626,10 @@ Route::middleware('auth.redirect')->group(function () {
 
     // Replay a stored external (Ko-fi, etc.) event as an alert
     Route::post('/external-events/{externalEvent}/replay', [ExternalEventController::class, 'replay'])->name('external-events.replay');
+
+    // Bulk-remove rows from the recent-events feed (test events, bot spam).
+    // Spans both event tables, so it takes {source, id} pairs rather than ids.
+    Route::post('/events/bulk-delete', [EventDeletionController::class, 'destroy'])->name('events.bulk-delete');
 
     // Twitch events API - protected by authentication
     Route::prefix('/api/twitch/events')->middleware('auth:sanctum')->group(function () {

--- a/tests/Feature/EventBulkDeleteTest.php
+++ b/tests/Feature/EventBulkDeleteTest.php
@@ -1,0 +1,265 @@
+<?php
+
+use App\Models\ExternalEvent;
+use App\Models\TwitchEvent;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+uses(DatabaseTransactions::class);
+
+function bdUser(): User
+{
+    return User::factory()->create([
+        'twitch_id' => (string) fake()->unique()->randomNumber(9),
+    ]);
+}
+
+function bdTwitchEvent(?User $user, string $type = 'channel.follow', array $data = []): TwitchEvent
+{
+    return TwitchEvent::create([
+        'user_id' => $user?->id,
+        'event_type' => $type,
+        'event_data' => $data ?: ['user_name' => 'testFromUser'],
+        'twitch_timestamp' => now(),
+        'processed' => false,
+    ]);
+}
+
+function bdExternalEvent(User $user, string $service = 'kofi', string $type = 'donation'): ExternalEvent
+{
+    return ExternalEvent::create([
+        'user_id' => $user->id,
+        'service' => $service,
+        'event_type' => $type,
+        'message_id' => (string) fake()->unique()->uuid(),
+        'raw_payload' => ['from_name' => 'Jo Example'],
+        'normalized_payload' => ['event.from_name' => 'Jo Example'],
+    ]);
+}
+
+function bdPair(string $source, int $id): array
+{
+    return ['source' => $source, 'id' => $id];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Explicit picks
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('deletes picked rows from both event tables in one request', function () {
+    $user = bdUser();
+    $twitch = bdTwitchEvent($user);
+    $external = bdExternalEvent($user);
+    $keep = bdTwitchEvent($user, 'channel.cheer');
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), [
+            'events' => [bdPair('twitch', $twitch->id), bdPair('kofi', $external->id)],
+        ])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($twitch->id))->toBeNull()
+        ->and(ExternalEvent::find($external->id))->toBeNull()
+        ->and(TwitchEvent::find($keep->id))->not->toBeNull();
+});
+
+it('reports how many rows were deleted', function () {
+    $user = bdUser();
+    $a = bdTwitchEvent($user);
+    $b = bdTwitchEvent($user);
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), [
+            'events' => [bdPair('twitch', $a->id), bdPair('twitch', $b->id)],
+        ])
+        ->assertSessionHas('message', 'Deleted 2 events.');
+});
+
+// The two tables have independent auto-increment ids, so a pair whose source is
+// wrong would otherwise reach across into whichever table shares that id.
+it('routes ids by source rather than deleting the same id in both tables', function () {
+    $user = bdUser();
+    $twitch = bdTwitchEvent($user);
+    $external = bdExternalEvent($user);
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), [
+            'events' => [bdPair('twitch', $twitch->id)],
+        ])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($twitch->id))->toBeNull()
+        ->and(ExternalEvent::find($external->id))->not->toBeNull();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Ownership boundary
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('will not delete another user\'s events', function () {
+    $user = bdUser();
+    $other = bdUser();
+    $theirTwitch = bdTwitchEvent($other);
+    $theirExternal = bdExternalEvent($other);
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), [
+            'events' => [bdPair('twitch', $theirTwitch->id), bdPair('kofi', $theirExternal->id)],
+        ])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($theirTwitch->id))->not->toBeNull()
+        ->and(ExternalEvent::find($theirExternal->id))->not->toBeNull();
+});
+
+// twitch_events.user_id is nullable (events for broadcasters we don't know), so
+// a delete scoped only by id would reach rows that belong to nobody.
+it('will not delete ownerless twitch events', function () {
+    $user = bdUser();
+    $orphan = bdTwitchEvent(null);
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), [
+            'events' => [bdPair('twitch', $orphan->id)],
+        ])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($orphan->id))->not->toBeNull();
+});
+
+// GPS rows never appear in this feed, so they can never be picked from it -
+// even if the client sends a spoofed source.
+it('will not delete gps events', function () {
+    $user = bdUser();
+    $gps = bdExternalEvent($user, 'gps', 'location');
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), [
+            'events' => [bdPair('gps', $gps->id)],
+        ])
+        ->assertRedirect();
+
+    expect(ExternalEvent::find($gps->id))->not->toBeNull();
+});
+
+it('requires authentication', function () {
+    $user = bdUser();
+    $event = bdTwitchEvent($user);
+
+    $this->post(route('events.bulk-delete'), [
+        'events' => [bdPair('twitch', $event->id)],
+    ])->assertRedirect();
+
+    expect(TwitchEvent::find($event->id))->not->toBeNull();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Filter-scoped delete
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('deletes everything matching the filters when all is set', function () {
+    $user = bdUser();
+    $a = bdTwitchEvent($user);
+    $b = bdTwitchEvent($user, 'channel.cheer');
+    $c = bdExternalEvent($user);
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), ['all' => true])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($a->id))->toBeNull()
+        ->and(TwitchEvent::find($b->id))->toBeNull()
+        ->and(ExternalEvent::find($c->id))->toBeNull();
+});
+
+it('honours the source filter, leaving the other table untouched', function () {
+    $user = bdUser();
+    $twitch = bdTwitchEvent($user);
+    $kofi = bdExternalEvent($user, 'kofi');
+    $streamlabs = bdExternalEvent($user, 'streamlabs');
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete').'?source=kofi', ['all' => true])
+        ->assertRedirect();
+
+    expect(ExternalEvent::find($kofi->id))->toBeNull()
+        ->and(ExternalEvent::find($streamlabs->id))->not->toBeNull()
+        ->and(TwitchEvent::find($twitch->id))->not->toBeNull();
+});
+
+it('honours the event_type filter', function () {
+    $user = bdUser();
+    $follow = bdTwitchEvent($user, 'channel.follow');
+    $cheer = bdTwitchEvent($user, 'channel.cheer');
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete').'?event_type=channel.follow', ['all' => true])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($follow->id))->toBeNull()
+        ->and(TwitchEvent::find($cheer->id))->not->toBeNull();
+});
+
+it('honours the search filter against the stored payload', function () {
+    $user = bdUser();
+    $bot = bdTwitchEvent($user, 'channel.follow', ['user_name' => 'spam_bot_9000']);
+    $real = bdTwitchEvent($user, 'channel.follow', ['user_name' => 'Alice']);
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete').'?search=spam_bot', ['all' => true])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($bot->id))->toBeNull()
+        ->and(TwitchEvent::find($real->id))->not->toBeNull();
+});
+
+it('honours the range filter and spares older rows', function () {
+    $user = bdUser();
+    $recent = bdTwitchEvent($user);
+    $old = bdTwitchEvent($user);
+    $old->created_at = now()->subDays(10);
+    $old->save();
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete').'?range=24h', ['all' => true])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($recent->id))->toBeNull()
+        ->and(TwitchEvent::find($old->id))->not->toBeNull();
+});
+
+it('never lets a filtered delete escape the acting user', function () {
+    $user = bdUser();
+    $other = bdUser();
+    $mine = bdTwitchEvent($user);
+    $theirs = bdTwitchEvent($other);
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), ['all' => true])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($mine->id))->toBeNull()
+        ->and(TwitchEvent::find($theirs->id))->not->toBeNull();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Input handling
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('rejects an oversized selection', function () {
+    $user = bdUser();
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), [
+            'events' => array_map(fn (int $i) => bdPair('twitch', $i), range(1, 501)),
+        ])
+        ->assertSessionHasErrors('events');
+});
+
+it('reports when nothing was selected', function () {
+    $user = bdUser();
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete'), [])
+        ->assertSessionHas('type', 'warning');
+});

--- a/tests/Feature/EventBulkDeleteTest.php
+++ b/tests/Feature/EventBulkDeleteTest.php
@@ -213,6 +213,25 @@ it('honours the search filter against the stored payload', function () {
         ->and(TwitchEvent::find($real->id))->not->toBeNull();
 });
 
+// deleteMatching() shares applyFilters() with the feed, so the event-type
+// search reaches the delete path too - including its user scoping, which an
+// ungrouped OR would have broken in the most destructive possible way.
+it('honours an event-type search and stays inside the acting user', function () {
+    $user = bdUser();
+    $other = bdUser();
+    $mine = bdTwitchEvent($user, 'channel.poll.end', ['title' => 'Which game next']);
+    $follow = bdTwitchEvent($user, 'channel.follow');
+    $theirs = bdTwitchEvent($other, 'channel.poll.end', ['title' => 'Not yours']);
+
+    $this->actingAs($user)
+        ->post(route('events.bulk-delete').'?search=poll', ['all' => true])
+        ->assertRedirect();
+
+    expect(TwitchEvent::find($mine->id))->toBeNull()
+        ->and(TwitchEvent::find($follow->id))->not->toBeNull()
+        ->and(TwitchEvent::find($theirs->id))->not->toBeNull();
+});
+
 it('honours the range filter and spares older rows', function () {
     $user = bdUser();
     $recent = bdTwitchEvent($user);

--- a/tests/Feature/RecentActivityPartialReloadTest.php
+++ b/tests/Feature/RecentActivityPartialReloadTest.php
@@ -77,6 +77,47 @@ it('omits the filter-independent props from a partial reload', function () {
         ->assertJsonMissingPath('props.userLists');
 });
 
+// A poll payload has no "poll" in it anywhere - the word only exists in the
+// event type. Searching "po" used to match polls purely by accident, through
+// the "po" in the payload's `channel_points_voting` key, so typing the word out
+// in full made results disappear.
+it('finds events by event type, not just by payload', function () {
+    $user = rpUser();
+    $poll = TwitchEvent::create([
+        'user_id' => $user->id,
+        'event_type' => 'channel.poll.end',
+        'event_data' => ['title' => 'Which game next', 'channel_points_voting' => ['is_enabled' => false]],
+        'twitch_timestamp' => now(),
+        'processed' => false,
+    ]);
+    rpEvent($user, 'Alice');
+
+    $this->actingAs($user)
+        ->get(route('dashboard.recents', ['search' => 'poll']))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('recentEvents.data', 1)
+            ->where('recentEvents.data.0.id', $poll->id)
+        );
+});
+
+// The type match is an OR against the payload match. Ungrouped, it would climb
+// out past the user_id scope and show every user's polls to everybody.
+it('keeps the event-type search inside the user scope', function () {
+    $user = rpUser();
+    $other = rpUser();
+    TwitchEvent::create([
+        'user_id' => $other->id,
+        'event_type' => 'channel.poll.end',
+        'event_data' => ['title' => 'Not yours'],
+        'twitch_timestamp' => now(),
+        'processed' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard.recents', ['search' => 'poll']))
+        ->assertInertia(fn (Assert $page) => $page->has('recentEvents.data', 0));
+});
+
 it('still filters the feed on a partial reload', function () {
     $user = rpUser();
     rpEvent($user, 'spam_bot_9000');

--- a/tests/Feature/RecentActivityPartialReloadTest.php
+++ b/tests/Feature/RecentActivityPartialReloadTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\TwitchEvent;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(DatabaseTransactions::class);
+
+/**
+ * Headers for a partial reload. The version has to be the one the middleware
+ * computes from the asset manifest - a mismatch makes Inertia answer 409 with a
+ * full-reload instruction instead of the partial, and the assertions below
+ * would then be testing nothing.
+ */
+function rpPartialHeaders(string $only): array
+{
+    return [
+        'X-Inertia' => 'true',
+        'X-Inertia-Version' => app(HandleInertiaRequests::class)->version(request()),
+        'X-Inertia-Partial-Component' => 'dashboard/recents',
+        'X-Inertia-Partial-Data' => $only,
+    ];
+}
+
+function rpUser(): User
+{
+    return User::factory()->create([
+        'twitch_id' => (string) fake()->unique()->randomNumber(9),
+    ]);
+}
+
+function rpEvent(User $user, string $name = 'Alice'): TwitchEvent
+{
+    return TwitchEvent::create([
+        'user_id' => $user->id,
+        'event_type' => 'channel.follow',
+        'event_data' => ['user_name' => $name],
+        'twitch_timestamp' => now(),
+        'processed' => false,
+    ]);
+}
+
+it('serves every prop on a full page load', function () {
+    $user = rpUser();
+    rpEvent($user);
+
+    $this->actingAs($user)
+        ->get(route('dashboard.recents'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('dashboard/recents')
+            ->has('recentEvents')
+            ->has('filters')
+            ->has('facets')
+            ->has('recentTemplates')
+            ->has('userLists')
+        );
+});
+
+// The search box reloads on every keystroke batch, so the props a filter cannot
+// change are deferred behind closures. If they ever stop being deferred this
+// test fails and the keystroke cost comes back silently.
+it('omits the filter-independent props from a partial reload', function () {
+    $user = rpUser();
+    rpEvent($user);
+
+    // A partial reload answers with JSON rather than the HTML page, so
+    // assertInertia (which reads the `page` view data) cannot see it.
+    $this->actingAs($user)
+        ->get(route('dashboard.recents'), rpPartialHeaders('recentEvents,filters'))
+        ->assertOk()
+        ->assertJsonPath('component', 'dashboard/recents')
+        ->assertJsonStructure(['props' => ['recentEvents', 'filters']])
+        ->assertJsonMissingPath('props.facets')
+        ->assertJsonMissingPath('props.recentTemplates')
+        ->assertJsonMissingPath('props.userLists');
+});
+
+it('still filters the feed on a partial reload', function () {
+    $user = rpUser();
+    rpEvent($user, 'spam_bot_9000');
+    rpEvent($user, 'Alice');
+
+    $this->actingAs($user)
+        ->get(route('dashboard.recents', ['search' => 'spam_bot']), rpPartialHeaders('recentEvents,filters'))
+        ->assertOk()
+        ->assertJsonPath('props.filters.search', 'spam_bot')
+        ->assertJsonCount(1, 'props.recentEvents.data');
+});


### PR DESCRIPTION
Started as "let me delete these test events" and picked up three things in the same area on the way.

## Bulk delete on `/dashboard/recents`

Test events from seven sources pile up in the feed with no way to clear them. Detecting them turned out not to be viable: the donor name is the only shared signal and it differs per service (`testFromUser`, `Jo Example`, `marie_123`, `Kevin`, `supporter username`, `John`, and a fresh random name per payload from StreamElements), so any name rule eventually swallows a real supporter. `ExternalIntegration.test_mode` looked promising but only bypasses the repeat-UUID guard, so the *first* test event lands identically whether or not it is on - which is the one that causes the clutter.

So no detection. Per-row checkboxes, select-all-on-page, and a filter-scoped "select all N matching these filters" that re-derives the set server-side. That last one is the useful bit: filter to StreamLabs, search "Kevin", delete the 47 that match. The filter UI becomes the selector, so you decide what junk means per cleanup.

Things that needed care:
- **Selection keys are `source:id`.** The feed is a `UNION ALL` over two tables whose ids both start at 1, so a flat id list deletes the wrong table's row.
- **Selecting a row takes its hidden rows with it.** Gift-sub bombs fold N recipients under the gifter and a resub hides the bare `channel.subscribe` next to it. Those rows exist but are not rendered; deleting only what you can see would strand them to reappear ungrouped, looking like the delete failed.
- **`user_id` scoping is the authorization boundary** and also guards the nullable `twitch_events.user_id`. GPS rows stay unreachable.
- **Not on the token-authed `/events/feed`**, which shares the component behind a prop it does not pass. Overlay tokens live in an OBS browser source URL.
- **No control rollback and no live-stream lock.** Counters are running totals, not projections. A live lock would not protect session stats anyway, since they are a time-window query computed at read time, so it would only postpone the same mutation while blocking the follow-bot-spam case that needs it most. Both are covered in the confirm copy instead.

## The search box was eating characters

`recents.vue` kept a local filter object and watched the server's copy, replacing it wholesale on every response. The search input is bound to that object, so each response wrote a one-round-trip-stale value back into the field being typed in. Characters entered while a request was in flight appeared, then vanished when it landed - indistinguishable from the input being disabled during load, which is how it got reported.

The watcher now ignores an echo of what it dispatched and only adopts a search value it did not ask for (back/forward, a shared link). Plus debounce 300ms → 500ms, `replace: true` so it stops pushing a history entry per keystroke batch, and the filter visit asks only for `recentEvents` + `filters`, with the other three props deferred behind closures in the controller so a partial reload skips their queries too.

## Searching "poll" found nothing, searching "po" found polls

The search only matched the stored payload. A poll payload contains no "poll" - the word is in the event type and in the label rendered client-side. The "po" hits were incidental: poll payloads carry `channel_points_voting`, and "po" is a substring of "points". Being more specific made results disappear.

Event type is matched alongside the payload now. **The two conditions are grouped in a closure** - ungrouped, the `orWhere` would escape the `user_id` scope and the GPS exclusion, and since `deleteMatching()` shares `applyFilters()` with the feed, the identical slip would have let a filtered delete reach other users' rows. There is a test on each path that fails if the grouping goes.

Still unmatched: multi-word display labels, because the client renders "Poll updated" where the server catalogue says "Poll Progress". Fixing that means picking one source of truth for labels rather than widening the query.

## The list-feed card is collapsed by default

"Send these events to a list" ran a title, a paragraph, a status block, a 3-column grid, a fieldset and a save button above the events you came to look at. It is a disclosure now (`<h3>` wrapping `<button aria-expanded>`). The one thing surviving the collapse is whether a feed is actually running, reduced to a dot and a count and rendered only when one is on - a live feed with no sign of itself is worse than a slightly busier header.

## Testing

19 new tests across `EventBulkDeleteTest` and `RecentActivityPartialReloadTest`, covering the id-collision routing, the ownership boundary, ownerless Twitch rows, GPS exclusion, every filter, and the partial-reload prop deferral. The event-type search test was confirmed to fail against the old query rather than passing for free.

Existing feed suites pass unchanged. `vue-tsc`, eslint, pint and `npm run build` clean. Note there are five pre-existing pint failures in unrelated test files (`ApplyActionTest`, `EventFeedTest` and three others) left alone rather than swept in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
