### PR TITLE
fix(templates): move Add to OBS into the main tabs

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,21 @@
 # CHANGELOG AUGUST 2026
 
+## August 4th, 2026 - fix(templates): Add to OBS is a main tab now, not a code editor tab
+
+The Builder replaces the Code tab wholesale for overlays composed from blocks, which is the point of it. What went unnoticed is that Add to OBS lived physically inside the code editor, as the fifth entry in its vertical HEAD/BODY/CSS/TW3 strip. Overriding the Code tab took the browser-source URL with it, so a Builder overlay could be composed, saved and previewed, and then had no way at all of reaching OBS.
+
+Add to OBS is now the last main tab on both the overlay page and the edit page, alongside Details and Controls, where it no longer depends on which editor is rendering underneath it.
+
+- **The panel is one component now**, `components/templates/AddToObsPanel.vue`. The heading, the prose, the "you are adding an alert directly to OBS" warning and the button existed as two near-identical copies, one in show.vue and one in TemplateCodeEditor.vue. Moving it was the moment to stop having two.
+
+- **Digits still map to tabs, and now they map to all of them.** The edit page runs to ten tabs on an alert overlay, so 1-9 select the first nine and 0 takes the tenth. The old loop stopped at 8 while alerts already had nine tabs, which meant Effects had no key; it does now. The overlay page tops out at seven.
+
+- **Blocks still do not get the tab.** A block is a Builder ingredient, not a standalone overlay, so there is no browser source to add. Same gate as before, moved with the panel. On the overlay page it stays owner-only for the same reason as always: the URL carries a user-scoped token.
+
+- **The button is `type="button"` now.** It sits inside the edit page's form, where a bare button is a submit button, so clicking Add to OBS opened the dialog and saved the overlay at the same time. That was true in its old home too and was easy to miss, because the save happened behind a modal that had just told you to look away from your stream.
+
+- **TemplateCodeEditor lost its `template` and `templateType` props.** They existed only to feed the OBS tab, and create.vue never passed them, which is why the tab was already absent when creating an overlay.
+
 ## August 4th, 2026 - feat(moderation): public overlays can be reported
 
 Every public overlay had a share URL, an OpenGraph card and a copy button, and no way at all to tell anyone something was wrong with it. The gallery is user-generated content served from our domain, so the absence of a report path was the gap.

--- a/resources/js/components/AddToObsButton.vue
+++ b/resources/js/components/AddToObsButton.vue
@@ -27,6 +27,7 @@ defineExpose({ generateOBSUrl });
 
 <template>
   <button
+    type="button"
     @click="generateOBSUrl()"
     class="flex gap-2 py-4 btn btn-secondary w-full"
     title="Add this overlay to your OBS"

--- a/resources/js/components/templates/AddToObsPanel.vue
+++ b/resources/js/components/templates/AddToObsPanel.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import AddToObsButton from '@/components/AddToObsButton.vue';
+import { VideoIcon } from '@lucide/vue';
+
+// The "Add to OBS" tab body, shared by templates/show and templates/edit. It
+// used to live inside the code editor's vertical tabs, but Builder-composed
+// overlays replace that editor entirely, so it moved up to the main tabs.
+const props = defineProps<{
+  template: { id: number; name: string; slug: string; type?: string };
+}>();
+</script>
+
+<template>
+  <div class="mx-auto max-w-2xl space-y-4 text-sm text-foreground">
+    <div class="flex items-center gap-3">
+      <VideoIcon class="size-6 text-violet-500 dark:text-violet-400" />
+      <h3 class="text-lg font-semibold">Add this overlay to OBS</h3>
+    </div>
+    <p>
+      Add this overlay to OBS by clicking the button below and copying the exact URL to your OBS as a browser source.
+    </p>
+
+    <div
+      v-if="props.template?.type === 'alert'"
+      class="space-y-2 rounded border-l-4 border-violet-500 bg-violet-500/10 p-3 text-foreground/90"
+    >
+      <p class="font-medium text-violet-700 dark:text-violet-300">Heads up: you're adding an alert directly to OBS</p>
+      <p>
+        That works fine, but alerts are usually far more powerful rendered inside a static overlay, where they inherit its structure and styling.
+        <a
+          :href="route('help.overlays-vs-alerts')"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="cursor-pointer font-medium text-violet-600 underline hover:text-violet-500 dark:text-violet-300"
+        >Read "Overlays vs Alerts"</a>
+        so you know what you're doing.
+      </p>
+    </div>
+
+    <div>
+      <AddToObsButton :template="props.template" />
+    </div>
+  </div>
+</template>

--- a/resources/js/components/templates/TemplateCodeEditor.vue
+++ b/resources/js/components/templates/TemplateCodeEditor.vue
@@ -6,17 +6,11 @@ import { oneDark } from '@codemirror/theme-one-dark';
 import { EditorView } from '@codemirror/view';
 import { Codemirror } from 'vue-codemirror';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
-import { ChevronDown, ChevronUp, FileCode2, Code, Maximize, Minimize, Palette, Wind, Video } from '@lucide/vue';
-import AddToObsButton from '@/components/AddToObsButton.vue';
+import { ChevronDown, ChevronUp, FileCode2, Code, Maximize, Minimize, Palette, Wind } from '@lucide/vue';
 
 const headValue = defineModel<string>('head', { required: true });
 const htmlValue = defineModel<string>('body', { required: true });
 const cssValue = defineModel<string>('css', { required: true });
-
-const props = defineProps<{
-  template?: { id: number; name: string; slug: string };
-  templateType?: string;
-}>();
 
 // Detect dark mode reactively via MutationObserver on <html> class
 const isDark = ref(document.documentElement.classList.contains('dark'));
@@ -40,16 +34,9 @@ const editorTabs = [
   { key: 'body', label: 'BODY', icon: Code, color: 'text-cyan-500 dark:text-cyan-400' },
   { key: 'css', label: 'CSS', icon: Palette, color: 'text-lime-500 dark:text-lime-400' },
   { key: 'tailwind', label: 'TW3', icon: Wind, color: 'text-sky-500 dark:text-sky-400' },
-  { key: 'add-to-obs', label: 'OBS', icon: Video, color: 'text-violet-500 dark:text-violet-400' },
 ] as const;
 
 type CodeTab = (typeof editorTabs)[number]['key'];
-
-// OBS tab generates a browser-source URL, which only exists once the overlay is saved.
-// Blocks are Builder ingredients, not standalone overlays, so they never get the tab.
-const visibleTabs = computed(() =>
-  editorTabs.filter((tab) => tab.key !== 'add-to-obs' || (props.template && props.templateType !== 'block')),
-);
 
 const codeTab = ref<CodeTab>('body');
 const isExpanded = ref(false);
@@ -94,7 +81,7 @@ const cssExtensions = computed(() => [css(), baseTheme, ...(isDark.value ? [oneD
         <!-- Vertical file tabs -->
         <div class="flex flex-col bg-sidebar text-sidebar-foreground">
           <button
-            v-for="tab in visibleTabs"
+            v-for="tab in editorTabs"
             :key="tab.key"
             type="button"
             @click="codeTab = tab.key"
@@ -240,45 +227,6 @@ const cssExtensions = computed(() => [css(), baseTheme, ...(isDark.value ? [oneD
               </p>
             </div>
           </div>
-
-          <!-- Add to OBS panel -->
-          <div
-            v-show="codeTab === 'add-to-obs'"
-            v-if="props.template"
-            class="absolute inset-0 overflow-auto p-6 text-sm text-foreground"
-          >
-            <div class="mx-auto max-w-2xl space-y-4">
-              <div class="flex items-center gap-3">
-                <Video class="size-6 text-violet-500 dark:text-violet-400" />
-                <h3 class="text-lg font-semibold">Add this overlay to OBS</h3>
-              </div>
-              <p>
-                Add this overlay to OBS by clicking the button below and copying the exact URL to your OBS as a browser source.
-              </p>
-
-              <div
-                v-if="props.templateType === 'alert'"
-                class="space-y-2 rounded border-l-4 border-violet-500 bg-violet-500/10 p-3 text-foreground/90"
-              >
-                <p class="font-medium text-violet-700 dark:text-violet-300">Heads up: you're adding an alert directly to OBS</p>
-                <p>
-                  That works fine, but alerts are usually far more powerful rendered inside a static overlay, where they inherit its structure and styling.
-                  <a
-                    :href="route('help.overlays-vs-alerts')"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="cursor-pointer font-medium text-violet-600 underline hover:text-violet-500 dark:text-violet-300"
-                  >Read "Overlays vs Alerts"</a>
-                  so you know what you're doing.
-                </p>
-              </div>
-
-              <div>
-                <AddToObsButton :template="props.template" />
-              </div>
-            </div>
-          </div>
-
 
           <!-- Fullscreen hint bar -->
           <div v-if="isFullscreen" class="absolute bottom-0 left-0 right-0 flex items-center justify-center border-t border-border bg-sidebar/80 py-1.5 text-[11px] text-muted-foreground">

--- a/resources/js/pages/templates/edit.vue
+++ b/resources/js/pages/templates/edit.vue
@@ -8,6 +8,7 @@ import Heading from '@/components/Heading.vue';
 import RekaToast from '@/components/RekaToast.vue';
 import TemplateTagsList from '@/components/TemplateTagsList.vue';
 import TemplateCodeEditor from '@/components/templates/TemplateCodeEditor.vue';
+import AddToObsPanel from '@/components/templates/AddToObsPanel.vue';
 import AlertTargetOverlaySelector from '@/components/AlertTargetOverlaySelector.vue';
 import TemplateScreenshot from '@/components/templates/TemplateScreenshot.vue';
 import ControlsManager from '@/components/ControlsManager.vue';
@@ -36,6 +37,7 @@ import {
   SquarePenIcon,
   Target,
   ImageIcon,
+  Video,
   Volume2,
   Zap,
   Search,
@@ -232,6 +234,11 @@ const mainTabs = computed(() => {
     tabs.push({ key: 'triggers', label: 'Triggers', icon: Zap });
     tabs.push({ key: 'targeting', label: 'Targeting', icon: Target });
     tabs.push({ key: 'tts', label: 'Effects', icon: Volume2 });
+  }
+  // Always last. Blocks are Builder ingredients, not standalone overlays, so
+  // they never get a browser-source URL.
+  if (props.template.type !== 'block') {
+    tabs.push({ key: 'obs', label: 'Add to OBS', icon: Video });
   }
   return tabs;
 });
@@ -503,8 +510,10 @@ onMounted(() => {
     { description: 'Preview in new tab' }
   );
 
-  for (let i = 1; i <= 8; i++) {
-    register(`switch-tab-${i}`, `${i}`, () => {
+  // Digits 1-9 pick the first nine tabs, 0 the tenth: alert overlays run to ten
+  // tabs with Add to OBS on the end.
+  for (let i = 1; i <= 10; i++) {
+    register(`switch-tab-${i}`, i === 10 ? '0' : `${i}`, () => {
       const tab = mainTabs.value[i - 1];
       if (tab) mainTab.value = tab.key;
     }, { description: `Switch to tab ${i}` });
@@ -637,8 +646,6 @@ onMounted(() => {
           />
           <TemplateCodeEditor
             v-else
-            :template-type="props.template.type"
-            :template="props.template"
             v-show="mainTab === 'code'"
             v-model:head="form.head"
             v-model:body="form.html"
@@ -966,6 +973,11 @@ onMounted(() => {
                 </ul>
               </aside>
             </div>
+          </div>
+
+          <!-- Add to OBS Tab -->
+          <div v-if="mainTab === 'obs'" class="p-4 pt-6">
+            <AddToObsPanel :template="props.template" />
           </div>
         </div>
 

--- a/resources/js/pages/templates/show.vue
+++ b/resources/js/pages/templates/show.vue
@@ -4,7 +4,7 @@ import { Head, router, usePage } from '@inertiajs/vue3';
 import AppLayout from '@/layouts/AppLayout.vue';
 import RekaToast from '@/components/RekaToast.vue';
 import AlertTargetOverlaySelector from '@/components/AlertTargetOverlaySelector.vue';
-import AddToObsButton from '@/components/AddToObsButton.vue';
+import AddToObsPanel from '@/components/templates/AddToObsPanel.vue';
 import ControlsManager from '@/components/ControlsManager.vue';
 import TriggerManager, { type TriggerData } from '@/components/TriggerManager.vue';
 import { Dialog, DialogContent, DialogFooter, DialogTitle } from '@/components/ui/dialog';
@@ -67,17 +67,8 @@ const props = defineProps<{
 const editorTabs = [
   { key: 'head', label: 'HEAD', icon: FileCode2Icon, color: 'text-pink-500 dark:text-pink-400' },
   { key: 'html', label: 'BODY', icon: CodeIcon, color: 'text-cyan-500 dark:text-cyan-400' },
-  { key: 'css', label: 'CSS', icon: PaletteIcon, color: 'text-lime-500 dark:text-lime-400' },
-  { key: 'add-to-obs', label: 'OBS', icon: VideoIcon, color: 'text-violet-500 dark:text-violet-400' }
+  { key: 'css', label: 'CSS', icon: PaletteIcon, color: 'text-lime-500 dark:text-lime-400' }
 ];
-
-// OBS browser-source URL is owner-only (the token is user-scoped). Available for
-// both static and alert overlays - alerts are usually rendered inside a static
-// overlay, but adding one straight to OBS is valid too, so we inform rather than gate.
-// Blocks are Builder ingredients, not standalone overlays, so no OBS tab for them.
-const visibleEditorTabs = computed(() =>
-  editorTabs.filter((tab) => tab.key !== 'add-to-obs' || (props.canEdit && props.template?.type !== 'block')),
-);
 
 const mainTabs = computed(() => {
   const tabs: Array<{ key: string; label: string; icon: any }> = [
@@ -91,6 +82,11 @@ const mainTabs = computed(() => {
   if (props.canEdit && props.template?.type === 'alert') {
     tabs.push({ key: 'triggers', label: 'Triggers', icon: Zap });
     tabs.push({ key: 'targeting', label: 'Targeting', icon: TargetIcon });
+  }
+  // Always last. The browser-source URL carries a user-scoped token, so this is
+  // owner-only; blocks are Builder ingredients, not standalone overlays.
+  if (props.canEdit && props.template?.type !== 'block') {
+    tabs.push({ key: 'obs', label: 'Add to OBS', icon: VideoIcon });
   }
   return tabs;
 });
@@ -131,7 +127,7 @@ onMounted(() => {
     if (props.template?.id) router.visit(route('templates.edit', props.template.id));
   }, { description: 'Edit this overlay' });
 
-  for (let i = 1; i <= 6; i++) {
+  for (let i = 1; i <= 7; i++) {
     register(`switch-tab-${i}`, `${i}`, () => {
       const tab = mainTabs.value[i - 1];
       if (tab) mainTab.value = tab.key;
@@ -359,13 +355,18 @@ const breadcrumbs: BreadcrumbItem[] = [
           <button type="button" @click="saveTargeting" class="btn btn-primary mt-4">Save targeting</button>
         </div>
 
+        <!-- Add to OBS tab (owner only) -->
+        <div v-if="canEdit && mainTab === 'obs'" class="mb-6 p-4 pt-6">
+          <AddToObsPanel :template="props.template" />
+        </div>
+
         <!-- Code Tabs (overview only) -->
         <div v-if="!canEdit || mainTab === 'overview'" class="overflow-hidden">
           <div v-show="showCode" class="flex min-h-[30vh] overflow-hidden">
             <!-- File tabs sidebar -->
             <div class="flex flex-col bg-sidebar text-sidebar-foreground">
               <button
-                v-for="tab in visibleEditorTabs"
+                v-for="tab in editorTabs"
                 :key="tab.key"
                 @click="activeTab = tab.key"
                 :class="[
@@ -379,54 +380,17 @@ const breadcrumbs: BreadcrumbItem[] = [
                 <span>{{ tab.label }}</span>
               </button>
             </div>
-            <!-- Code panel -->
+            <!-- Code panel (read-only) -->
             <div class="relative flex-1 min-w-0 text-gray-700 dark:text-accent-foreground">
-              <!-- Add to OBS panel -->
-              <div
-                v-if="activeTab === 'add-to-obs'"
-                class="h-[50vh] overflow-auto p-6 text-sm text-foreground bg-white dark:bg-[#160e21]"
-              >
-                <div class="mx-auto max-w-2xl space-y-4">
-                  <div class="flex items-center gap-3">
-                    <VideoIcon class="size-6 text-violet-500 dark:text-violet-400" />
-                    <h3 class="text-lg font-semibold">Add this overlay to OBS</h3>
-                  </div>
-                  <p>
-                    Add this overlay to OBS by clicking the button below and copying the exact URL to your OBS as a browser source.
-                  </p>
-                  <div
-                    v-if="props.template?.type === 'alert'"
-                    class="space-y-2 rounded border-l-4 border-violet-500 bg-violet-500/10 p-3 text-foreground/90"
-                  >
-                    <p class="font-medium text-violet-700 dark:text-violet-300">Heads up: you're adding an alert directly to OBS</p>
-                    <p>
-                      That works fine, but alerts are usually far more powerful rendered inside a static overlay, where they inherit its structure and styling.
-                      <a
-                        :href="route('help.overlays-vs-alerts')"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="cursor-pointer font-medium text-violet-600 underline hover:text-violet-500 dark:text-violet-300"
-                      >Read "Overlays vs Alerts"</a>
-                      so you know what you're doing.
-                    </p>
-                  </div>
-                  <div>
-                    <AddToObsButton :template="props.template" />
-                  </div>
-                </div>
+              <div class="h-[50vh] w-full overflow-auto p-4 bg-white dark:bg-[#160e21]">
+                <code class="text-sm whitespace-break-spaces overflow-hidden text-muted-foreground">{{ props.template?.[activeTab] || 'No content' }}</code>
               </div>
-              <!-- Read-only code view -->
-              <template v-else>
-                <div class="h-[50vh] w-full overflow-auto p-4 bg-white dark:bg-[#160e21]">
-                  <code class="text-sm whitespace-break-spaces overflow-hidden text-muted-foreground">{{ props.template?.[activeTab] || 'No content' }}</code>
-                </div>
-                <button
-                  @click="copyToClipboard(props.template?.[activeTab], activeTab.toUpperCase())"
-                  class="btn btn-sm btn-chill absolute top-4 right-8 w-30"
-                >
-                  Copy {{ activeTab.toUpperCase() }}
-                </button>
-              </template>
+              <button
+                @click="copyToClipboard(props.template?.[activeTab], activeTab.toUpperCase())"
+                class="btn btn-sm btn-chill absolute top-4 right-8 w-30"
+              >
+                Copy {{ activeTab.toUpperCase() }}
+              </button>
             </div>
           </div>
 


### PR DESCRIPTION
## Why

The Builder replaces the Code tab wholesale for block-composed overlays. Add to OBS lived physically inside the code editor's vertical HEAD/BODY/CSS/TW3 strip, so overriding the Code tab took the browser-source URL with it: a Builder overlay could be composed, saved and previewed, and then had no way at all of reaching OBS.

## What

Add to OBS is now the **last main tab** on both `templates/show` and `templates/edit`, where it no longer depends on which editor is rendering underneath.

- **New `components/templates/AddToObsPanel.vue`** — the heading, prose, alert warning box and `AddToObsButton`, previously two near-identical copies (one in `show.vue`, one in `TemplateCodeEditor.vue`).
- **Tab shortcuts extended to cover it.** Edit runs to ten tabs on an alert overlay, so 1-9 select the first nine and `0` takes the tenth. The old loop stopped at 8 while alerts already had nine tabs, so Effects had no key before either. Show tops out at seven.
- **Blocks still get no OBS tab** (Builder ingredients, not standalone overlays), and on `show` it stays owner-only — the URL carries a user-scoped token.
- **`AddToObsButton` is `type="button"` now.** It sits inside the edit page's `<form>`, where a bare button submits, so clicking Add to OBS opened the dialog *and* saved the overlay. Same bug in its old home, easy to miss because the save happened behind a modal that had just told you to look away from your stream.
- **`TemplateCodeEditor` lost its `template` / `templateType` props** — they only fed the OBS tab, and `create.vue` never passed them.

## Verification

`npx vue-tsc --noEmit` passes clean. Changelog entry in `docs/changelog/changelog-2026-08.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)