### PR TITLE
fix(deps): pin composer PHP platform, update league/commonmark

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.4",
+        "php": "^8.4.1",
         "ext-pdo": "*",
         "cloudinary/cloudinary_php": "^3.1",
         "inertiajs/inertia-laravel": "^3.0",
@@ -94,6 +94,9 @@
         "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true,
+        "platform": {
+            "php": "8.4.1"
+        },
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cebd4475d1b13fc5913186cf19d9b7f2",
+    "content-hash": "f5a93412e634c8a3576933b5905d8816",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2553,16 +2553,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.3",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
                 "shasum": ""
             },
             "require": {
@@ -2599,7 +2599,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -2656,7 +2656,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-12T15:29:16+00:00"
+            "time": "2026-08-03T13:42:31+00:00"
         },
         {
             "name": "league/config",
@@ -12682,9 +12682,12 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4",
+        "php": "^8.4.1",
         "ext-pdo": "*"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.4.1"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,16 @@
 # CHANGELOG AUGUST 2026
 
+## August 7th, 2026 - fix(deps): Dependabot could not update anything, and had been failing silently
+
+Dependabot tried to ship a security update for `league/commonmark` and died with "Your requirements could not be resolved to an installable set of packages". The interesting part is that it had nothing to do with commonmark, and it would have broken every future composer security update the same way.
+
+Dependabot injects its own `config.platform.php`, and set it to `8.4` - which composer reads as **8.4.0**. That number is the floor of our `require: php ^8.4`. Meanwhile `nunomaduro/collision` pulls `symfony/console` v8.1.1, which requires `php >=8.4.1`. So resolution failed on a constraint three packages away from the one being updated, before commonmark was ever considered.
+
+- **The PHP constraint was simply false.** `^8.4` claimed the app runs on 8.4.0. It cannot - symfony/console needs 8.4.1. Local dev is on 8.4.24 and prod is a FrankenPHP 8.4 image, so nothing ever surfaced it. `require.php` is now `^8.4.1`, which is the truth.
+- **`config.platform.php` is now pinned explicitly to 8.4.1.** Dependabot's own error says "overridden via config.platform", so it honours one that already exists - that is the lever that actually fixes the automation. It also makes resolution identical on a laptop, in CI, and in the Docker build, rather than silently depending on whichever PHP the `composer:2` image happens to ship that week.
+- **The six advisories were real but not reachable.** All denial-of-service via crafted markdown, five high and one medium, published the day before. Both CommonMark call sites read from `resource_path('help/reference')` and `resource_path('help/pages')` - repo files, authored by us. No user-supplied markdown reaches the parser and there are no markdown mailables, so exploiting it required commit access. Worth fixing, not worth panicking, and Dependabot being broken did not leave anything exposed.
+- **The update moved exactly one package.** `league/commonmark` 2.8.3 -> 2.9.0, no installs, no removals, nothing else touched. `composer audit` now reports no advisories, and the suite passes 1233.
+
 ## August 7th, 2026 - feat(ops): a backup that never runs is now louder than one that fails
 
 The Discord webhook only ever answered one of the two questions. It fires when the backup runs and fails. It cannot fire when the backup never runs at all, because the thing that would send the message is the thing that is down - and silence from a dead scheduler is indistinguishable from silence after a perfect night. Healthchecks.io alerts on the absence of a ping, which is the only shape of check that works when the failure mode is "nothing happened".


### PR DESCRIPTION
Dependabot's security update for `league/commonmark` failed with `Your requirements could not be resolved to an installable set of packages`. The cause has nothing to do with commonmark, and it would have broken **every** future composer security update the same way.

## The actual error, under 200 lines of Ruby stack trace

```
Problem 1
  - nunomaduro/collision is locked to v8.9.5 and an update was not requested.
  - nunomaduro/collision v8.9.5 requires symfony/console ^7.4.14 || ^8.1.1
  - symfony/console v8.1.1 requires php >=8.4.1 -> your php version
    (8.4; overridden via config.platform, actual: 8.4.24) does not satisfy that
```

Dependabot injects a `config.platform.php` of `8.4`, which composer reads as **8.4.0** - exactly the floor of our `require: php ^8.4`. `symfony/console` needs `>=8.4.1`. So resolution died on a constraint three packages away from the one being updated, before commonmark was ever considered.

## Fixes

- **`require.php` is now `^8.4.1`.** The old constraint was simply false - it claimed the app runs on 8.4.0, which it cannot. Local dev is 8.4.24 and prod is a FrankenPHP 8.4 image, so nothing ever surfaced it.
- **`config.platform.php` pinned to `8.4.1`.** This is the lever that actually fixes the automation: Dependabot's own error says "overridden via config.platform", meaning it honours one that already exists. It also makes resolution identical on a laptop, in CI, and in the Docker build, rather than silently tracking whichever PHP the `composer:2` image ships that week.
- **`league/commonmark` 2.8.3 → 2.9.0.**

## On the advisories: real, but not reachable here

Six advisories (5 high, 1 medium) published the day before, all denial-of-service via crafted markdown - deeply nested XML, colliding heading slugs, duplicate footnotes, adjacent inline attribute blocks.

Both CommonMark call sites read from disk:

- `HelpReferenceService` → `resource_path('help/reference')`
- `HelpPage` → `resource_path('help/pages')`

Repo files, authored by us. No user-supplied markdown reaches the parser and there are no markdown mailables, so exploiting this needed commit access - at which point a DoS is the least of the problems. Worth fixing, not worth panicking, and Dependabot being broken did not leave anything exposed.

## Blast radius

`composer.lock` moved exactly one package - commonmark's version, hash and timestamp, plus the content-hash and the two platform lines. No installs, no removals, nothing else touched.

- `composer audit`: **No security vulnerability advisories found**
- Full suite: **1233 passed**, 3 skipped (the pg_dump end-to-end tests, which run on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
