### PR TITLE
fix(deps): bump nanoid to 3.3.18 for CVE-2026-67213

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,15 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 9th, 2026 - fix(deps): nanoid 3.3.16 to 3.3.18 for CVE-2026-67213
+
+Dependabot alert 92, high severity: custom nanoid generators can loop indefinitely when size is zero. Fixed in 3.3.17; the lockfile picked up 3.3.18.
+
+- **Transitive and build-time only.** One `nanoid` in the tree, required by `postcss` at `^3.3.16`, which arrives via `tailwindcss` and `@tailwindcss/vite`. GitHub labels the scope "runtime" because those two sit in `dependencies` rather than `devDependencies`, but postcss runs under Vite at build time and nanoid never reaches a browser bundle. The practical exposure was nil; the fix was a three-line lockfile change, so the calculus never got interesting.
+- **`npm update nanoid` was enough** because the existing `^3.3.16` range already admits the patch. No manifest edit, no override, no forced resolution.
+- **`npm run build` verified afterwards**, clean in 5.33s. A dependency bump that is not build-checked is a guess, even a patch-level one.
+- **This is the security-advisory carve-out to "let majors cook"**, not a departure from it. Patch releases that close an advisory go in immediately; the waiting rule is about majors and feature minors.
+
 ## August 9th, 2026 - fix(license): GitHub reported the licence as "Other"
 
 The relicense landed and GitHub's API still returned `{"key":"other","name":"Other"}`. The community checklist went green because that only asks whether a licence file exists, but the repo sidebar said "Other" and anything reading the licence programmatically got nothing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3963,9 +3963,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
Closes Dependabot alert [#92](https://github.com/jasperfrontend/overlabels/security/dependabot/92). It was the only open alert on the repo.

## The advisory

| | |
|---|---|
| Severity | **High** |
| CVE | `CVE-2026-67213` |
| GHSA | `GHSA-2v37-7h3g-55p8` |
| Summary | custom generators can loop indefinitely when size is zero |
| Vulnerable | `< 3.3.17` |
| Installed | `3.3.16` -> **`3.3.18`** |

## Actual exposure: none

There is exactly one `nanoid` in the tree, required by `postcss` at `^3.3.16`, which arrives via `tailwindcss` and `@tailwindcss/vite`.

GitHub reports the scope as `runtime`, but that is an artefact of those two packages sitting in `dependencies` rather than `devDependencies`. postcss runs under Vite at **build time**; nanoid never reaches a browser bundle, and nothing in this project calls a custom generator with size zero.

Fixed regardless, because the cost was three lines of lockfile.

## The change

The existing `^3.3.16` range already admits the patch, so `npm update nanoid` was sufficient. No manifest edit, no `overrides` block, no forced resolution. `package-lock.json` is the only file changed apart from the changelog.

## Verification

`npm run build` clean in 5.33s after the bump. A dependency change that has not been build-checked is a guess, even at patch level.

`public/build` is gitignored, so the build produced no incidental diff.

## On timing

This is the security-advisory carve-out to the project's "let majors cook" rule, not a departure from it. Patch releases that close an advisory go in immediately; the waiting applies to majors and feature minors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)