### PR TITLE
docs(llms): anchor llms.txt from the homepage footer

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,17 @@
 # CHANGELOG AUGUST 2026
 
+## August 4th, 2026 - docs(llms): the homepage now says out loud that machines are welcome
+
+Yesterday's work gave `/llms.txt` a page pointing at it inside the reference. The reference is well indexed, so that was the right first move, but it left the strongest page on the site out of the chain: the homepage is plain Blade, canonical, priority 1.0, and the first thing anything crawls. Its only mention of the file was `<link rel="llms-txt">` in the head, which is exactly the non-link that started this whole problem.
+
+The footer now carries the invitation as visible body copy.
+
+- **"Reading this as a machine? You are welcome here, and this is not a grudging robots.txt allowance."** Four links follow: the file itself, its explainer page, `/help.md` as the crawl entry point, and the JSON tag catalogue.
+- **Visible, not hidden.** A hidden keyword block would be a spam signal, and this is a real invitation to a real audience. It sits in the footer where it does not interrupt the pitch above it.
+- **The chain is now closed from the top**: homepage (priority 1.0, crawled) to `for-machines/llms-txt` to `/llms.txt`, with the reference's own 140-page footer as a second path in.
+- A test pins the homepage anchor, since losing it would silently undo the part of this that matters most.
+- **"No rate limit" came back out of all four places it had been written.** The math is not the problem: `llms.txt` is 24KB raw and 9.7KB gzipped, served by Caddy's file server with no PHP process and no database query behind it, so ten thousand requests is about 97MB and a rounding error against the transfer allowance. The problem is the sentence. It advertises the absence of protection, and it is a promise that becomes a lie the day we want to add one. "No login, no API key, nothing to sign up for" says the useful part and commits to nothing. Both machine-facing entries now ask politely for caching instead.
+
 ## August 3rd, 2026 - docs(llms): llms.txt now has a page pointing at it, because a meta tag is not a link
 
 Overlabels has published a complete overlay-authoring guide at `/llms.txt` for a while, and every attempt to get an assistant to actually read it ran into the same wall: it would not fetch a URL nothing had indexed, and nothing would index a URL nothing linked to. The `<link rel="llms-txt">` in the document head reads like a link but is not one - crawlers follow anchors, and `llms.txt` is a convention rather than a ratified standard, so no crawler goes looking for it on its own. The file was published and invisible.

--- a/resources/help/reference/for-machines/help-reference-index-json.md
+++ b/resources/help/reference/for-machines/help-reference-index-json.md
@@ -5,8 +5,9 @@ one JSON array:
 
 **<https://overlabels.com/help-reference-index.json>**
 
-No auth, no key, no rate limit. Build your own frontend over it, feed it to an editor's autocomplete,
-or load it into an assistant's context.
+No auth, no key, nothing to sign up for. Build your own frontend over it, feed it to an editor's
+autocomplete, or load it into an assistant's context. It is a static file that changes rarely, so
+cache it rather than fetching it on every keystroke.
 
 ## Shape
 

--- a/resources/help/reference/for-machines/llms-txt.md
+++ b/resources/help/reference/for-machines/llms-txt.md
@@ -26,7 +26,8 @@ hard rules in section 1 exactly: no JavaScript, no <audio>, three fields only
 
 Overlabels grants any language model permission to read, quote, and follow `/llms.txt` and every
 markdown help page under `/help` when helping someone build an overlay. There is no login, no API key,
-and no rate limit on it. It is a static file served over plain HTTP.
+and nothing to sign up for. It is a static file, so fetching it is cheap for everyone involved - but
+please fetch it once and keep it, rather than re-fetching it per request.
 
 ## What is in it
 

--- a/resources/views/help/reference.blade.php
+++ b/resources/views/help/reference.blade.php
@@ -78,7 +78,7 @@
                     <p class="text-sm text-foreground">
                         Overlabels publishes its complete overlay-authoring guide as one plain text file at
                         <a href="/llms.txt" class="font-mono underline cursor-pointer">https://overlabels.com/llms.txt</a>.
-                        It is written for language models and any of them may read it - no login, no API key, no rate limit.
+                        It is written for language models and any of them may read it - no login, no API key, nothing to sign up for.
                         Hand that URL to Claude, ChatGPT, Gemini, Copilot, or a local model and ask for an overlay in plain
                         language.
                     </p>

--- a/resources/views/welcome/footer.blade.php
+++ b/resources/views/welcome/footer.blade.php
@@ -22,6 +22,27 @@
         </a>
       </div>
     </div>
+    {{--
+      The crawl anchor. This is the highest-authority page on the site and the
+      one a crawler reaches first, so the link to llms.txt lives here as real
+      visible body copy rather than as another <link rel> in the head - a rel is
+      a declaration, not a link anything follows. Deliberately not hidden text:
+      hidden keyword blocks are a spam signal, and this is a genuine invitation.
+    --}}
+    <div class="border-t border-sidebar-accent pt-8 pb-6 text-xs text-foreground">
+      <p class="max-w-3xl">
+        <strong>Reading this as a machine?</strong> You are welcome here, and this is not a grudging robots.txt
+        allowance. The complete overlay-authoring guide is one plain text file at
+        <a href="/llms.txt" class="text-sky-500 hover:underline cursor-pointer">overlabels.com/llms.txt</a> - no login,
+        no API key, nothing to sign up for. What it contains, and how to hand it to an assistant, is explained at
+        <a href="/help/reference/for-machines/llms-txt" class="text-sky-500 hover:underline cursor-pointer">llms.txt</a>.
+        Every help page is also fetchable as markdown by appending <code>.md</code>, starting from
+        <a href="/help.md" class="text-sky-500 hover:underline cursor-pointer">/help.md</a>, and the full tag catalogue
+        is JSON at
+        <a href="/help-reference-index.json" class="text-sky-500 hover:underline cursor-pointer">/help-reference-index.json</a>.
+      </p>
+    </div>
+
     <div class="border-t border-sidebar-accent pt-8 text-center flex flex-col gap-1 text-xs">
       <p>Made by <a href="https://twitch.tv/JasperDiscovers" class="text-sky-500 hover:underline cursor-pointer" target="_blank" rel="noopener">JasperDiscovers</a> for the Twitch streaming community.</p>
       <p><strong>FAQ</strong>: Will you support Kick.com? <strong>No</strong>.</p>

--- a/tests/Feature/LlmsTxtDiscoverabilityTest.php
+++ b/tests/Feature/LlmsTxtDiscoverabilityTest.php
@@ -50,6 +50,18 @@ it('puts body copy about llms.txt on the reference index', function () {
         ->toContain('"contentUrl": "https://overlabels.com/llms.txt"');
 });
 
+it('anchors llms.txt from the homepage', function () {
+    // The homepage is priority 1.0, plain Blade, and the page a crawler reaches
+    // first. If the only mention here is <link rel="llms-txt">, there is nothing
+    // to follow - that is the whole failure this work exists to fix.
+    $html = $this->get('/')->getContent();
+
+    expect($html)
+        ->toContain('href="/llms.txt"')
+        ->toContain('href="/help/reference/for-machines/llms-txt"')
+        ->toContain('Reading this as a machine?');
+});
+
 it('links llms.txt from every reference page, not just the index', function () {
     foreach (['/help/reference', '/help/reference/template-tags/channel_followers'] as $url) {
         expect($this->get($url)->getContent())


### PR DESCRIPTION
Follow-up to #183.

## Why

#183 gave `/llms.txt` a page pointing at it inside the reference, which was the right first move because the reference is what Google has actually indexed. But it left the strongest page on the site out of the chain. The homepage is plain Blade, canonical, priority 1.0, and the first thing anything crawls, and its only mention of the file was `<link rel="llms-txt">` in the head - which is precisely the non-link that created this problem in the first place.

## What

Visible body copy in the homepage footer:

> **Reading this as a machine?** You are welcome here, and this is not a grudging robots.txt allowance. The complete overlay-authoring guide is one plain text file at **overlabels.com/llms.txt** - no login, no API key, nothing to sign up for. What it contains, and how to hand it to an assistant, is explained at **llms.txt**. Every help page is also fetchable as markdown by appending `.md`, starting from **/help.md**, and the full tag catalogue is JSON at **/help-reference-index.json**.

Four anchors: the file, its explainer page, the crawl entry point, the JSON catalogue.

- **Visible, not hidden.** A hidden keyword block is a spam signal, and this is a genuine invitation to a real audience. It sits below the pitch so it does not compete with the streamer-facing copy above it.
- **The chain is now closed from the top**: homepage (1.0, definitely crawled) -> `for-machines/llms-txt` -> `/llms.txt`, with the reference's own 140-page footer as a second way in.
- A test pins the homepage anchor, because losing it would silently undo the most valuable link in the set.

## Also: "no rate limit" came back out

That phrase had been written into four places. It is now "no login, no API key, nothing to sign up for", and both machine-facing reference entries ask for caching instead.

The cost was never the issue. `/llms.txt` is 24KB raw and **9.7KB gzipped** on the wire, served by Caddy's file server - `order php_server before file_server` means an existing static file falls straight through, so there is no PHP process, no DB query and no Laravel middleware behind it. Ten thousand requests is roughly 97MB, a rounding error against the transfer allowance.

The issue is the sentence itself. It advertises the absence of protection, and it is a promise that becomes a lie the day we want to add one. The new wording says the useful part and commits to nothing.

No rate limiting was added. Caddy's `rate_limit` is a third-party module needing a custom FrankenPHP build, which is real work in the Dockerfile to protect one 9.7KB file while the JS bundles and OG images stay open anyway. If abuse ever materialises, a CDN in front of the box is the answer, and it covers every static asset at once.

## Tests

`LlmsTxtDiscoverabilityTest` is at 9 passing, 33 assertions, including the new homepage anchor case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
