### PR TITLE
Make the events feed empty state actionable, and fix the second character-eating search box

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -9,7 +9,7 @@ The empty state now says which of your filters is actually responsible, quotes t
 - **Three branches, each one true.** A search is named and clearable; a narrowed time range is called out on its own; anything else falls back to the plain message. No sentence mentions a filter that is not set.
 - **`EmptyState` grew a default slot**, so callers that need markup in the copy can pass it while `message` keeps working. The slot falls back to `message`, and every existing caller passes a plain string or the named `action` slot, so nothing else changed.
 - **Clearing cancels the pending debounce** before it applies, so a keystroke still in flight cannot land after the clear and re-filter the list behind you.
-- **Only the token-authed feed has this so far.** `/dashboard/recents` and `/dashboard/events` still carry the old static sentence.
+- **All three feeds got it**, since the same sentence was copy-pasted across the token-authed feed, `/dashboard/recents` and `/dashboard/events`.
 
 ## August 3rd, 2026 - ui(events): the list-feed card on Recent Activity is collapsed by default
 

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -10,6 +10,7 @@ The empty state now says which of your filters is actually responsible, quotes t
 - **`EmptyState` grew a default slot**, so callers that need markup in the copy can pass it while `message` keeps working. The slot falls back to `message`, and every existing caller passes a plain string or the named `action` slot, so nothing else changed.
 - **Clearing cancels the pending debounce** before it applies, so a keystroke still in flight cannot land after the clear and re-filter the list behind you.
 - **All three feeds got it**, since the same sentence was copy-pasted across the token-authed feed, `/dashboard/recents` and `/dashboard/events`.
+- **`/dashboard/events` also got the echo guard** that Recent Activity received earlier the same day. It had been carrying the identical character-eating search box the whole time - same wholesale replacement of the local filter object on every response, same one-round-trip-stale value written back into the field being typed in. Found while adding the empty state to the same file.
 
 ## August 3rd, 2026 - ui(events): the list-feed card on Recent Activity is collapsed by default
 

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,16 @@
 # CHANGELOG AUGUST 2026
 
+## August 3rd, 2026 - ui(events): the events feed's empty state now offers the way out instead of describing it
+
+"No events match your filters. Try widening the time range or clearing search." Two problems: the advice was static, so it suggested clearing a search you had not typed and widening a range already set to All Time; and it described an action rather than offering one, while the filter panel it refers to is collapsible, so the search box was often not even on screen.
+
+The empty state now says which of your filters is actually responsible, quotes the search term back at you, and makes clearing it a button.
+
+- **Three branches, each one true.** A search is named and clearable; a narrowed time range is called out on its own; anything else falls back to the plain message. No sentence mentions a filter that is not set.
+- **`EmptyState` grew a default slot**, so callers that need markup in the copy can pass it while `message` keeps working. The slot falls back to `message`, and every existing caller passes a plain string or the named `action` slot, so nothing else changed.
+- **Clearing cancels the pending debounce** before it applies, so a keystroke still in flight cannot land after the clear and re-filter the list behind you.
+- **Only the token-authed feed has this so far.** `/dashboard/recents` and `/dashboard/events` still carry the old static sentence.
+
 ## August 3rd, 2026 - ui(events): the list-feed card on Recent Activity is collapsed by default
 
 "Send these events to a list" occupied most of the first screen of Recent Activity: a title, an explanatory paragraph, a status block, a three-column configuration grid, an event-type fieldset and a save button, all above the events you came to look at. Since the hash-authed feed route landed, mirroring events into a list is a cool thing to have rather than something you need on the way in, and it was pushing the actual point of the page below the fold.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -11,6 +11,8 @@ The empty state now says which of your filters is actually responsible, quotes t
 - **Clearing cancels the pending debounce** before it applies, so a keystroke still in flight cannot land after the clear and re-filter the list behind you.
 - **All three feeds got it**, since the same sentence was copy-pasted across the token-authed feed, `/dashboard/recents` and `/dashboard/events`.
 - **`/dashboard/events` also got the echo guard** that Recent Activity received earlier the same day. It had been carrying the identical character-eating search box the whole time - same wholesale replacement of the local filter object on every response, same one-round-trip-stale value written back into the field being typed in. Found while adding the empty state to the same file.
+- **Then all of it got deduplicated**, because writing the same guard twice is how the second page came to be missing it in the first place. `useEventFilters` now owns the filter ref, the echo guard, the debounce and the clear for both Inertia feeds; `EventsEmptyState` owns the empty copy for all three. 200 lines out of the three consumers, ~90 back as shared code, and one place left to get it wrong.
+- **The token-authed feed deliberately does not use the composable.** Its filters are local state that never round-trips through props, so it has no echo to guard against - wiring it through a watcher that watches nothing would be indirection bought with no bug fixed. It shares the empty state and nothing else.
 
 ## August 3rd, 2026 - ui(events): the list-feed card on Recent Activity is collapsed by default
 

--- a/resources/js/components/EmptyState.vue
+++ b/resources/js/components/EmptyState.vue
@@ -2,7 +2,9 @@
 import type { Component } from 'vue';
 
 withDefaults(defineProps<{
-  message: string;
+  // Plain-text message. Pass default slot content instead when the copy needs
+  // markup, such as an inline button that undoes whatever emptied the list.
+  message?: string;
   colspan?: number;
   icon?: Component;
   title?: string;
@@ -16,7 +18,7 @@ withDefaults(defineProps<{
   <!-- Table row variant — used inside <tbody> -->
   <tr v-if="colspan !== undefined">
     <td :colspan="colspan" class="px-3 py-6 text-center text-sm text-muted-foreground">
-      {{ message }}
+      <slot>{{ message }}</slot>
     </td>
   </tr>
 
@@ -30,7 +32,9 @@ withDefaults(defineProps<{
   >
     <component v-if="icon" :is="icon" class="mb-4 h-12 w-12 text-muted-foreground/50" />
     <h3 v-if="title" class="mb-2 text-lg font-semibold">{{ title }}</h3>
-    <p :class="['text-muted-foreground', title ? 'mb-6 max-w-sm text-sm' : 'text-sm']">{{ message }}</p>
+    <p :class="['text-muted-foreground', title ? 'mb-6 max-w-sm text-sm' : 'text-sm']">
+      <slot>{{ message }}</slot>
+    </p>
     <slot name="action" />
   </div>
 </template>

--- a/resources/js/components/EventsEmptyState.vue
+++ b/resources/js/components/EventsEmptyState.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import EmptyState from '@/components/EmptyState.vue';
+
+/**
+ * Empty state for the three event feeds. The advice only ever names a filter
+ * that is actually set, and the way out of a search is offered as a button
+ * rather than described - the filter panel is collapsible on every feed, so
+ * when this shows the search box is frequently not on screen at all.
+ */
+defineProps<{
+  search: string;
+  range: string;
+}>();
+
+defineEmits<{ 'clear-search': [] }>();
+</script>
+
+<template>
+  <EmptyState>
+    <template v-if="search">
+      No events match <span class="font-medium text-foreground">"{{ search }}"</span>.
+      <button
+        type="button"
+        class="cursor-pointer underline underline-offset-2 hover:text-foreground"
+        @click="$emit('clear-search')"
+      >
+        Clear the search</button><template v-if="range !== 'all'"> or widen the time range</template>.
+    </template>
+    <template v-else-if="range !== 'all'">
+      No events in this time range. Try widening it.
+    </template>
+    <template v-else>
+      No events match your filters.
+    </template>
+  </EmptyState>
+</template>

--- a/resources/js/composables/useEventFilters.ts
+++ b/resources/js/composables/useEventFilters.ts
@@ -1,0 +1,92 @@
+import { ref, watch } from 'vue';
+import debounce from 'lodash/debounce';
+
+/** Filter values as they arrive from the server, all optional. */
+export interface EventFiltersShape {
+  search?: string;
+  source?: string;
+  event_type?: string;
+  range?: string;
+}
+
+/** Filter values once defaulted, safe to bind straight to inputs. */
+export interface NormalizedEventFilters {
+  search: string;
+  source: string;
+  event_type: string;
+  range: string;
+}
+
+export function normalizeEventFilters(input?: EventFiltersShape): NormalizedEventFilters {
+  return {
+    search: input?.search || '',
+    source: input?.source || '',
+    event_type: input?.event_type || '',
+    range: input?.range || 'all',
+  };
+}
+
+/**
+ * Local filter state for an Inertia-backed event feed, kept in sync with the
+ * server's copy without letting that copy stomp what is being typed.
+ *
+ * Only for pages whose filters round-trip through props. The token-authed feed
+ * owns its filter state outright, never receives an echo, and so has nothing to
+ * guard against - it deliberately does not use this.
+ *
+ * @param options.serverFilters reactive getter for the server's copy, e.g. `() => props.filters`
+ * @param options.apply performs the actual visit; called after the dispatched term is recorded
+ * @param options.debounceMs quiet period before search-as-you-type fires
+ */
+export function useEventFilters(options: {
+  serverFilters: () => EventFiltersShape | undefined;
+  apply: () => void;
+  debounceMs?: number;
+}) {
+  const filters = ref(normalizeEventFilters(options.serverFilters()));
+
+  // The search term we last asked the server for. A response can only ever echo
+  // something we already knew, so writing its `search` back into the box would
+  // undo whatever has been typed since the request left - the network is always
+  // at least one round trip behind the keyboard, and characters typed while a
+  // request is in flight would disappear a beat after appearing. Anything that
+  // does NOT match this is news (back/forward, a shared link), so we take it.
+  let dispatchedSearch = filters.value.search;
+
+  watch(
+    options.serverFilters,
+    (incomingRaw) => {
+      const incoming = normalizeEventFilters(incomingRaw);
+      const isOwnEcho = incoming.search === dispatchedSearch;
+
+      filters.value = {
+        ...incoming,
+        // The dropdowns can't be mid-edit, so they always take the server's word.
+        search: isOwnEcho ? filters.value.search : incoming.search,
+      };
+
+      if (!isOwnEcho) dispatchedSearch = incoming.search;
+    },
+    { deep: true },
+  );
+
+  function applyFilter() {
+    dispatchedSearch = filters.value.search;
+    options.apply();
+  }
+
+  const debounceSearch = debounce(applyFilter, options.debounceMs ?? 300);
+
+  /**
+   * Offered from the empty state, where the filter panel may be collapsed and
+   * the search box out of sight. Cancels any pending debounce so the cleared
+   * value cannot be followed by a stale one.
+   */
+  function clearSearch() {
+    debounceSearch.cancel();
+    filters.value.search = '';
+    applyFilter();
+  }
+
+  return { filters, applyFilter, debounceSearch, clearSearch };
+}

--- a/resources/js/events-feed/EventsFeed.vue
+++ b/resources/js/events-feed/EventsFeed.vue
@@ -169,6 +169,15 @@ const debounceSearch = debounce(() => {
   applyFilter();
 }, 300);
 
+// Offered from the empty state, where the filter panel may well be collapsed
+// and the search box out of sight. Cancels any pending debounce so the cleared
+// value cannot be followed by a stale one.
+function clearSearch() {
+  debounceSearch.cancel();
+  filters.value.search = '';
+  applyFilter();
+}
+
 function goToPage(target: number) {
   if (target < 1 || target > meta.value.last_page || target === page.value) return;
   page.value = target;
@@ -367,7 +376,26 @@ function eventTypeLabel(type: string): string {
     <div v-else-if="initialized" class="bg-card px-2 py-1 transition-opacity duration-300" :class="refreshing ? 'opacity-40' : 'opacity-100'">
       <EventsTable v-if="events.length > 0" :events="events" :token="token" @replay-result="onReplayResult" />
 
-      <EmptyState v-else message="No events match your filters. Try widening the time range or clearing search." />
+      <!-- The advice is only useful if it names a filter that is actually set,
+           and the search box may be hidden behind the collapsed filter panel,
+           so the way out is offered here rather than described. -->
+      <EmptyState v-else>
+        <template v-if="filters.search">
+          No events match <span class="font-medium text-foreground">"{{ filters.search }}"</span>.
+          <button
+            type="button"
+            class="cursor-pointer underline underline-offset-2 hover:text-foreground"
+            @click="clearSearch"
+          >
+            Clear the search</button><template v-if="filters.range !== 'all'"> or widen the time range</template>.
+        </template>
+        <template v-else-if="filters.range !== 'all'">
+          No events in this time range. Try widening it.
+        </template>
+        <template v-else>
+          No events match your filters.
+        </template>
+      </EmptyState>
 
       <div v-if="meta.last_page > 1" class="mt-4 flex items-center justify-between gap-2 pb-2 text-sm">
         <button

--- a/resources/js/events-feed/EventsFeed.vue
+++ b/resources/js/events-feed/EventsFeed.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import EventsTable from '@/components/EventsTable.vue';
-import EmptyState from '@/components/EmptyState.vue';
+import EventsEmptyState from '@/components/EventsEmptyState.vue';
 import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, RefreshCw, SlidersHorizontal, Volume2, VolumeX } from '@lucide/vue';
 import debounce from 'lodash/debounce';
 import { EVENT_TYPE_LABELS } from '@/composables/useEventColors';
@@ -376,26 +376,12 @@ function eventTypeLabel(type: string): string {
     <div v-else-if="initialized" class="bg-card px-2 py-1 transition-opacity duration-300" :class="refreshing ? 'opacity-40' : 'opacity-100'">
       <EventsTable v-if="events.length > 0" :events="events" :token="token" @replay-result="onReplayResult" />
 
-      <!-- The advice is only useful if it names a filter that is actually set,
-           and the search box may be hidden behind the collapsed filter panel,
-           so the way out is offered here rather than described. -->
-      <EmptyState v-else>
-        <template v-if="filters.search">
-          No events match <span class="font-medium text-foreground">"{{ filters.search }}"</span>.
-          <button
-            type="button"
-            class="cursor-pointer underline underline-offset-2 hover:text-foreground"
-            @click="clearSearch"
-          >
-            Clear the search</button><template v-if="filters.range !== 'all'"> or widen the time range</template>.
-        </template>
-        <template v-else-if="filters.range !== 'all'">
-          No events in this time range. Try widening it.
-        </template>
-        <template v-else>
-          No events match your filters.
-        </template>
-      </EmptyState>
+      <EventsEmptyState
+        v-else
+        :search="filters.search"
+        :range="filters.range"
+        @clear-search="clearSearch"
+      />
 
       <div v-if="meta.last_page > 1" class="mt-4 flex items-center justify-between gap-2 pb-2 text-sm">
         <button

--- a/resources/js/pages/dashboard/events.vue
+++ b/resources/js/pages/dashboard/events.vue
@@ -4,10 +4,10 @@ import { Head, usePage, router } from '@inertiajs/vue3';
 import EventsTable from '@/components/EventsTable.vue';
 import Pagination from '@/components/Pagination.vue';
 import RekaToast from '@/components/RekaToast.vue';
-import EmptyState from '@/components/EmptyState.vue';
+import EventsEmptyState from '@/components/EventsEmptyState.vue';
 import { ChevronDown, ChevronUp, RefreshCw, SlidersHorizontal, Volume2, VolumeX } from '@lucide/vue';
-import debounce from 'lodash/debounce';
 import { EVENT_TYPE_LABELS } from '@/composables/useEventColors';
+import { useEventFilters, type EventFiltersShape } from '@/composables/useEventFilters';
 import { loadHiddenTypes, saveHiddenTypes } from '@/utils/hiddenEventTypes';
 import type { AppPageProps } from '@/types';
 
@@ -38,12 +38,9 @@ interface PaginatedEvents {
   current_page: number;
 }
 
-interface FiltersShape {
-  search?: string;
-  source?: string;
-  event_type?: string;
+/** Adds the per-device event-type filter this page mirrors into the query. */
+interface FiltersShape extends EventFiltersShape {
   hidden_types?: string[];
-  range?: string;
 }
 
 interface FilterFacets {
@@ -58,46 +55,10 @@ const props = defineProps<{
   alertsMuted: boolean;
 }>();
 
-function normalizeFilters(input?: FiltersShape) {
-  return {
-    search: input?.search || '',
-    source: input?.source || '',
-    event_type: input?.event_type || '',
-    range: input?.range || 'all',
-  };
-}
-
-const filters = ref(normalizeFilters(props.filters));
-
 // Subtractive event-type filter, persisted per device. Source of truth is
 // localStorage; we mirror it into the query string so the server filters and
 // pagination links carry it.
 const hiddenTypes = ref<string[]>(loadHiddenTypes());
-
-// The search term we last asked the server for. A response can only ever echo
-// something we already knew, so writing its `search` back into the box would
-// undo whatever has been typed since the request left - the network is always
-// at least one round trip behind the keyboard, and characters typed while a
-// request is in flight would disappear a beat after appearing. Anything that
-// does NOT match this is news (back/forward, a shared link), so we take it.
-let dispatchedSearch = filters.value.search;
-
-watch(
-  () => props.filters,
-  (newFilters) => {
-    const incoming = normalizeFilters(newFilters);
-    const isOwnEcho = incoming.search === dispatchedSearch;
-
-    filters.value = {
-      ...incoming,
-      // The dropdowns can't be mid-edit, so they always take the server's word.
-      search: isOwnEcho ? filters.value.search : incoming.search,
-    };
-
-    if (!isOwnEcho) dispatchedSearch = incoming.search;
-  },
-  { deep: true },
-);
 
 function buildQuery(): Record<string, string> {
   const params: Record<string, string> = {};
@@ -108,14 +69,14 @@ function buildQuery(): Record<string, string> {
   return params;
 }
 
-function applyFilter() {
-  dispatchedSearch = filters.value.search;
-
-  router.get(route('dashboard.events'), buildQuery(), {
-    preserveState: true,
-    preserveScroll: true,
-  });
-}
+const { filters, applyFilter, debounceSearch, clearSearch } = useEventFilters({
+  serverFilters: () => props.filters,
+  apply: () =>
+    router.get(route('dashboard.events'), buildQuery(), {
+      preserveState: true,
+      preserveScroll: true,
+    }),
+});
 
 function isTypeVisible(type: string): boolean {
   return !hiddenTypes.value.includes(type);
@@ -151,19 +112,6 @@ onMounted(() => {
     applyFilter();
   }
 });
-
-const debounceSearch = debounce(() => {
-  applyFilter();
-}, 300);
-
-// Offered from the empty state, where the filter panel may be collapsed and the
-// search box out of sight. Cancels any pending debounce so the cleared value
-// cannot be followed by a stale one.
-function clearSearch() {
-  debounceSearch.cancel();
-  filters.value.search = '';
-  applyFilter();
-}
 
 const page = usePage<AppPageProps>();
 const toastMessage = ref<string | null>(null);
@@ -338,26 +286,12 @@ function eventTypeLabel(type: string): string {
     <div class="bg-card px-2 py-1 transition-opacity duration-300" :class="refreshing ? 'opacity-40' : 'opacity-100'">
       <EventsTable v-if="events.data.length > 0" :events="events.data" />
 
-      <!-- The advice only names a filter that is actually set, and the search
-           box may be hidden behind the collapsed filter panel, so the way out
-           is offered here rather than described. -->
-      <EmptyState v-else>
-        <template v-if="filters.search">
-          No events match <span class="font-medium text-foreground">"{{ filters.search }}"</span>.
-          <button
-            type="button"
-            class="cursor-pointer underline underline-offset-2 hover:text-foreground"
-            @click="clearSearch"
-          >
-            Clear the search</button><template v-if="filters.range !== 'all'"> or widen the time range</template>.
-        </template>
-        <template v-else-if="filters.range !== 'all'">
-          No events in this time range. Try widening it.
-        </template>
-        <template v-else>
-          No events match your filters.
-        </template>
-      </EmptyState>
+      <EventsEmptyState
+        v-else
+        :search="filters.search"
+        :range="filters.range"
+        @clear-search="clearSearch"
+      />
 
       <div v-if="events.last_page > 1" class="mt-4">
         <Pagination :links="events.links" :from="events.from" :to="events.to" :total="events.total" />

--- a/resources/js/pages/dashboard/events.vue
+++ b/resources/js/pages/dashboard/events.vue
@@ -137,6 +137,15 @@ const debounceSearch = debounce(() => {
   applyFilter();
 }, 300);
 
+// Offered from the empty state, where the filter panel may be collapsed and the
+// search box out of sight. Cancels any pending debounce so the cleared value
+// cannot be followed by a stale one.
+function clearSearch() {
+  debounceSearch.cancel();
+  filters.value.search = '';
+  applyFilter();
+}
+
 const page = usePage<AppPageProps>();
 const toastMessage = ref<string | null>(null);
 const toastType = ref<'info' | 'success' | 'warning' | 'error'>('info');
@@ -310,7 +319,26 @@ function eventTypeLabel(type: string): string {
     <div class="bg-card px-2 py-1 transition-opacity duration-300" :class="refreshing ? 'opacity-40' : 'opacity-100'">
       <EventsTable v-if="events.data.length > 0" :events="events.data" />
 
-      <EmptyState v-else message="No events match your filters. Try widening the time range or clearing search." />
+      <!-- The advice only names a filter that is actually set, and the search
+           box may be hidden behind the collapsed filter panel, so the way out
+           is offered here rather than described. -->
+      <EmptyState v-else>
+        <template v-if="filters.search">
+          No events match <span class="font-medium text-foreground">"{{ filters.search }}"</span>.
+          <button
+            type="button"
+            class="cursor-pointer underline underline-offset-2 hover:text-foreground"
+            @click="clearSearch"
+          >
+            Clear the search</button><template v-if="filters.range !== 'all'"> or widen the time range</template>.
+        </template>
+        <template v-else-if="filters.range !== 'all'">
+          No events in this time range. Try widening it.
+        </template>
+        <template v-else>
+          No events match your filters.
+        </template>
+      </EmptyState>
 
       <div v-if="events.last_page > 1" class="mt-4">
         <Pagination :links="events.links" :from="events.from" :to="events.to" :total="events.total" />

--- a/resources/js/pages/dashboard/events.vue
+++ b/resources/js/pages/dashboard/events.vue
@@ -74,10 +74,27 @@ const filters = ref(normalizeFilters(props.filters));
 // pagination links carry it.
 const hiddenTypes = ref<string[]>(loadHiddenTypes());
 
+// The search term we last asked the server for. A response can only ever echo
+// something we already knew, so writing its `search` back into the box would
+// undo whatever has been typed since the request left - the network is always
+// at least one round trip behind the keyboard, and characters typed while a
+// request is in flight would disappear a beat after appearing. Anything that
+// does NOT match this is news (back/forward, a shared link), so we take it.
+let dispatchedSearch = filters.value.search;
+
 watch(
   () => props.filters,
   (newFilters) => {
-    filters.value = normalizeFilters(newFilters);
+    const incoming = normalizeFilters(newFilters);
+    const isOwnEcho = incoming.search === dispatchedSearch;
+
+    filters.value = {
+      ...incoming,
+      // The dropdowns can't be mid-edit, so they always take the server's word.
+      search: isOwnEcho ? filters.value.search : incoming.search,
+    };
+
+    if (!isOwnEcho) dispatchedSearch = incoming.search;
   },
   { deep: true },
 );
@@ -92,6 +109,8 @@ function buildQuery(): Record<string, string> {
 }
 
 function applyFilter() {
+  dispatchedSearch = filters.value.search;
+
   router.get(route('dashboard.events'), buildQuery(), {
     preserveState: true,
     preserveScroll: true,

--- a/resources/js/pages/dashboard/recents.vue
+++ b/resources/js/pages/dashboard/recents.vue
@@ -139,6 +139,15 @@ const debounceSearch = debounce(() => {
   applyFilter();
 }, 500);
 
+// Offered from the empty state. Cancels any pending debounce so the cleared
+// value cannot be followed by a stale one, and goes through applyFilter() so
+// the echo guard above records the empty term as dispatched.
+function clearSearch() {
+  debounceSearch.cancel();
+  filters.value.search = '';
+  applyFilter();
+}
+
 const page = usePage<AppPageProps>();
 const toastMessage = ref<string | null>(null);
 const toastType = ref<'info' | 'success' | 'warning' | 'error'>('info');
@@ -727,10 +736,25 @@ const breadcrumbs = [
             @update:selection="selection = $event"
           />
 
-          <EmptyState
-            v-else
-            message="No events match your filters. Try widening the time range or clearing search."
-          />
+          <!-- The advice only names a filter that is actually set, and the
+               way out is offered here rather than described. -->
+          <EmptyState v-else>
+            <template v-if="filters.search">
+              No events match <span class="font-medium text-foreground">"{{ filters.search }}"</span>.
+              <button
+                type="button"
+                class="cursor-pointer underline underline-offset-2 hover:text-foreground"
+                @click="clearSearch"
+              >
+                Clear the search</button><template v-if="filters.range !== 'all'"> or widen the time range</template>.
+            </template>
+            <template v-else-if="filters.range !== 'all'">
+              No events in this time range. Try widening it.
+            </template>
+            <template v-else>
+              No events match your filters.
+            </template>
+          </EmptyState>
 
           <!-- Pagination -->
           <div v-if="recentEvents.last_page > 1" class="mt-6">

--- a/resources/js/pages/dashboard/recents.vue
+++ b/resources/js/pages/dashboard/recents.vue
@@ -5,12 +5,12 @@ import { Head, usePage, router } from '@inertiajs/vue3';
 import EventsTable from '@/components/EventsTable.vue';
 import Pagination from '@/components/Pagination.vue';
 import RekaToast from '@/components/RekaToast.vue';
-import EmptyState from '@/components/EmptyState.vue';
+import EventsEmptyState from '@/components/EventsEmptyState.vue';
 import EventsFeedLinkButton from '@/components/EventsFeedLinkButton.vue';
 import { Check, ChevronDown, ChevronRight, ListPlus, Radio, RefreshCw, Trash2 } from '@lucide/vue';
 import Heading from '@/components/Heading.vue';
-import debounce from 'lodash/debounce';
 import { EVENT_TYPE_LABELS } from '@/composables/useEventColors';
+import { useEventFilters, type EventFiltersShape } from '@/composables/useEventFilters';
 import type { AppPageProps, OverlayTemplate } from '@/types';
 
 interface FeedList {
@@ -52,13 +52,6 @@ interface PaginatedEvents {
   current_page: number;
 }
 
-interface FiltersShape {
-  search?: string;
-  source?: string;
-  event_type?: string;
-  range?: string;
-}
-
 interface FilterFacets {
   sources: string[];
   event_types: string[];
@@ -67,46 +60,10 @@ interface FilterFacets {
 const props = defineProps<{
   recentTemplates: OverlayTemplate[];
   recentEvents: PaginatedEvents;
-  filters?: FiltersShape;
+  filters?: EventFiltersShape;
   facets: FilterFacets;
   userLists: FeedList[];
 }>();
-
-function normalizeFilters(input?: FiltersShape) {
-  return {
-    search: input?.search || '',
-    source: input?.source || '',
-    event_type: input?.event_type || '',
-    range: input?.range || 'all',
-  };
-}
-
-const filters = ref(normalizeFilters(props.filters));
-
-// The search term we last asked the server for. A response can only ever echo
-// something we already knew, so writing its `search` back into the box would
-// undo whatever has been typed since the request left - the network is always
-// at least one round trip behind the keyboard, and characters typed while a
-// request is in flight would disappear a beat after appearing. Anything that
-// does NOT match this is news (back/forward, a shared link), so we take it.
-let dispatchedSearch = filters.value.search;
-
-watch(
-  () => props.filters,
-  (newFilters) => {
-    const incoming = normalizeFilters(newFilters);
-    const isOwnEcho = incoming.search === dispatchedSearch;
-
-    filters.value = {
-      ...incoming,
-      // The dropdowns can't be mid-edit, so they always take the server's word.
-      search: isOwnEcho ? filters.value.search : incoming.search,
-    };
-
-    if (!isOwnEcho) dispatchedSearch = incoming.search;
-  },
-  { deep: true },
-);
 
 function buildQuery(): Record<string, string> {
   const params: Record<string, string> = {};
@@ -117,36 +74,24 @@ function buildQuery(): Record<string, string> {
   return params;
 }
 
-function applyFilter() {
-  dispatchedSearch = filters.value.search;
-
-  router.get(route('dashboard.recents'), buildQuery(), {
-    preserveState: true,
-    preserveScroll: true,
-    // Search-as-you-type would otherwise leave a history entry per keystroke
-    // batch, so going back walks you through `t`, `te`, `tes` before leaving.
-    replace: true,
-    // Templates, facets and lists cannot change from a filter, and the
-    // controller defers them behind closures, so leaving them out keeps their
-    // queries off every keystroke as well as their bytes off the wire.
-    only: ['recentEvents', 'filters'],
-  });
-}
-
-// Long enough to sit through the pause for a modifier key. A filter on a table
-// you are reading can afford to wait; it is not the whole UI.
-const debounceSearch = debounce(() => {
-  applyFilter();
-}, 500);
-
-// Offered from the empty state. Cancels any pending debounce so the cleared
-// value cannot be followed by a stale one, and goes through applyFilter() so
-// the echo guard above records the empty term as dispatched.
-function clearSearch() {
-  debounceSearch.cancel();
-  filters.value.search = '';
-  applyFilter();
-}
+const { filters, applyFilter, debounceSearch, clearSearch } = useEventFilters({
+  serverFilters: () => props.filters,
+  // Long enough to sit through the pause for a modifier key. A filter on a
+  // table you are reading can afford to wait; it is not the whole UI.
+  debounceMs: 500,
+  apply: () =>
+    router.get(route('dashboard.recents'), buildQuery(), {
+      preserveState: true,
+      preserveScroll: true,
+      // Search-as-you-type would otherwise leave a history entry per keystroke
+      // batch, so going back walks you through `t`, `te`, `tes` before leaving.
+      replace: true,
+      // Templates, facets and lists cannot change from a filter, and the
+      // controller defers them behind closures, so leaving them out keeps their
+      // queries off every keystroke as well as their bytes off the wire.
+      only: ['recentEvents', 'filters'],
+    }),
+});
 
 const page = usePage<AppPageProps>();
 const toastMessage = ref<string | null>(null);
@@ -736,25 +681,12 @@ const breadcrumbs = [
             @update:selection="selection = $event"
           />
 
-          <!-- The advice only names a filter that is actually set, and the
-               way out is offered here rather than described. -->
-          <EmptyState v-else>
-            <template v-if="filters.search">
-              No events match <span class="font-medium text-foreground">"{{ filters.search }}"</span>.
-              <button
-                type="button"
-                class="cursor-pointer underline underline-offset-2 hover:text-foreground"
-                @click="clearSearch"
-              >
-                Clear the search</button><template v-if="filters.range !== 'all'"> or widen the time range</template>.
-            </template>
-            <template v-else-if="filters.range !== 'all'">
-              No events in this time range. Try widening it.
-            </template>
-            <template v-else>
-              No events match your filters.
-            </template>
-          </EmptyState>
+          <EventsEmptyState
+            v-else
+            :search="filters.search"
+            :range="filters.range"
+            @clear-search="clearSearch"
+          />
 
           <!-- Pagination -->
           <div v-if="recentEvents.last_page > 1" class="mt-6">


### PR DESCRIPTION
Follow-up to #181, which was merged while this was in progress. Three commits, all three event feeds.

## The empty state described a way out instead of offering one

> No events match your filters. Try widening the time range or clearing search.

Static advice, so it suggested clearing a search you had not typed and widening a range already set to All Time. And it *described* an action rather than offering one, while the filter panel it refers to is collapsible - so when this message appears, the search box is frequently not on screen at all. You were being told to go clear something you could not see.

The empty state now names only the filter actually responsible, quotes the search term back, and makes clearing it a button.

- **Three branches, each one true.** A search is named and clearable; a narrowed time range is called out on its own; anything else falls back to the plain message. No sentence mentions a filter that is not set.
- **`EmptyState` grew a default slot** so callers needing markup in the copy can pass it. It falls back to the `message` prop, and every existing caller passes either a plain string or the named `action` slot, so nothing else changed.
- **Clearing cancels the pending debounce** before applying, so a keystroke still in flight cannot land after the clear and re-filter the list behind you. On `/dashboard/recents` it also routes through `applyFilter()` so the echo guard from #181 records the empty term as dispatched.
- **All three feeds**, since the sentence was copy-pasted across the token-authed feed, `/dashboard/recents` and `/dashboard/events`.

## `/dashboard/events` had the same character-eating search box

Found while adding the empty state to that file. It carried the identical bug #181 fixed on `/dashboard/recents`: the watcher replaced the whole local `filters` object on every response, writing a value that is one round trip stale back into the field being typed in. Characters entered while a request was in flight appeared, then vanished when it landed - indistinguishable from the input being disabled during load.

The watcher now ignores an echo of the term `applyFilter()` dispatched and only adopts a search value it did not ask for. Dropdowns keep syncing unconditionally, since you cannot be mid-edit in a `<select>`.

**Not ported from #181:** the 500ms debounce, `replace: true`, and the partial-reload prop list. Those are polish rather than the defect, and the last one needs matching closures in `DashboardController::events`. Easy to add if wanted, kept out to keep this reviewable.

`vue-tsc`, eslint and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
