### PR TITLE
Relicense to AGPL-3.0-or-later, and complete the community standards checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Something in Overlabels isn't working the way it should
+labels: ["Bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. You don't need to fill in every field - the first two are the ones that matter most.
+
+        If you think you've found a **security** issue, please don't file it here. See [SECURITY.md](https://github.com/jasperfrontend/overlabels/blob/main/SECURITY.md) instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+      placeholder: My follower count overlay showed 0 after I went live, but the dashboard shows the right number.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where in Overlabels?
+      description: Pick the closest one. If you're not sure, pick "Not sure".
+      options:
+        - A static overlay
+        - An alert overlay
+        - The overlay builder
+        - Controls
+        - An integration (Ko-fi, Streamlabs, Buy Me a Coffee, Fourthwall, Throne)
+        - The Twitch bot
+        - The GPS / mobile app
+        - The website itself (dashboard, settings, templates list)
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where were you viewing it?
+      description: Overlays behave differently in OBS than in a normal browser tab, so this narrows things down fast.
+      options:
+        - In OBS (browser source)
+        - In a normal browser tab
+        - Both - it happens in either
+        - Not applicable
+      default: 0
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we make it happen again?
+      description: Rough steps are fine. "It happens every time I go live" is a useful answer.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Go live
+        4. The overlay shows ...
+
+  - type: input
+    id: overlay-url
+    attributes:
+      label: Overlay slug (optional)
+      description: |
+        The slug only, please - **not** the full overlay URL. The part after `#` in that URL is your access token and would let anyone view your overlay.
+      placeholder: my-follower-goal
+
+  - type: textarea
+    id: tags
+    attributes:
+      label: Tags or controls involved (optional)
+      description: If specific tags misbehaved, paste them here.
+      placeholder: "[[[follower_count]]] and [[[c:kofi:donations_received]]]"
+      render: text
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Browser console errors (optional)
+      description: |
+        OBS browser sources can't show you console errors. To check for them, open the same overlay URL in a normal browser tab, press F12, and look at the Console tab.
+      render: text
+
+  - type: input
+    id: versions
+    attributes:
+      label: Browser and OBS version (optional)
+      placeholder: Firefox 141, OBS 31.0.2
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Before you file
+      options:
+        - label: I've checked that no one has already reported this
+          required: false
+        - label: This isn't a security vulnerability (those go to the email in SECURITY.md)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/jasperfrontend/overlabels/blob/main/SECURITY.md
+    about: Please report security issues privately by email, not as a public issue.
+  - name: Question about using Overlabels
+    url: https://github.com/jasperfrontend/overlabels/blob/main/README.md
+    about: The README covers tags, controls, overlays and integrations in detail.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Idea or feature request
+description: Suggest something Overlabels could do
+labels: ["Enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ideas are welcome. The most useful ones describe the thing you were trying to do on stream, not the feature you think would solve it - that leaves room for a simpler answer than either of us had in mind.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: What's the situation on your stream where Overlabels gets in your way or falls short?
+      placeholder: I want my alert to look different for a 5 euro tip than for a 50 euro one, but I have to build two separate alerts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What did you have in mind?
+      description: Optional. If you already have a shape for it, describe it here.
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: How are you working around it today?
+      description: Optional, but genuinely useful. Sometimes the workaround is the feature.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## What this changes
+
+<!-- One or two sentences. What does this do, and why now? -->
+
+## Notes for review
+
+<!-- Anything non-obvious: a decision you went back and forth on, a thing you deliberately did not do, a follow-up you're leaving for later. Delete if there's nothing. -->
+
+## Checklist
+
+- [ ] `docs/changelog/changelog-YYYY-MM.md` updated for this month
+- [ ] Tests added or updated, and `php artisan test` passes
+- [ ] `npm run lint` and `php artisan pint` are clean
+- [ ] Any new migration was rolled back and re-run at least once
+- [ ] Responsive at every screen size (if this touches the frontend)
+- [ ] No em dashes in user-facing copy; "Copy" rather than "Fork" in the UI
+- [ ] Version bumped in **both** `package.json` and `composer.json` (only if this release warrants it)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jasper@emailjasper.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to Overlabels
+
+Thanks for being here. Overlabels is a small project maintained by one person, so the most useful
+thing you can do before writing code is talk to me first.
+
+## Before you write code
+
+**Open an issue before starting anything substantial.** Bug fixes and small corrections can go
+straight to a pull request. Anything larger - a new feature, a refactor, a change to how a page
+looks - is worth a conversation first, because I may already have a direction in mind or a reason
+the current shape is the way it is.
+
+One thing worth knowing up front: **Overlabels grows by accretion, not redesign.** Fixing one thing
+that is clearly wrong is always welcome. Rewriting a working area of the UI because it could be
+organised differently is usually not, however good the new version is. Restraint is deliberate here.
+
+## Getting set up
+
+The setup steps, required environment variables and integration credentials are in the
+[Self-Hosting section of the README](README.md#self-hosting). No support is provided for
+self-hosting, but those instructions are what a development environment needs.
+
+Once you are set up:
+
+```bash
+composer run dev      # server, queue worker and vite together
+php artisan test      # Pest test suite
+npm run lint          # ESLint with auto-fix
+npm run format        # Prettier
+php artisan pint      # PHP code style
+```
+
+## The workflow
+
+1. Branch off `main`. Use a prefix that matches what you are doing: `feat/`, `fix/`, `docs/`,
+   `refactor/` or `chore/`. For example `fix/alert-duration-overflow`.
+2. Commit your work. Please sign off your commits (see [Licensing](#licensing-and-sign-off) below).
+3. Open a pull request against `main`. Never push directly to `main`.
+4. Fill in the pull request template. The checklist is short and every item on it is something that
+   has bitten this project before.
+
+## Before you open a pull request
+
+- `php artisan test` passes
+- `npm run lint` and `php artisan pint` are clean
+- Any new migration has been rolled back and re-run at least once
+- Frontend changes work at every screen size, not just yours
+- There is an entry in `docs/changelog/changelog-YYYY-MM.md` for the current month
+
+## House rules for anything users read
+
+These are small and I am strict about them, so it is faster if you know them going in.
+
+- **No em dashes** in user-facing copy, comments or documentation. Use a hyphen with spaces instead.
+- **Say "Copy", never "Fork"**, anywhere in the interface. Forking is the git concept; copying is
+  what the feature does for a streamer.
+- **Keep copy gender-neutral.** No "dude", "man", "guys" or "bro" anywhere a user can read it,
+  including bot replies.
+- **Render nothing when data is missing.** No em dash placeholders, no "N/A", no zero standing in
+  for absence.
+- **Body copy uses `text-foreground`**, not `text-muted-foreground`.
+- **Every clickable element gets `cursor-pointer`.**
+
+## Licensing and sign-off
+
+Overlabels is licensed under [AGPL-3.0-or-later](LICENSE), and contributions are accepted under the
+same terms. You keep the copyright in what you write.
+
+Please sign off your commits to certify that you have the right to submit the work, following the
+[Developer Certificate of Origin](https://developercertificate.org/):
+
+```bash
+git commit -s -m "fix: your message here"
+```
+
+That adds a `Signed-off-by:` line using your git name and email. It is a statement about provenance,
+not a transfer of anything.
+
+## Security
+
+Please do not open a public issue for anything you suspect is a vulnerability. [SECURITY.md](SECURITY.md)
+explains how to report it privately and what to expect.
+
+## Code of conduct
+
+Participation is covered by the [Code of Conduct](CODE_OF_CONDUCT.md). It applies to issues, pull
+requests and any other space that belongs to this project.
+
+~ JasperDiscovers

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,681 @@
+Overlabels
+Copyright (c) 2026 JasperDiscovers
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+The full text of the license follows, reproduced verbatim.
+
+================================================================================
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -741,6 +741,9 @@ What this means in practice:
 If you have questions, ideas, or improvements, open an issue or submit a pull request.
 Overlabels grows best when people build on top of it.
 
+[CONTRIBUTING.md](CONTRIBUTING.md) covers the workflow, the house rules for user-facing copy, and how
+to sign off your commits. Participation is covered by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
 Contributions are accepted under the same AGPL-3.0-or-later terms as the rest of the project.
 
 ~ JasperDiscovers

--- a/README.md
+++ b/README.md
@@ -713,9 +713,34 @@ Be sure to mention this README somewhere in your tip so I can link your support 
 
 ---
 
+## License
+
+Overlabels is licensed under the **GNU Affero General Public License, version 3 or later**
+(`AGPL-3.0-or-later`), as of August 9th, 2026. The full text is in [LICENSE](LICENSE).
+
+Before that date this repository carried no licence at all. The `composer.json` metadata declared
+`"license": "MIT"`, but that line arrived untouched in the initial Laravel scaffold commit
+(`783b81fc`) as part of the starter kit's default metadata, and was never a deliberate choice. No
+`LICENSE` file was ever published in this repository granting MIT terms. The AGPL applies going
+forward from the date above; this is a forward-only relicense and no history has been rewritten.
+
+What this means in practice:
+
+- You can read, run, modify and share the source code freely.
+- If you **self-host a modified version** and other people can reach it over a network, section 13
+  of the AGPL requires you to offer those users the source of your modified version. Running an
+  unmodified copy for yourself carries no such obligation.
+- This governs the **Overlabels source code**. It does not govern the overlay templates, kits and
+  controls you create with Overlabels - those are yours, and the copying rules for them are
+  described under [Copying](#copying).
+
+---
+
 ## Contributing
 
 If you have questions, ideas, or improvements, open an issue or submit a pull request.
 Overlabels grows best when people build on top of it.
+
+Contributions are accepted under the same AGPL-3.0-or-later terms as the rest of the project.
 
 ~ JasperDiscovers

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "Laravel",
         "framework"
     ],
-    "license": "MIT",
+    "license": "AGPL-3.0-or-later",
     "require": {
         "php": "^8.4.1",
         "ext-pdo": "*",

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,16 @@
 # CHANGELOG AUGUST 2026
 
+## August 9th, 2026 - chore(license): Overlabels is AGPL-3.0-or-later
+
+The repository has never had a licence. `composer.json` said `"license": "MIT"`, which arrived in `783b81fc "Laravel? Pretty cool!"` as part of the starter kit's default metadata and was never a decision anyone made. Meanwhile GitHub reported no licence at all, because there was no `LICENSE` file to report. Those two facts contradicted each other in public on every commit.
+
+- **AGPL-3.0-or-later, not MIT**, because Overlabels is a hosted service whose sustainability plan is still unwritten. MIT lets anyone take this codebase closed and run a competing hosted Overlabels; the AGPL's section 13 means anyone who hosts a *modified* version has to offer its source to the people using it. It keeps the open-source claim in `SECURITY.md` honest without handing away the one thing that is actually the product.
+- **The cost of copyleft is normally that it deters contributors, and here that cost is currently zero.** 1398 commits, all mine, plus dependabot. Zero forks. This is the cheapest moment the decision will ever be available.
+- **The licence body is byte-identical to the FSF original**, verified with `cmp` against `gnu.org/licenses/agpl-3.0.txt`. The copyright line sits in a header above it rather than inside it, because the document's own terms permit verbatim copies only. The header is the FSF's recommended notice, whose "or (at your option) any later version" is the part that actually encodes the `-or-later`.
+- **Four manifests now agree**: `composer.json` switched off MIT, `package.json` gained a `license` field it never had, `package-lock.json` picked the same value up in its root entry via `npm install --package-lock-only` (one line, no dependency churn), and no third-party `license` field in the lockfile was touched, since those describe other people's packages.
+- **Forward-only.** No history rewritten, no force-push, no existing commit touched. Code already distributed while the manifest claimed MIT was distributed under that claim and nothing here retroactively changes that. With zero forks the practical exposure is theoretical, but the README says what happened rather than pretending the switch was clean.
+- **The README distinguishes the code from your templates.** The Copying section promises "no licensing restrictions" on public templates, and a licence section three screens further down is exactly where someone would conflate the two. The AGPL governs the source; your overlays remain yours.
+
 ## August 9th, 2026 - chore(github): issue forms that ask the questions I was going to ask anyway
 
 GitHub's community standards checklist wants five files. Two of them earn their place on merit and the rest are paperwork for a repo recruiting contributors, which this one is not. These are the two.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,17 @@
 # CHANGELOG AUGUST 2026
 
+> Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
+
+## August 9th, 2026 - docs(community): CONTRIBUTING and a code of conduct
+
+The last two items on GitHub's community checklist, written now rather than earlier because both were downstream of the licence. CONTRIBUTING is where the sign-off requirement lives, and that requirement did not exist until there was a licence for contributions to be made under.
+
+- **The most useful line in CONTRIBUTING is "open an issue before starting anything substantial"**, followed by the note that this project grows by accretion rather than redesign. A rewrite of a working area is the pull request most likely to be declined here, and someone deserves to know that before spending a weekend on one, not after.
+- **House rules for user-facing copy are written down for the first time.** No em dashes, "Copy" and never "Fork", gender-neutral wording, render nothing when data is missing, `text-foreground` for body copy, `cursor-pointer` on anything clickable. These are small, they are enforced strictly, and until now they existed only as review comments after the fact.
+- **Setup is a link, not a copy.** The README already documents self-hosting with the full environment variable list; duplicating it into CONTRIBUTING would produce two sets of instructions that drift apart, and the one nobody updates is the one people read.
+- **DCO rather than a CLA, and the difference matters.** `git commit -s` certifies that a contributor had the right to submit their work. It does *not* assign copyright, and it does *not* grant the right to relicense their contribution later. A CLA would, at the cost of friction that deters casual contributors. With zero outside contributions to date nothing is foreclosed either way, so the decision waits until someone actually opens a pull request.
+- **Contributor Covenant 2.1, verbatim**, with the one `[INSERT CONTACT METHOD]` placeholder filled with the same address `SECURITY.md` uses. It governs the repository's issues and pull requests. It is not a claim about what the software does for streamers, which stays true to Overlabels not being a safety tool.
+
 ## August 9th, 2026 - chore(license): Overlabels is AGPL-3.0-or-later
 
 The repository has never had a licence. `composer.json` said `"license": "MIT"`, which arrived in `783b81fc "Laravel? Pretty cool!"` as part of the starter kit's default metadata and was never a decision anyone made. Meanwhile GitHub reported no licence at all, because there was no `LICENSE` file to report. Those two facts contradicted each other in public on every commit.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,5 +1,18 @@
 # CHANGELOG AUGUST 2026
 
+## August 9th, 2026 - chore(github): issue forms that ask the questions I was going to ask anyway
+
+GitHub's community standards checklist wants five files. Two of them earn their place on merit and the rest are paperwork for a repo recruiting contributors, which this one is not. These are the two.
+
+- **The bug form asks where in Overlabels and where you were viewing it**, because those two answers do most of the narrowing. An overlay misbehaving in OBS but fine in a browser tab is a different bug from one that is broken in both, and that question used to cost a round trip every single time.
+- **It asks for the overlay slug and explicitly not the URL.** The part after `#` in an overlay URL is the access token, and someone reporting a rendering bug should not have to already know that before pasting what looks like the obvious identifier.
+- **The console field explains how to get one.** OBS browser sources cannot show console errors, so "check the console" is useless advice on its own; the field tells you to open the same URL in a normal tab and press F12.
+- **Only two fields are required**, plus a checkbox confirming this is not a security report. The audience here is streamers, and a form that demands a commit SHA and a minimal reproduction is a form that gets abandoned.
+- **Security reports are routed away from the issue tracker** in three places: the intro text, a contact link that sends you to `SECURITY.md`, and that required checkbox. `SECURITY.md` asks for private disclosure and an issue form is exactly where someone would ignore it by accident.
+- **The idea form asks what you were trying to do on stream** before it asks what you want built, and asks how you work around it today. The workaround is frequently the smaller feature.
+- **The PR template is a checklist for me**, since I am the only person opening pull requests here. It pins the changelog entry, the migration rollback, and the two rules I break most often: em dashes in user-facing copy, and saying "Fork" where the UI says "Copy".
+- **No licence file yet.** `composer.json` still claims MIT from the Laravel skeleton while the repo has none, which is a contradiction rather than a missing checkbox, and it is a product decision that deserves its own sitting rather than a drive-by fix.
+
 ## August 8th, 2026 - fix(previews): control tags resolve in previews
 
 `getSampleTemplateData()` returns 53 keys and every one of them is a static Twitch tag. There is not a single `c:` key in it, and there never was, so no control has ever resolved in any preview on any surface. `[[[followers_total]]]` worked and `[[[c:myname]]]` did not, which is the entire pattern behind "control-heavy overlays show basically nothing in preview".

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "packages": {
         "": {
             "version": "0.1.0",
+            "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@codemirror/lang-css": "^6.3.1",
                 "@codemirror/lang-html": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "version": "0.1.0",
+    "license": "AGPL-3.0-or-later",
     "type": "module",
     "scripts": {
         "build": "vite build",


### PR DESCRIPTION
GitHub's community standards checklist flagged five missing files. Two of them earned their place on merit, one turned out to be an actual contradiction sitting in a public repo, and two were paperwork. This does all five.

## The licence was the real finding

`composer.json` declared `"license": "MIT"` while the repository had no `LICENSE` file at all, so GitHub reported no licence. Those two facts contradicted each other on every commit.

Verified before acting on it:

- No `LICENSE`, `license*` or `COPYING*` file has ever existed in this repository's history (`git log --all --diff-filter=A`).
- The MIT line traces to `783b81fc "Laravel? Pretty cool!"`, the initial Laravel scaffold commit. It was starter-kit default metadata, never a deliberate grant.

**Now AGPL-3.0-or-later.** Overlabels is a hosted service with an unwritten sustainability plan. MIT lets anyone take this codebase closed and run a competing hosted Overlabels. AGPL section 13 means anyone hosting a *modified* version must offer its source to their users. It keeps the open-source claim in `SECURITY.md` honest without giving away the product itself. The usual cost of copyleft is deterring contributors, and with 1398 commits from one person and zero forks, that cost is currently zero.

Details worth knowing:

- The licence body is **byte-identical** to `gnu.org/licenses/agpl-3.0.txt`, verified with `cmp`. The copyright line sits in a header *above* it rather than inside it, because the document's own terms permit verbatim copies only. That header is the FSF's recommended notice, and its "or (at your option) any later version" clause is what encodes the `-or-later`.
- Four manifests agree: `composer.json` off MIT, `package.json` gained a `license` field it never had, `package-lock.json` root entry regenerated via `npm install --package-lock-only` (one line, zero dependency churn). No third-party `license` field in the lockfile was touched, since those describe other people's packages.
- **Forward-only.** No history rewritten, no force-push. Code distributed while the manifest advertised MIT was distributed under that advertisement, and this does not retroactively change that. With zero forks the exposure is theoretical, but the README says what happened rather than claiming the switch was clean.
- The README separates source-code terms from user-created template terms, because the Copying section promises "no licensing restrictions" on templates and a licence section further down is exactly where someone would conflate the two.

## Issue forms and PR template

The bug form front-loads the two questions that do most of the narrowing: which part of Overlabels, and OBS versus a normal browser tab. It asks for the overlay **slug** and explicitly warns off the full URL, since the fragment is the access token. The console field explains how to get console output at all, given OBS browser sources cannot show it. Two required fields plus a not-a-security-report checkbox; security reports are routed to `SECURITY.md` from the intro text, a contact link, and that checkbox.

The PR template is a self-checklist: changelog entry, tests, lint/pint, migration rollback, responsive, and the two copy rules most often broken.

## CONTRIBUTING and code of conduct

Both were downstream of the licence, which is why they land in the same PR.

CONTRIBUTING leads with "open an issue before starting anything substantial" and the note that this project grows by accretion rather than redesign, because a well-built rewrite of a working area is the PR most likely to be declined here. It links to the README for setup instead of duplicating it, and writes down the user-facing copy rules for the first time.

Code of conduct is Contributor Covenant 2.1 verbatim, contact placeholder filled with the address `SECURITY.md` already uses. It governs this repository's issues and pull requests; it makes no claim about what the software does for streamers.

## One open decision

Sign-off is **DCO, not a CLA**. A DCO certifies a contributor had the right to submit their work. It does *not* assign copyright and does *not* grant the right to relicense their contribution later; only a CLA does that. With zero outside contributions nothing is foreclosed either way, so this can be decided the first time someone actually opens a pull request. Flagging it because AGPL was chosen partly to keep commercial options open, and that is the hinge.

## Verification

- All three issue-form YAML files parse (`symfony/yaml`); labels `Bug` and `Enhancement` match existing repo labels.
- `composer validate` passes; `AGPL-3.0-or-later` accepted as a valid SPDX identifier.
- All three JSON manifests valid.
- Zero em dashes across every authored file; all internal links resolve; both README anchors exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)