### PR TITLE
docs(claude): stop and warn on a dirty working tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,26 @@ Always create migrations for schema changes. Test rollback before committing. Us
 
 ## Workflow Preferences
 
+### STOP: check the working tree first
+
+**At the start of EVERY conversation, run `git status` before doing anything the user asked for.**
+
+If the working tree is dirty (any modified, staged, or untracked files), **do not start the task**.
+Stop, show the user exactly which files are dirty, and tell them the tree should be cleaned first -
+committed, stashed, or discarded, their choice. Then wait.
+
+Be strict about this. Jasper consistently forgets he has uncommitted work in progress, and it is not
+good: the risk is that unrelated changes get swept into a commit, or that his work in progress gets
+clobbered by a checkout, a stash, or a branch switch that a later step needs to make.
+
+- This applies to the whole tree, not just files related to the request. Dirty is dirty.
+- Being careful to stage selectively is **not** a substitute for stopping. Do that only after he
+  has been told and has decided to continue.
+- The only way past this is Jasper explicitly saying to proceed anyway after being warned. Once he
+  has said so, continue without raising it again for the rest of that conversation.
+
+### Committing and pushing
+
 - At the end of every logical unit of work, prepare a commit: update CHANGELOG (docs/changelog/changelog-YYYY-MM.md - per-month files) first, then commit everything together - one commit. Do NOT push automatically. Ask the user for confirmation before pushing.
 - If unsure whether to commit first or apply changes first, commit first then apply
 - NEVER use em dashes in user-facing copy or code. Use hyphens with spaces instead.


### PR DESCRIPTION
Adds a blocking precondition to `CLAUDE.md`'s workflow section, at Jasper's request.

## The rule

Run `git status` at the start of every conversation, before doing anything that was asked for. If the tree is dirty - modified, staged or untracked, related to the request or not - stop, show which files, and wait.

Three clauses that make it actually work rather than merely exist:

- **Dirty is dirty.** It applies to the whole tree, not just files touching the current task.
- **Staging selectively is explicitly not a substitute for stopping.** That is the loophole that would otherwise swallow the rule, since carefully avoiding the dirty files feels responsible and skips the warning entirely.
- **There is an escape hatch.** Jasper saying "proceed anyway" after being warned clears it for the rest of that conversation. Without one, a strict rule becomes unworkable and gets ignored.

## Why

Jasper consistently forgets he has work in progress. The concrete risks are unrelated changes being swept into a commit, and work in progress being clobbered by a checkout, stash or branch switch that a later step needs to make.

The first of those happened during the session that produced this rule, minutes after it was written: an unrelated two-file commit landed on the branch behind security PR #203 and would have been pushed into that PR on the next push. It was caught before pushing and moved to its own branch, but that is the exact failure mode, demonstrated live.

## Not changelogged

`docs/changelog/` is a product changelog and every entry in it is a product or infrastructure change. "Claude checks git status first" would be noise there. Happy to add one if that call is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)