### PR TITLE
fix(controls): reset only the per-stream twitch controls at go-live

### DIFF
--- a/app/Services/StreamSessionService.php
+++ b/app/Services/StreamSessionService.php
@@ -25,6 +25,28 @@ class StreamSessionService
     ];
 
     /**
+     * Control keys reset to their reset_value at the start of every stream.
+     *
+     * Scoped by key rather than by source on purpose. The `latest_cheer*` presets
+     * also carry source='twitch', but they are most-recent values, not per-stream
+     * tallies, and every equivalent on the five donation services persists across
+     * streams. Resetting them was collateral from this filter predating them, and
+     * it broke the bits/donation parity those presets were added to provide.
+     *
+     * A key belongs here only if its label promises per-stream scope.
+     */
+    public const array PER_STREAM_CONTROL_KEYS = [
+        'follows_this_stream',
+        'subs_this_stream',
+        'gift_subs_this_stream',
+        'resubs_this_stream',
+        'raids_this_stream',
+        'redemptions_this_stream',
+        'cheers_this_stream',
+        'bits_this_stream',
+    ];
+
+    /**
      * Control presets users can add to their overlays.
      */
     public const array CONTROL_PRESETS = [
@@ -161,12 +183,13 @@ class StreamSessionService
     }
 
     /**
-     * Reset all twitch source controls to their reset_value (or 0) and broadcast each.
+     * Reset the per-stream twitch controls to their reset_value (or 0) and broadcast each.
      */
     private function resetControls(User $user): void
     {
         $controls = OverlayControl::where('user_id', $user->id)
             ->where('source', 'twitch')
+            ->whereIn('key', self::PER_STREAM_CONTROL_KEYS)
             ->where('source_managed', true)
             ->with('template')
             ->get();
@@ -189,7 +212,7 @@ class StreamSessionService
 
         }
 
-        Log::info("Reset twitch controls for user {$user->id}", [
+        Log::info("Reset per-stream twitch controls for user {$user->id}", [
             'count' => $controls->count(),
         ]);
     }

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,17 @@
 # CHANGELOG AUGUST 2026
 
+## August 7th, 2026 - fix(controls): your latest cheerer stopped being erased at every go-live
+
+`c:twitch:latest_cheerer_name` was wiped to a literal `"0"` the moment a stream started, and its 25 equivalents across Ko-fi, Streamlabs, Fourthwall, Buy Me a Coffee and Throne were not. Same idea, opposite lifecycle, and the only thing separating them was which code path created the row.
+
+- **Nobody ever decided this.** `resetControls()` arrived in March with six presets, every one of them named `*_this_stream`. Resetting them *is* the feature and it was exactly right. Five weeks later the `channel.cheer` presets landed - explicitly "so bits payloads can drive overlays the same way donations do" - and the three `latest_cheer*` ones inherited the reset purely because they share `source='twitch'`. The filter predated the controls it was erasing.
+- **So the reset broke the one thing that commit set out to build.** Bits parity with donations was the stated goal, and `latest_donor_name` persisting while `latest_cheerer_name` did not is precisely the parity failing. It stayed invisible for four months because you only notice when you race the two against each other.
+- **The reset is now scoped by key, not by source.** The eight `*_this_stream` counters still reset at go-live, because that is the only thing implementing what their labels promise - they increment additively and nothing else ever zeroes them. The three `latest_cheer*` controls no longer do. A key earns its place on the list only if its label promises per-stream scope.
+- **This is the pattern the GPS integration already used.** Its reset takes an explicit key list and deliberately leaves cumulative `distance` alone behind a separate manual button. The twitch path was the one place resetting by source with no filter.
+- **`latest()` racing across services now behaves as documented.** Twitch was the only competitor whose `_at` moved at go-live, so it won every race at stream start holding `"0"`. Nothing about `latest()` changed - it was reporting the freshest write, correctly, the whole time.
+- **You may notice this on your next stream.** An overlay that went blank at go-live and stayed blank until someone cheered will now keep showing the previous cheerer. That is what the label says it does, but it is a visible change rather than a silent one.
+- **Nine tests pin it**, and the three that assert the new behaviour were verified to fail against the old filter. The rest cover the scoping that was already right - other users, other sources, and user-created controls that merely share a key name - so a future change cannot widen the blast radius unnoticed.
+
 ## August 7th, 2026 - fix(deps): Dependabot could not update anything, and had been failing silently
 
 Dependabot tried to ship a security update for `league/commonmark` and died with "Your requirements could not be resolved to an installable set of packages". The interesting part is that it had nothing to do with commonmark, and it would have broken every future composer security update the same way.

--- a/tests/Feature/StreamControlResetTest.php
+++ b/tests/Feature/StreamControlResetTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use App\Events\ControlValueUpdated;
+use App\Models\OverlayControl;
+use App\Models\OverlayTemplate;
+use App\Models\User;
+use App\Services\StreamSessionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Create a source_managed twitch control carrying a non-default value, so a
+ * reset is observable.
+ */
+function twitchControl(User $user, OverlayTemplate $template, string $key, string $value, string $type = 'counter'): OverlayControl
+{
+    return OverlayControl::factory()->create([
+        'user_id' => $user->id,
+        'overlay_template_id' => $template->id,
+        'key' => $key,
+        'type' => $type,
+        'value' => $value,
+        'source' => 'twitch',
+        'source_managed' => true,
+    ]);
+}
+
+beforeEach(function () {
+    Event::fake([ControlValueUpdated::class]);
+
+    $this->user = User::factory()->create();
+    $this->template = OverlayTemplate::factory()->create(['owner_id' => $this->user->id]);
+});
+
+it('resets every per-stream counter when a session opens', function () {
+    $controls = collect(StreamSessionService::PER_STREAM_CONTROL_KEYS)
+        ->mapWithKeys(fn (string $key) => [
+            $key => twitchControl($this->user, $this->template, $key, '42'),
+        ]);
+
+    app(StreamSessionService::class)->openSession($this->user);
+
+    foreach ($controls as $key => $control) {
+        expect($control->fresh()->value)->toBe('0', "$key should reset at go-live");
+    }
+});
+
+it('leaves the latest_cheer* controls alone when a session opens', function () {
+    // These carry source='twitch' but are most-recent values, not per-stream
+    // tallies. Their equivalents on the donation services persist across
+    // streams, and these must match that.
+    $name = twitchControl($this->user, $this->template, 'latest_cheerer_name', 'alice', 'text');
+    $amount = twitchControl($this->user, $this->template, 'latest_cheer_amount', '500', 'number');
+    $message = twitchControl($this->user, $this->template, 'latest_cheer_message', 'have some bits', 'text');
+
+    app(StreamSessionService::class)->openSession($this->user);
+
+    expect($name->fresh()->value)->toBe('alice')
+        ->and($amount->fresh()->value)->toBe('500')
+        ->and($message->fresh()->value)->toBe('have some bits');
+});
+
+it('never writes the string "0" over a latest_cheerer_name', function () {
+    // The specific regression: a reset_value of 0 on a text control put a
+    // literal "0" in the label, which then won any latest() race across
+    // services because its _at was the freshest timestamp on the board.
+    $control = twitchControl($this->user, $this->template, 'latest_cheerer_name', 'alice', 'text');
+
+    app(StreamSessionService::class)->openSession($this->user);
+
+    expect($control->fresh()->value)->not->toBe('0');
+});
+
+it('does not touch the _at companion of a control it leaves alone', function () {
+    // _at is updated_at, so a no-op reset must not bump it. This is what makes
+    // latest() racing twitch against the donation services meaningful.
+    $control = twitchControl($this->user, $this->template, 'latest_cheerer_name', 'alice', 'text');
+    $before = $control->fresh()->updated_at;
+
+    $this->travel(5)->minutes();
+    app(StreamSessionService::class)->openSession($this->user);
+
+    expect($control->fresh()->updated_at->timestamp)->toBe($before->timestamp);
+});
+
+it('leaves controls belonging to other sources alone', function () {
+    $kofi = OverlayControl::factory()->create([
+        'user_id' => $this->user->id,
+        'overlay_template_id' => $this->template->id,
+        'key' => 'latest_donor_name',
+        'type' => 'text',
+        'value' => 'bob',
+        'source' => 'kofi',
+        'source_managed' => true,
+    ]);
+
+    app(StreamSessionService::class)->openSession($this->user);
+
+    expect($kofi->fresh()->value)->toBe('bob');
+});
+
+it('leaves a user-created control alone even when its key matches a per-stream key', function () {
+    // source_managed=false means the user owns this row, whatever it is called.
+    $own = OverlayControl::factory()->create([
+        'user_id' => $this->user->id,
+        'overlay_template_id' => $this->template->id,
+        'key' => 'follows_this_stream',
+        'type' => 'counter',
+        'value' => '99',
+        'source' => null,
+        'source_managed' => false,
+    ]);
+
+    app(StreamSessionService::class)->openSession($this->user);
+
+    expect($own->fresh()->value)->toBe('99');
+});
+
+it('leaves another users controls alone', function () {
+    $other = User::factory()->create();
+    $otherTemplate = OverlayTemplate::factory()->create(['owner_id' => $other->id]);
+    $control = twitchControl($other, $otherTemplate, 'follows_this_stream', '7');
+
+    app(StreamSessionService::class)->openSession($this->user);
+
+    expect($control->fresh()->value)->toBe('7');
+});
+
+it('honours a configured reset_value instead of always zeroing', function () {
+    $control = OverlayControl::factory()->create([
+        'user_id' => $this->user->id,
+        'overlay_template_id' => $this->template->id,
+        'key' => 'follows_this_stream',
+        'type' => 'counter',
+        'value' => '42',
+        'config' => ['step' => 1, 'reset_value' => 10],
+        'source' => 'twitch',
+        'source_managed' => true,
+    ]);
+
+    app(StreamSessionService::class)->openSession($this->user);
+
+    expect($control->fresh()->value)->toBe('10');
+});
+
+it('keeps every per-stream key pointed at a real preset', function () {
+    $presetKeys = collect(StreamSessionService::CONTROL_PRESETS)->pluck('key');
+
+    foreach (StreamSessionService::PER_STREAM_CONTROL_KEYS as $key) {
+        expect($presetKeys)->toContain($key);
+    }
+});


### PR DESCRIPTION
## What

`resetControls()` selected on `source='twitch'` with no key filter, so the three `latest_cheer*` presets were wiped at every `openSession()` alongside the eight per-stream counters. `latest_cheerer_name` is a text control with no `config`, so `(string) ($control->config['reset_value'] ?? 0)` put the literal string `"0"` in it.

The equivalents on all five donation services persist across streams. Twitch was the odd one out.

## Why it happened

Two commits, five weeks apart:

- **`3a02044` (Mar 7)** added `resetControls()` with six presets, every one named `*_this_stream`. The reset **is** the feature there and it was exactly right.
- **`c6be780` (Apr 13)** added the `channel.cheer` presets, explicitly *"so bits payloads can drive overlays the same way Ko-fi/StreamLabs donations do"*. The three `latest_cheer*` ones inherited the reset purely by sharing a `source` column with controls the filter was written for.

So the reset broke the one thing that second commit set out to build. Bits parity with donations was the stated goal, and `latest_donor_name` persisting while `latest_cheerer_name` did not is precisely that parity failing.

## The change

Reset is now scoped by key via `PER_STREAM_CONTROL_KEYS`. The eight counters still reset - they increment additively and nothing else ever zeroes them, so the reset is the only thing making their labels true. The three `latest_cheer*` no longer do.

This mirrors `GpsIntegrationController::resetControls()`, which already takes an explicit key list and leaves cumulative `distance` alone behind a separate manual button. The twitch path was the one place resetting by source with no filter.

`latest()` is untouched and was never wrong - it reports the freshest write, correctly. It just happened that twitch was the only competitor whose `_at` moved at go-live.

## Behaviour change

An overlay that went blank at go-live (because `"0"` is falsy in a conditional) and stayed blank until someone cheered will now keep showing the previous stream's cheerer. That is what the label promises, but it is visible rather than silent.

## Testing

9 new tests in `tests/Feature/StreamControlResetTest.php`. The 3 asserting the new behaviour were **verified to fail against the old filter** (reverted the `whereIn`, confirmed exactly those 3 red and 6 green, restored and diffed byte-exact). The other 6 pin scoping that was already correct - other users, other sources, user-created controls sharing a key name - so a future change cannot widen the blast radius unnoticed.

Full suite: 1242 passed, 3 skipped. Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)