### PR TITLE
fix(license): make GitHub detect the licence as AGPL-3.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,4 @@
-Overlabels
 Copyright (c) 2026 JasperDiscovers
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-The full text of the license follows, reproduced verbatim.
-
-================================================================================
 
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007

--- a/README.md
+++ b/README.md
@@ -734,6 +734,24 @@ What this means in practice:
   controls you create with Overlabels - those are yours, and the copying rules for them are
   described under [Copying](#copying).
 
+### Copyright notice
+
+```
+Overlabels
+Copyright (c) 2026 JasperDiscovers
+
+This program is free software: you can redistribute it and/or modify it under the terms of the
+GNU Affero General Public License as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program.
+If not, see <https://www.gnu.org/licenses/>.
+```
+
 ---
 
 ## Contributing

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,17 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 9th, 2026 - fix(license): GitHub reported the licence as "Other"
+
+The relicense landed and GitHub's API still returned `{"key":"other","name":"Other"}`. The community checklist went green because that only asks whether a licence file exists, but the repo sidebar said "Other" and anything reading the licence programmatically got nothing.
+
+- **The header above the licence text was the cause.** GitHub runs [licensee](https://github.com/licensee/licensee), which normalises `LICENSE` and needs 98% similarity to a known licence. It strips copyright lines specifically, but the header also carried the FSF "This program is free software" notice, a title line and a separator rule. Running licensee locally scored the file at **88.91%** against AGPL-3.0, nowhere near the threshold and a long way from the ~98% that had been assumed when the header was written.
+- **The fix is one line of header instead of nineteen.** `Copyright (c) 2026 JasperDiscovers`, a blank line, then the verbatim text. That line matches the copyright regex licensee strips, so what remains is the canonical document. Scores **98.86%** via the Dice matcher.
+- **Pure verbatim with no header scores 100% via the Exact matcher**, and is what most AGPL projects ship. It was not chosen because the copyright line is wanted in the file; the 98.86% result is deterministic rather than fuzzy, so the smaller margin costs nothing in practice.
+- **The FSF notice moved to the README's licence section**, which is its actual home. It is the "how to apply these terms to your program" boilerplate, not part of the licence, and it was never doing any work inside `LICENSE`.
+- **The licence body is still byte-identical to `gnu.org/licenses/agpl-3.0.txt`**, re-verified with `cmp` after the change.
+- **Verified before pushing this time, not predicted.** `licensee detect .` on the working tree returns `License: AGPL-3.0`, with `LICENSE`, `README.md` and `package.json` all matching. The previous round asserted GitHub would detect it cleanly on reasoning alone and was wrong by nine percentage points.
+
 ## August 9th, 2026 - docs(community): CONTRIBUTING and a code of conduct
 
 The last two items on GitHub's community checklist, written now rather than earlier because both were downstream of the licence. CONTRIBUTING is where the sign-off requirement lives, and that requirement did not exist until there was a licence for contributions to be made under.


### PR DESCRIPTION
#201 relicensed the project, but GitHub's API still reports the licence as `Other`:

```json
{"licenseInfo":{"key":"other","name":"Other","nickname":""}}
```

The community standards checklist went green regardless, because it only asks whether a licence file exists. But the repo sidebar shows "Other" and anything reading the licence programmatically gets nothing useful.

## Cause

GitHub runs [licensee](https://github.com/licensee/licensee), which normalises `LICENSE` and needs 98% similarity to a known licence text. It strips copyright lines specifically, but the header added in #201 also carried the FSF "This program is free software" notice, a title line, and a separator rule.

Measured locally with licensee 10.1.0 rather than guessed:

```
LICENSE:
  License:  NOASSERTION
  Closest non-matching licenses:
    AGPL-3.0 similarity:  88.91%
```

88.91%, against a 98% threshold. #201 asserted on reasoning alone that GitHub would detect this cleanly, and was wrong by nine percentage points.

## Fix

Header cut from nineteen lines to one. `Copyright (c) 2026 JasperDiscovers`, a blank line, then the verbatim text. That line matches the copyright regex licensee strips, so what remains is the canonical document.

Both viable candidates were measured before choosing:

| Candidate | Confidence | Matcher | Result |
|---|---|---|---|
| Bare copyright line + verbatim | **98.86%** | Dice | AGPL-3.0 |
| Pure verbatim, no header | **100.00%** | Exact | AGPL-3.0 |
| Current (`main`) | 88.91% | none | NOASSERTION |

Pure verbatim scores 100% and is what most AGPL projects ship, but the copyright line is wanted in the file. The 98.86% result is deterministic rather than fuzzy, so the smaller margin costs nothing in practice.

The FSF notice moves to the README's licence section, which is its actual home. It is the "how to apply these terms to your program" boilerplate, not part of the licence, and it was doing no work inside `LICENSE`.

## Verification

Run against the working tree before pushing:

```
License:        AGPL-3.0
Matched files:  LICENSE, README.md, package.json
LICENSE:
  Confidence:  98.86%
  Matcher:     Licensee::Matchers::Dice
  License:     AGPL-3.0
```

All three sources now agree. The licence body is still byte-identical to `gnu.org/licenses/agpl-3.0.txt`, re-verified with `cmp` after the change.

I will re-query the GitHub API once this merges to confirm the sidebar reads AGPL-3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)