### PR TITLE
ui(builder): fade the block name label in on hover

### DIFF
--- a/docs/design/overlabels-dsl-spec.md
+++ b/docs/design/overlabels-dsl-spec.md
@@ -1,3 +1,4 @@
+
 # The Overlabels DSL - Specification
 
 > **Status:** first written 2026-07-28; **shared spec implemented the same day.** Sections 1-6 are

--- a/resources/js/components/builder/BuilderPlacement.vue
+++ b/resources/js/components/builder/BuilderPlacement.vue
@@ -139,7 +139,7 @@ const gridArea = computed(
   <div
     :style="{ gridArea, outline, outlineOffset: `-${px(selected ? OUTLINE_SELECTED_PX : OUTLINE_PX)}` }"
     :class="[
-      'group relative min-h-0 min-w-0 cursor-grab touch-none overflow-hidden select-none active:cursor-grabbing',
+      'group transition-all relative min-h-0 min-w-0 cursor-grab touch-none overflow-hidden select-none active:cursor-grabbing',
       selected ? 'z-10' : '',
     ]"
     @click.stop="emit('select', placement.instance_id)"
@@ -153,7 +153,7 @@ const gridArea = computed(
       :title="placement.block_name"
     />
     <div
-      class="pointer-events-none absolute truncate bg-sidebar-accent/90 font-mono text-foreground"
+      class="pointer-events-none absolute truncate bg-sidebar-accent/90 font-mono text-foreground opacity-0 transition-opacity duration-300 group-hover:opacity-100"
       :style="{ ...chipStyle, left: cornerInset, fontSize: px(12), padding: `${px(1)} ${px(6)}` }"
     >
       {{ placement.block_name }}


### PR DESCRIPTION
Jasper's work in progress, moved onto its own branch. The commit is his; this PR is the wrapper.

## What changes

`BuilderPlacement.vue`:

- `transition-all` added to the placement wrapper
- the block name chip goes from permanently visible to `opacity-0` with `group-hover:opacity-100` and a 300ms fade

So the label stops competing for attention until you point at the block. Reads as a follow-on to `b5a1b166 "ui(builder): move the block name out from under the resize grip"` - that one got the label out of the way of the resize grip, this one gets it out of the way entirely until wanted.

`overlabels-dsl-spec.md`: a leading blank line.

## Provenance

This commit was originally made on `fix/nanoid-advisory`, the branch behind security PR #203, where it would have been pushed into that PR on the next push. It was moved before that happened: parked on a new branch, then rebased onto `main` so it carries only these two files. Nothing was rewritten on the nanoid branch beyond resetting it back to the commit origin already had.

## Note

No changelog entry. By the project's own workflow this wants one before merge - flagging rather than writing it, since the change is Jasper's to describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)