### PR TITLE
fix(previews): render previews through the shared pipeline, and resolve control tags

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,16 @@
 # CHANGELOG AUGUST 2026
 
+## August 8th, 2026 - fix(previews): control tags resolve in previews
+
+`getSampleTemplateData()` returns 53 keys and every one of them is a static Twitch tag. There is not a single `c:` key in it, and there never was, so no control has ever resolved in any preview on any surface. `[[[followers_total]]]` worked and `[[[c:myname]]]` did not, which is the entire pattern behind "control-heavy overlays show basically nothing in preview".
+
+- **The values were already on the page.** The edit route ships `userScopedControls` and the template's own `controls` for the controls manager; the Builder holds `BuilderControlDef`s for the blocks placed in this session. None of it reached the preview, which received `sampleData` and nothing else. No new endpoint, no new query - the bag handed to the renderer now carries `c:` entries built from data the page already had.
+- **Key derivation mirrors the render query exactly**, because a preview that resolves a different set of keys than the overlay is worse than one that resolves none. Source-managed controls use the namespaced broadcast key (`c:kofi:donations_received`), everything else uses `c:` plus the raw key, and each gets its automatic `_at` companion in Unix seconds. Membership matches too: every template-scoped control, plus user-scoped ones that are source-managed - which is what `userScopedControls` already filters to.
+- **Timers are computed rather than read**, since their stored `value` is not the number on screen. That logic already existed as `resolvePreviewValue()` inside `ExpressionBuilder.vue`; it moved to `controlPreview.ts` and the modal now imports it, because leaving a second copy behind is what the previous commit was about.
+- **Random-mode numbers deliberately return their stored value** instead of rolling a fresh one. The server rerolls on each render, but a canvas whose numbers change on every keystroke reads as broken.
+- **Builder control definitions carry no timestamps**, so their `_at` companion is left absent rather than faked to `now()`. An overlay that has never been saved has no last-write time and should not claim one.
+- **Verified against real local data**, rendering template 232 with its own controls: `[[[c:bb_block_contents]]]` went from empty to "Hello Jasper" and `<img src="">` became `<img src="https://jasper.monster/sharex/...">`.
+
 ## August 8th, 2026 - fix(previews): previews render through the same pipeline the live overlay uses
 
 Every preview surface had its own tag substituter, and all three were the same twelve lines copied around: loop over the sample data, build a literal regex per key by string interpolation, replace. `resources/dsl/dsl.json` opens with a comment forbidding exactly this, and the reason is on display here - a regex built as `[[[${tag}]]]` can only match a bare tag, so `[[[followers_total|number]]]` never matched its own sample value even though the value was sitting right there in the same object.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,17 @@
 # CHANGELOG AUGUST 2026
 
+## August 8th, 2026 - fix(previews): previews render through the same pipeline the live overlay uses
+
+Every preview surface had its own tag substituter, and all three were the same twelve lines copied around: loop over the sample data, build a literal regex per key by string interpolation, replace. `resources/dsl/dsl.json` opens with a comment forbidding exactly this, and the reason is on display here - a regex built as `[[[${tag}]]]` can only match a bare tag, so `[[[followers_total|number]]]` never matched its own sample value even though the value was sitting right there in the same object.
+
+- **What happened to a tag that did not match depended on which preview you opened.** The Builder canvas and the composed-overlay preview both followed up with a catch-all `replace(/\[\[\[[^\]]*]]]/g, '')`, which deleted it. The overlay create page did not, so the same tag stayed on screen as raw `[[[c:bb_block_contents]]]`. One bug, two symptoms, and the comment in `BuilderPlacement.vue` claiming it used the "same preview approach as the template create page" was close enough to stop anyone looking.
+- **The catch-all strip also ate the block syntax**, which is the part that made control-heavy blocks look broken rather than merely empty. `[[[if:...]]]BIG[[[else]]]small[[[endif]]]` had its markers removed and rendered `BIGsmall`; a `foreach` rendered its body exactly once with the loop markers gone. Neither construct was ever evaluated in a preview.
+- **All three now call `renderTemplateSource()`**, a small util that runs `processTemplate` then `replaceTagsWithFormatting` - the same two passes, in the same order, that `OverlayRenderer.parseSource()` runs. Previews cannot drift from what OBS shows, because there is no second implementation left to drift.
+- **Deleting the strip is not a regression.** `replaceTagsWithFormatting` already resolves an absent value to `''`, so unmatched tags still vanish. They now go through `?? default` on the way, so `[[[c:donations ?? nothing yet]]]` shows its fallback instead of being erased along with everything else.
+- **Locale reaches previews for the first time.** It comes off `auth.user.locale`, which `HandleInertiaRequests` already shares, so `currency` and `date` and `number` format the way that user has them set rather than not formatting at all.
+- **Verified against the real modules rather than by reading them**, bundling the util with esbuild and running it in node: pipes resolve (`1,234`), `??` fires, both conditional branches select correctly, `foreach` emits one node per item, HTML values stay entity-encoded, and the CSS path stays unencoded so `.a > .b` survives.
+- **`useHelpReference.ts` keeps its own tag regex on purpose.** It wraps literal tags in clickable `<code>` for the help pages, where resolving them is precisely what you do not want.
+
 ## August 7th, 2026 - feat(dashboard): a welcome card, so the dashboard opens with a greeting instead of four lists
 
 The dashboard was four boxes with a list in each. Functional and clean, and not remotely inviting. There is now a card above them holding your avatar, your name, and one tile each for the four things underneath: static overlays, alerts, recent events, recent updates.

--- a/resources/js/components/builder/BuilderCanvas.vue
+++ b/resources/js/components/builder/BuilderCanvas.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
   canvas: { width: number; height: number };
   placements: BuilderPlacementType[];
   selectedId: string | null;
-  sampleData: Record<string, string>;
+  sampleData: Record<string, unknown>;
   isCellOccupied: (x: number, y: number) => boolean;
   stalePlacementIds?: Set<string>;
 }>();

--- a/resources/js/components/builder/BuilderEditor.vue
+++ b/resources/js/components/builder/BuilderEditor.vue
@@ -17,7 +17,7 @@ import { isTextEntryTarget } from '@/utils/isTextEntryTarget';
 // via the exposed API when its Save button submits.
 const props = defineProps<{
   initial: BuilderMetadata;
-  sampleData: Record<string, string>;
+  sampleData: Record<string, unknown>;
   blocks: LibraryBlock[];
 }>();
 

--- a/resources/js/components/builder/BuilderPlacement.vue
+++ b/resources/js/components/builder/BuilderPlacement.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { BuilderPlacement } from '@/types';
+import { usePage } from '@inertiajs/vue3';
+import type { AppPageProps, BuilderPlacement } from '@/types';
+import { renderTemplateSource } from '@/utils/renderTemplate';
 
 export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
 
@@ -25,6 +27,9 @@ const emit = defineEmits<{
 // edges and not others - the borders here are specified thick enough that they
 // survive the transform.
 const px = (screenPx: number) => `${screenPx / props.scale}px`;
+
+const page = usePage<AppPageProps>();
+const locale = computed(() => page.props.auth.user?.locale ?? 'en-US');
 
 const OUTLINE_PX = 2;
 const OUTLINE_SELECTED_PX = 3;
@@ -104,20 +109,16 @@ function onHandlePointerDown(handle: ResizeHandle, e: PointerEvent) {
   emit('resizeStart', props.placement.instance_id, handle, e);
 }
 
-// Same preview approach as the template create page: substitute sample data
-// into the block's code, strip leftover tag/conditional markers for visual
-// cleanliness, render in a sandboxed iframe (free style isolation).
+// Render through the same two-pass pipeline the live overlay uses, so a block
+// previews the way it will actually ship. The previous approach built a literal
+// regex per sample key, which could only ever match a bare [[[tag]]] - anything
+// carrying a pipe or a `??` default fell through and was then deleted outright
+// by a catch-all strip, along with every conditional and foreach marker.
+// Absent values still collapse to '' here, but now `??` defaults get their turn
+// first. Rendered in a sandboxed iframe for free style isolation.
 const previewDoc = computed(() => {
-  let html = props.placement.snapshot.html;
-  let css = props.placement.snapshot.css;
-
-  Object.entries(props.sampleData).forEach(([tag, value]) => {
-    const pattern = new RegExp(`\\[\\[\\[${tag}]]]`, 'g');
-    html = html.replace(pattern, value);
-    css = css.replace(pattern, value);
-  });
-  html = html.replace(/\[\[\[[^\]]*]]]/g, '');
-  css = css.replace(/\[\[\[[^\]]*]]]/g, '');
+  const html = renderTemplateSource(props.placement.snapshot.html, props.sampleData, locale.value, true);
+  const css = renderTemplateSource(props.placement.snapshot.css, props.sampleData, locale.value, false);
 
   // height:100% on html/body mirrors the compiled environment: there the
   // block's wrapper is a grid item with a definite height, so a block using

--- a/resources/js/components/builder/BuilderPlacement.vue
+++ b/resources/js/components/builder/BuilderPlacement.vue
@@ -8,7 +8,7 @@ export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
 
 const props = defineProps<{
   placement: BuilderPlacement;
-  sampleData: Record<string, string>;
+  sampleData: Record<string, unknown>;
   selected: boolean;
   sourceStale?: boolean;
   /** Canvas scale factor, so chrome can be sized in screen pixels. */

--- a/resources/js/components/controls/ExpressionBuilder.vue
+++ b/resources/js/components/controls/ExpressionBuilder.vue
@@ -12,6 +12,7 @@ import {
 import { ExternalLink, FunctionSquare } from '@lucide/vue';
 import { buildContext, evaluate, ARG_FUNCTIONS, SUPPORTED_FUNCTIONS } from '@/composables/useExpressionEngine';
 import type { OverlayControl } from '@/types';
+import { controlPreviewValue } from '@/utils/controlPreview';
 
 interface FunctionGroup {
   label: string;
@@ -56,30 +57,6 @@ watch(expressionText, (val) => {
 const expressionError = ref('');
 const expressionPreview = ref('');
 
-/** Compute a representative preview value for a control, including timer types. */
-function resolvePreviewValue(ctrl: OverlayControl): unknown {
-  if (ctrl.type === 'timer') {
-    const cfg = ctrl.config ?? {};
-    const mode = cfg.mode ?? 'countup';
-    const offset = Number(cfg.offset_seconds ?? 0);
-
-    if (mode === 'countto') {
-      const target = cfg.target_datetime ? new Date(cfg.target_datetime).getTime() : null;
-      if (!target) return 0;
-      return Math.max(0, Math.floor((target - Date.now()) / 1000));
-    }
-
-    let elapsed = offset;
-    if (cfg.running && cfg.started_at) {
-      elapsed = offset + Math.floor((Date.now() - new Date(cfg.started_at).getTime()) / 1000);
-    }
-
-    const base = Number(cfg.base_seconds ?? 0);
-    return mode === 'countdown' ? Math.max(0, base - elapsed) : elapsed;
-  }
-
-  return ctrl.value ?? '';
-}
 const controlFilter = ref('');
 const functionsOpen = ref(false);
 const copiedSnippet = ref<string | null>(null);
@@ -192,7 +169,7 @@ watch([expressionText, liveTwitchTags], ([text]) => {
     const mockData: Record<string, unknown> = {};
     for (const ctrl of props.availableControls) {
       const key = ctrl.source ? `c:${ctrl.source}:${ctrl.key}` : `c:${ctrl.key}`;
-      mockData[key] = resolvePreviewValue(ctrl);
+      mockData[key] = controlPreviewValue(ctrl);
     }
 
     // For every t.<name> reference, prefer the live server value; fall back

--- a/resources/js/pages/builder/create.vue
+++ b/resources/js/pages/builder/create.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
-import { Head, Link, router } from '@inertiajs/vue3';
+import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import axios from 'axios';
 import AppLayout from '@/layouts/AppLayout.vue';
-import type { BreadcrumbItem } from '@/types';
+import type { AppPageProps, BreadcrumbItem } from '@/types';
 import Heading from '@/components/Heading.vue';
 import RekaToast from '@/components/RekaToast.vue';
 import PublicToggle from '@/components/PublicToggle.vue';
@@ -19,12 +19,16 @@ import { composeBuilderTemplate } from '@/utils/composeBuilderTemplate';
 import { sanitizeHtmlFields } from '@/utils/sanitize';
 import { compileTailwindCss } from '@/utils/compileTailwind';
 import { isTextEntryTarget } from '@/utils/isTextEntryTarget';
+import { renderTemplateSource } from '@/utils/renderTemplate';
 import { ExternalLink, Save } from '@lucide/vue';
 
 const props = defineProps<{
   sampleData: Record<string, string>;
   blocks: LibraryBlock[];
 }>();
+
+const page = usePage<AppPageProps>();
+const locale = computed(() => page.props.auth.user?.locale ?? 'en-US');
 
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Builder', href: '/builder' }];
 
@@ -111,15 +115,11 @@ const composed = computed(() => composeBuilderTemplate(state.serialize()));
 
 function previewOverlay() {
   const { head, html, css } = composed.value;
-  let previewBody = html;
-  let previewCss = css;
-  Object.entries(props.sampleData).forEach(([tag, value]) => {
-    const pattern = new RegExp(`\\[\\[\\[${tag}]]]`, 'g');
-    previewBody = previewBody.replace(pattern, value);
-    previewCss = previewCss.replace(pattern, value);
-  });
-  previewBody = previewBody.replace(/\[\[\[[^\]]*]]]/g, '');
-  previewCss = previewCss.replace(/\[\[\[[^\]]*]]]/g, '');
+  // Same two-pass pipeline the live overlay uses, so the composed preview
+  // matches what OBS will show - pipes, `??` defaults, conditionals and
+  // foreach included. See renderTemplateSource.
+  const previewBody = renderTemplateSource(html, props.sampleData, locale.value, true);
+  const previewCss = renderTemplateSource(css, props.sampleData, locale.value, false);
 
   previewHtml.value = `<!DOCTYPE html>
 <html lang="en">

--- a/resources/js/pages/builder/create.vue
+++ b/resources/js/pages/builder/create.vue
@@ -20,6 +20,7 @@ import { sanitizeHtmlFields } from '@/utils/sanitize';
 import { compileTailwindCss } from '@/utils/compileTailwind';
 import { isTextEntryTarget } from '@/utils/isTextEntryTarget';
 import { renderTemplateSource } from '@/utils/renderTemplate';
+import { controlsToPreviewData } from '@/utils/controlPreview';
 import { ExternalLink, Save } from '@lucide/vue';
 
 const props = defineProps<{
@@ -33,6 +34,14 @@ const locale = computed(() => page.props.auth.user?.locale ?? 'en-US');
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Builder', href: '/builder' }];
 
 const state = useBuilderState();
+
+// Blocks placed here bring control *definitions* rather than saved rows - the
+// rows are only created on save - so previews resolve `c:` tags from those
+// defaults. Recomputes as blocks are added or removed.
+const previewData = computed<Record<string, unknown>>(() => ({
+  ...props.sampleData,
+  ...controlsToPreviewData(state.controlsForImport()),
+}));
 const { stalePlacementIds, refreshPlacement, syncAll, noteFreshSource } = useBlockSourceSync(state);
 
 function refreshSelectedFromSource() {
@@ -118,8 +127,8 @@ function previewOverlay() {
   // Same two-pass pipeline the live overlay uses, so the composed preview
   // matches what OBS will show - pipes, `??` defaults, conditionals and
   // foreach included. See renderTemplateSource.
-  const previewBody = renderTemplateSource(html, props.sampleData, locale.value, true);
-  const previewCss = renderTemplateSource(css, props.sampleData, locale.value, false);
+  const previewBody = renderTemplateSource(html, previewData.value, locale.value, true);
+  const previewCss = renderTemplateSource(css, previewData.value, locale.value, false);
 
   previewHtml.value = `<!DOCTYPE html>
 <html lang="en">
@@ -240,7 +249,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
             :canvas="state.canvas.value"
             :placements="state.placements.value"
             :selected-id="state.selectedId.value"
-            :sample-data="props.sampleData"
+            :sample-data="previewData"
             :is-cell-occupied="(x, y) => state.occupied(x, y)"
             :stale-placement-ids="stalePlacementIds"
             @cell-click="onCellClick"

--- a/resources/js/pages/templates/create.vue
+++ b/resources/js/pages/templates/create.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
-import { useForm, Head, Link } from '@inertiajs/vue3';
+import { useForm, Head, Link, usePage } from '@inertiajs/vue3';
 import AppLayout from '@/layouts/AppLayout.vue';
-import type { BreadcrumbItem } from '@/types';
+import type { AppPageProps, BreadcrumbItem } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import Heading from '@/components/Heading.vue';
 import RekaToast from '@/components/RekaToast.vue';
@@ -14,10 +14,14 @@ import PublicToggle from '@/components/PublicToggle.vue';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
 import { sanitizeHtmlFields } from '@/utils/sanitize';
 import { compileTailwindCss } from '@/utils/compileTailwind';
+import { renderTemplateSource } from '@/utils/renderTemplate';
 
 const props = defineProps<{
   sampleData: Record<string, string>;
 }>();
+
+const page = usePage<AppPageProps>();
+const locale = computed(() => page.props.auth.user?.locale ?? 'en-US');
 
 const form = useForm({
   name: '',
@@ -96,13 +100,13 @@ const submitForm = async () => {
 };
 
 const previewTemplate = (): void => {
-  let htmlContent = form.html;
-  let cssContent = form.css;
-  Object.entries(props.sampleData).forEach(([tag, value]) => {
-    const tagPattern = new RegExp(`\\[\\[\\[${tag}]]]`, 'g');
-    htmlContent = htmlContent.replace(tagPattern, value);
-    cssContent = cssContent.replace(tagPattern, value);
-  });
+  // Same two-pass pipeline the live overlay uses, so the preview matches what
+  // OBS will show. The previous approach built a literal regex per sample key,
+  // so it only ever matched a bare [[[tag]]]: anything with a pipe or a `??`
+  // default was left on screen raw, and conditionals and foreach blocks were
+  // never resolved at all.
+  const htmlContent = renderTemplateSource(form.html, props.sampleData, locale.value, true);
+  const cssContent = renderTemplateSource(form.css, props.sampleData, locale.value, false);
 
   previewHtml.value = `<!DOCTYPE html>
 <html lang="en">

--- a/resources/js/pages/templates/edit.vue
+++ b/resources/js/pages/templates/edit.vue
@@ -18,6 +18,7 @@ import CopyTypeDialog from '@/components/templates/CopyTypeDialog.vue';
 import IntegrationSuggestionModal from '@/components/IntegrationSuggestionModal.vue';
 import TemplateMeta from '@/components/TemplateMeta.vue';
 import TriggerManager, { type TriggerData } from '@/components/TriggerManager.vue';
+import { controlsToPreviewData } from '@/utils/controlPreview';
 import BrowseFreesoundModal from '@/components/BrowseFreesoundModal.vue';
 import BuilderEditor from '@/components/builder/BuilderEditor.vue';
 import type { LibraryBlock } from '@/components/builder/BlockPickerModal.vue';
@@ -245,6 +246,19 @@ const mainTabs = computed(() => {
 
 const mainTab = ref<string>('code');
 const localControls = ref<OverlayControl[]>([...(props.controls ?? [])]);
+
+// Previews resolve control tags the same way the live overlay does, so the bag
+// handed to the renderer carries `c:` entries alongside the Twitch sample data.
+// Membership mirrors the render query: every template-scoped control, plus the
+// user-scoped ones that are source-managed (which is what `userScopedControls`
+// already is). Template controls are merged last so they win a key clash; the
+// server resolves that by sort_order, which does not survive the split here.
+// Rebuilds as localControls changes, so adding a control updates the preview.
+const previewData = computed<Record<string, unknown>>(() => ({
+  ...(props.sampleData ?? {}),
+  ...controlsToPreviewData(props.userScopedControls ?? []),
+  ...controlsToPreviewData(localControls.value),
+}));
 
 const localTargetOverlayIds = ref<number[]>([...(props.targetStaticOverlayIds ?? [])]);
 
@@ -639,7 +653,7 @@ onMounted(() => {
             v-show="mainTab === 'code'"
             ref="builderEditor"
             :initial="props.template.metadata.builder"
-            :sample-data="props.sampleData ?? {}"
+            :sample-data="previewData"
             :blocks="props.builderBlocks ?? []"
             @dirty="builderDirty = true"
             @error="(msg) => pushToast(msg, 'warning')"

--- a/resources/js/utils/controlPreview.ts
+++ b/resources/js/utils/controlPreview.ts
@@ -1,0 +1,93 @@
+/**
+ * Turn control rows (or Builder control definitions) into the `c:`-prefixed
+ * entries the render pipeline expects, so a preview resolves control tags the
+ * same way the live overlay does.
+ *
+ * Key derivation mirrors OverlayTemplateController's render query:
+ *   source_managed -> 'c:' + broadcastKey()   e.g. c:kofi:donations_received
+ *   otherwise      -> 'c:' + key              e.g. c:myname
+ * plus the automatic `_at` companion in Unix seconds.
+ */
+
+/**
+ * The subset of a control this module needs. Builder control definitions carry
+ * no id, source or timestamps, so everything after `type` is optional.
+ */
+export interface PreviewableControl {
+    key: string;
+    type: string;
+    value: string | null;
+    config?: Record<string, any> | null;
+    source?: string | null;
+    source_managed?: boolean;
+    created_at?: string;
+    updated_at?: string;
+}
+
+/**
+ * A representative value for one control.
+ *
+ * Timers are computed rather than read, because their stored `value` is not the
+ * number on screen - it is derived from mode/offset/base and the wall clock,
+ * and templates pipe the result through `|duration`. Mirrors
+ * OverlayControl::resolveTimerDisplayValue().
+ *
+ * Random-mode numbers deliberately return their stored value rather than
+ * rolling a new one: a preview that changes on every re-render reads as broken.
+ */
+export function controlPreviewValue(ctrl: PreviewableControl): unknown {
+    if (ctrl.type === 'timer') {
+        const cfg = ctrl.config ?? {};
+        const mode = cfg.mode ?? 'countup';
+        const offset = Number(cfg.offset_seconds ?? 0);
+
+        if (mode === 'countto') {
+            const target = cfg.target_datetime ? new Date(cfg.target_datetime).getTime() : null;
+            if (!target) return 0;
+            return Math.max(0, Math.floor((target - Date.now()) / 1000));
+        }
+
+        let elapsed = offset;
+        if (cfg.running && cfg.started_at) {
+            elapsed = offset + Math.floor((Date.now() - new Date(cfg.started_at).getTime()) / 1000);
+        }
+
+        const base = Number(cfg.base_seconds ?? 0);
+
+        return mode === 'countdown' ? Math.max(0, base - elapsed) : elapsed;
+    }
+
+    return ctrl.value ?? '';
+}
+
+/** Mirrors OverlayControl::broadcastKey() for the source case. */
+function dataKeyFor(ctrl: PreviewableControl): string {
+    return ctrl.source_managed && ctrl.source ? `c:${ctrl.source}:${ctrl.key}` : `c:${ctrl.key}`;
+}
+
+/**
+ * Build the `c:` half of a preview data bag. Later entries win, so callers
+ * should pass template-scoped controls after user-scoped ones when a key
+ * exists in both.
+ */
+export function controlsToPreviewData(controls: PreviewableControl[]): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+
+    for (const ctrl of controls) {
+        if (!ctrl?.key) continue;
+
+        const dataKey = dataKeyFor(ctrl);
+        out[dataKey] = controlPreviewValue(ctrl);
+
+        // Every control carries an automatic `_at` companion in Unix seconds.
+        // Builder definitions have no timestamps yet, so theirs stays absent
+        // rather than being faked to now().
+        const stamp = ctrl.updated_at ?? ctrl.created_at;
+        if (stamp) {
+            const ms = new Date(stamp).getTime();
+            if (!isNaN(ms)) out[`${dataKey}_at`] = String(Math.floor(ms / 1000));
+        }
+    }
+
+    return out;
+}

--- a/resources/js/utils/renderTemplate.ts
+++ b/resources/js/utils/renderTemplate.ts
@@ -1,0 +1,35 @@
+import { useConditionalTemplates } from '@/composables/useConditionalTemplates';
+import { replaceTagsWithFormatting } from '@/utils/tagParser';
+
+// useConditionalTemplates is a plain factory - no refs, no lifecycle hooks - so
+// a single module-level instance is safe and avoids rebuilding its closures on
+// every keystroke-driven preview re-render.
+const { processTemplate } = useConditionalTemplates();
+
+/**
+ * The canonical two-pass template render.
+ *
+ * Mirrors OverlayRenderer's `parseSource()` so a preview cannot drift from what
+ * OBS actually shows. Anything that renders template source outside the live
+ * overlay should call this rather than substituting tags by hand.
+ *
+ * Pass 1 resolves conditional and foreach blocks, including the loop-scoped
+ * `alias.*` / `loop.*` tokens whose lifetime is confined to a loop body.
+ * Pass 2 is the single tag-substitution pass; substituted values are never
+ * re-scanned for tags (see the SINGLE-PASS note in tagParser.ts).
+ *
+ * `encode` is true for HTML sinks and false for CSS, where entity-encoding
+ * would corrupt selectors like `.a > .b`.
+ */
+export function renderTemplateSource(
+    source: string | null | undefined,
+    data: Record<string, unknown>,
+    locale: string,
+    encode: boolean = true,
+): string {
+    if (!source) return '';
+
+    const withBlocks = processTemplate(source, data, { locale, encode });
+
+    return replaceTagsWithFormatting(withBlocks, data, locale, encode);
+}


### PR DESCRIPTION
Two commits. The first replaces three bespoke tag substituters with the pipeline the live overlay already uses; the second puts control values into the bag it receives.

## 1. Previews render through the shared pipeline

Three preview surfaces each carried a copy of the same twelve lines: loop the sample data, build a literal regex per key by string interpolation, replace.

```js
const pattern = new RegExp(`\[\[\[${tag}]]]`, 'g');
```

`resources/dsl/dsl.json` forbids hand-rolled tag regexes in its opening comment, and this is why: that pattern only matches a bare `[[[tag]]]`, so `[[[followers_total|number]]]` never matched its own sample value even though the value was in the same object.

What happened next depended on which preview you opened. The Builder canvas and the composed-overlay preview followed up with a catch-all `replace(/\[\[\[[^\]]*]]]/g, '')` that deleted the tag; the overlay create page did not, so the same tag stayed on screen raw. One bug, two symptoms. The comment claiming they used the "same preview approach" was close enough to stop anyone checking.

That catch-all also ate the block syntax, which is what made control-heavy blocks look broken rather than merely empty:

- `[[[if:...]]]BIG[[[else]]]small[[[endif]]]` rendered `BIGsmall`
- a `foreach` rendered its body exactly once with the loop markers gone

All three now call `renderTemplateSource()`, which runs `processTemplate` then `replaceTagsWithFormatting` - the same two passes in the same order as `OverlayRenderer.parseSource()`.

Removing the strip is not a regression: `replaceTagsWithFormatting` already resolves an absent value to `''`, so unmatched tags still vanish. They now pass through `?? default` on the way.

Locale reaches previews for the first time, from `auth.user.locale`, so `currency` / `date` / `number` format rather than not formatting at all.

## 2. Control tags resolve

`getSampleTemplateData()` returns 53 keys and every one is a static Twitch tag. Not one `c:` key, ever, so no control had ever resolved in any preview on any surface. `[[[followers_total]]]` worked and `[[[c:myname]]]` did not.

The values were already client-side - the edit route ships `userScopedControls` and the template's own controls for the controls manager, and the Builder holds `BuilderControlDef`s for blocks placed this session. None of it reached the preview. No new endpoint or query; `controlsToPreviewData()` turns either shape into the `c:` half of the bag.

Key derivation mirrors `OverlayTemplateController`'s render query, because a preview resolving a *different* key set than the overlay is worse than one resolving none: source-managed controls use the namespaced broadcast key, everything else `c:` + key, each with its `_at` companion in Unix seconds. Membership matches too.

Smaller calls:

- **Timers are computed, not read** - their stored `value` is not the number on screen. That logic moved out of `ExpressionBuilder.vue` rather than being copied.
- **Random-mode numbers return their stored value** instead of rerolling, so the canvas does not change on every keystroke.
- **Builder definitions have no timestamps**, so their `_at` stays absent rather than being faked to `now()`.
- **`useHelpReference.ts` keeps its own tag regex on purpose** - it wraps literal tags in clickable `<code>` for the help pages.

## Verification

No JS test runner exists in this repo and none was added. The real modules were bundled with esbuild and run in node.

Pipeline behaviour:

```
pipe formatter             | "1,234"
bare unmatched tag         | "<b></b>"
?? default on absent       | "nothing yet"
conditional true branch    | "BIG"
conditional false branch   | "small"
currency pipe              | "€12.50"
foreach over array         | "<li>ana</li><li>bo</li>"
html encoding              | "&lt;script&gt;alert(1)&lt;/script&gt;"
css encode:false           | ".a > .b { width: 40px }"
```

Against real local data (template 232), before and after control injection:

```
BEFORE  "Hello Jasper" present : false   first <img>: <img src="" ...>
AFTER   "Hello Jasper" present : true    first <img>: <img src="https://jasper.monster/sharex/...">
```

## Not covered

`head` is still unparsed in all three previews, exactly as before. Tags in `head` render literally. Pre-existing, and outside "replace the stripper".

Iterables (`[[[foreach:subscribers as sub]]]`) still render empty - nothing supplies a `subscribers` array. That needs invented data rather than real data, which is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
