### PR TITLE
Rebuild the Add Control modal as a two-step picker

### DIFF
--- a/resources/js/components/ControlFormModal.vue
+++ b/resources/js/components/ControlFormModal.vue
@@ -197,7 +197,7 @@ const dialogDescription = computed(() => {
 });
 
 /**
- * Placeholders follow the chosen type. A switch suggesting "Death counter"
+ * Placeholders follow the chosen type. A switch suggesting "Win counter"
  * teaches the wrong thing about what a switch is for, so the example comes from
  * the catalog entry and matches that type's demo.
  */
@@ -534,6 +534,17 @@ async function save() {
       @open-auto-focus="onOpenAutoFocus"
     >
       <div class="border-b border-sidebar-border px-6 py-5 sm:px-8">
+        <!-- Mirrors the footer's Back. The dialog is tall enough that the
+             footer can be a long way from where the eye is. -->
+        <button
+          v-if="step === 'configure' && !isEditing"
+          type="button"
+          class="mb-2 flex cursor-pointer items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+          @click="backToPicker"
+        >
+          <ArrowLeft class="size-3.5" />
+          Back to all controls
+        </button>
         <DialogTitle class="text-2xl font-semibold tracking-tight text-foreground">{{ dialogTitle }}</DialogTitle>
         <DialogDescription class="mt-1.5 max-w-4xl text-sm text-foreground/75">
           {{ dialogDescription }}
@@ -557,7 +568,7 @@ async function save() {
         <div
           v-if="step === 'configure'"
           class="grid gap-8 lg:grid-cols-3"
-          :class="form.type === 'expression' && !isPresetMode ? 'xl:grid-cols-4' : ''"
+          :class="form.type === 'expression' && !isPresetMode ? 'xl:grid-cols-[6fr_6fr_8fr]' : ''"
         >
           <!-- Rail: what you picked, why it is good, and the tag you will paste. -->
           <aside class="space-y-5 lg:col-span-1">
@@ -919,10 +930,12 @@ async function save() {
             </section>
           </div>
 
-          <!-- Expression builder gets its own column, because a formula needs room. -->
+          <!-- Expression builder gets its own column, because a formula needs room.
+               At xl the three columns are 30/30/40 (see grid-cols above), so each
+               takes a single track; below that the builder drops to its own row. -->
           <div
             v-if="form.type === 'expression' && !isPresetMode"
-            class="lg:col-span-3 xl:col-span-2"
+            class="lg:col-span-3 xl:col-span-1"
           >
             <ExpressionBuilder
               v-model="expressionText"

--- a/resources/js/components/ControlFormModal.vue
+++ b/resources/js/components/ControlFormModal.vue
@@ -1,40 +1,25 @@
 <script setup lang="ts">
-import { ref, watch, computed, nextTick } from 'vue';
+import { ref, watch, computed, nextTick, onBeforeUnmount } from 'vue';
 import axios from 'axios';
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
+  DialogDescription,
   DialogTitle,
-  DialogFooter,
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
-import {
-  Combobox,
-  ComboboxAnchor,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxGroup,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxLabel,
-  ComboboxTrigger,
-} from '@/components/ui/combobox';
-import { ChevronsUpDownIcon } from '@lucide/vue';
+import { ArrowLeft, Check, Copy, Lightbulb } from '@lucide/vue';
 import ExpressionBuilder from '@/components/controls/ExpressionBuilder.vue';
+import ControlTypePicker from '@/components/controls/ControlTypePicker.vue';
+import ControlTypeCard from '@/components/controls/ControlTypeCard.vue';
+import ProviderIcon from '@/components/ProviderIcon.vue';
 import {
-  ALERTS_PRESETS,
-  KOFI_PRESETS,
-  GPS_PRESETS,
-  STREAMLABS_PRESETS,
-  FOURTHWALL_PRESETS,
-  BMAC_PRESETS,
-  THRONE_PRESETS,
-  TWITCH_PRESETS,
-  getPresetsForSource,
-  type ServicePreset,
-} from '@/components/controls/controlPresets';
-import { fuzzyMatch, presetHaystack } from '@/utils/services';
+  controlTypeMeta,
+  PRESET_GROUPS,
+  SERVICE_ACCENT,
+} from '@/components/controls/controlTypeCatalog';
+import { getPresetsForSource, type ServicePreset } from '@/components/controls/controlPresets';
+import { serviceLabel } from '@/utils/services';
 import type { OverlayControl, OverlayTemplate } from '@/types';
 
 interface UserList {
@@ -62,20 +47,28 @@ const emit = defineEmits<{
 }>();
 
 const isEditing = computed(() => !!props.control);
+const isCopying = computed(() => !isEditing.value && !!props.copyFrom);
 const saving = ref(false);
 const errors = ref<Record<string, string>>({});
 const booleanValue = ref(false);
 const manualInputRef = ref<HTMLInputElement | null>(null);
 const labelInputRef = ref<HTMLInputElement | null>(null);
+const pickerRef = ref<InstanceType<typeof ControlTypePicker> | null>(null);
 
-function focusLabelInput(event: Event) {
-  event.preventDefault();
-  nextTick(() => {
-    labelInputRef.value?.focus();
-  });
-}
+/**
+ * The modal is two screens, not one long scroll. `pick` sells the eight control
+ * types and the ready-made service controls side by side; `configure` fills in
+ * the one you chose. Editing and duplicating skip straight to `configure`,
+ * because the type is already settled in both cases.
+ */
+type Step = 'pick' | 'configure';
+const step = ref<Step>('pick');
 
-// Service preset selection
+// --- Service preset selection -----------------------------------------------
+// Written only by selectPreset/clearPreset. It used to be a combobox v-model
+// with a watcher that reset the form when it emptied, which made "clear the
+// preset, then set a type" order-dependent: the watcher ran after the sync
+// code and clobbered the type that had just been set.
 const servicePresetKey = ref('');
 const servicePresetSource = ref<string | null>(null);
 
@@ -86,118 +79,57 @@ const selectedServicePreset = computed(() => {
   return presets.find((p) => p.key === key) ?? null;
 });
 
-function displayPresetValue(combinedKey: string): string {
-  if (!combinedKey) return '';
-  const separatorIndex = combinedKey.indexOf(':');
-  if (separatorIndex < 0) return '';
-  const source = combinedKey.substring(0, separatorIndex);
-  const key = combinedKey.substring(separatorIndex + 1);
-  const preset = getPresetsForSource(source).find((p) => p.key === key);
-  return preset ? preset.label : '';
+/** Group label first ("Overlabels alerts"), service label as the fallback. */
+function presetSourceLabel(source: string): string {
+  return PRESET_GROUPS.find((g) => g.source === source)?.label ?? serviceLabel(source);
 }
 
-const isCopying = computed(() => !isEditing.value && !!props.copyFrom);
-const showKofiPresets = computed(
-  () => !isEditing.value && !isCopying.value && props.template?.type === 'static' && (props.connectedServices ?? []).includes('kofi'),
-);
-const showGpsPresets = computed(
-  () => !isEditing.value && !isCopying.value && props.template?.type === 'static' && (props.connectedServices ?? []).includes('gps'),
-);
-const showStreamLabsPresets = computed(
-  () => !isEditing.value && !isCopying.value && props.template?.type === 'static' && (props.connectedServices ?? []).includes('streamlabs'),
-);
-const showFourthwallPresets = computed(
-  () => !isEditing.value && !isCopying.value && props.template?.type === 'static' && (props.connectedServices ?? []).includes('fourthwall'),
-);
-const showBmacPresets = computed(
-  () => !isEditing.value && !isCopying.value && props.template?.type === 'static' && (props.connectedServices ?? []).includes('bmac'),
-);
-const showThronePresets = computed(
-  () => !isEditing.value && !isCopying.value && props.template?.type === 'static' && (props.connectedServices ?? []).includes('throne'),
-);
-const showTwitchPresets = computed(
-  () => !isEditing.value && !isCopying.value && props.template?.type === 'static',
-);
-// System presets (alerts:muted): no integration required, so same visibility
-// rule as the Twitch presets.
-const showAlertsPresets = computed(
-  () => !isEditing.value && !isCopying.value && props.template?.type === 'static',
-);
-
-// Filter out presets that already exist as controls on this template
-function isPresetAlreadyAdded(source: string, key: string): boolean {
-  return (props.existingControls ?? []).some(
-    (c) => c.source === source && c.key === key,
-  );
-}
-
-// Current text in the ComboboxInput. Reka's default filter is disabled via
-// `ignore-filter` on the Combobox; we do fuzzy subsequence matching against
-// `label + service display name + source key` so typing "overla" finds every
-// Overlabels Mobile preset, "kofi" matches "Ko-fi", etc.
-const presetSearch = ref('');
-
-function matchesPresetSearch(source: string, preset: ServicePreset): boolean {
-  return fuzzyMatch(presetSearch.value.trim(), presetHaystack(source, preset.label));
-}
-
-const availableTwitchPresets = computed(() =>
-  TWITCH_PRESETS.filter((p) => !isPresetAlreadyAdded('twitch', p.key) && matchesPresetSearch('twitch', p)),
-);
-const availableAlertsPresets = computed(() =>
-  ALERTS_PRESETS.filter((p) => !isPresetAlreadyAdded('alerts', p.key) && matchesPresetSearch('alerts', p)),
-);
-const availableKofiPresets = computed(() =>
-  KOFI_PRESETS.filter((p) => !isPresetAlreadyAdded('kofi', p.key) && matchesPresetSearch('kofi', p)),
-);
-const availableGpsPresets = computed(() =>
-  GPS_PRESETS.filter((p) => !isPresetAlreadyAdded('gps', p.key) && matchesPresetSearch('gps', p)),
-);
-const availableStreamLabsPresets = computed(() =>
-  STREAMLABS_PRESETS.filter((p) => !isPresetAlreadyAdded('streamlabs', p.key) && matchesPresetSearch('streamlabs', p)),
-);
-const availableFourthwallPresets = computed(() =>
-  FOURTHWALL_PRESETS.filter((p) => !isPresetAlreadyAdded('fourthwall', p.key) && matchesPresetSearch('fourthwall', p)),
-);
-const availableBmacPresets = computed(() =>
-  BMAC_PRESETS.filter((p) => !isPresetAlreadyAdded('bmac', p.key) && matchesPresetSearch('bmac', p)),
-);
-const availableThronePresets = computed(() =>
-  THRONE_PRESETS.filter((p) => !isPresetAlreadyAdded('throne', p.key) && matchesPresetSearch('throne', p)),
-);
-
-watch(servicePresetKey, (combinedKey) => {
-  if (!combinedKey) {
-    form.value.key = '';
-    form.value.label = '';
-    form.value.type = 'text';
-    servicePresetSource.value = null;
-    errors.value = {};
-    return;
-  }
-
-  const separatorIndex = combinedKey.indexOf(':');
-  const source = combinedKey.substring(0, separatorIndex);
-  const key = combinedKey.substring(separatorIndex + 1);
-  const preset = getPresetsForSource(source).find((p) => p.key === key) ?? null;
-
-  if (preset) {
-    form.value.key = preset.key;
-    form.value.label = preset.label;
-    form.value.type = preset.type;
-    servicePresetSource.value = source;
-  } else {
-    form.value.key = '';
-    form.value.label = '';
-    form.value.type = 'text';
-    servicePresetSource.value = null;
-  }
+function selectPreset(source: string, preset: ServicePreset) {
+  servicePresetKey.value = `${source}:${preset.key}`;
+  servicePresetSource.value = source;
+  form.value.key = preset.key;
+  form.value.label = preset.label;
+  form.value.type = preset.type;
+  keyManuallyEdited.value = false;
   errors.value = {};
-});
+  step.value = 'configure';
+}
 
-// Sort order
+function selectType(type: OverlayControl['type']) {
+  // Coming from a preset, the label and key were the preset's, not the user's.
+  if (servicePresetKey.value) {
+    servicePresetKey.value = '';
+    servicePresetSource.value = null;
+    form.value.key = '';
+    form.value.label = '';
+    keyManuallyEdited.value = false;
+  }
+  form.value.type = type;
+  errors.value = {};
+  step.value = 'configure';
+}
+
+function backToPicker() {
+  step.value = 'pick';
+  errors.value = {};
+  nextTick(() => pickerRef.value?.focusSearch());
+}
+
+// --- Sort order --------------------------------------------------------------
 type SortMode = 'before' | 'after' | 'manual';
 const sortMode = ref<SortMode>('after');
+
+const SORT_MODES = [
+  { value: 'after', label: 'Last', hint: 'After everything else' },
+  { value: 'before', label: 'First', hint: 'Before everything else' },
+  { value: 'manual', label: 'Custom', hint: 'Pick the number yourself' },
+] as const;
+
+const TIMER_MODES = [
+  { value: 'countup', label: 'Count up', hint: 'From zero, upwards' },
+  { value: 'countdown', label: 'Count down', hint: 'From a duration you set' },
+  { value: 'countto', label: 'Count to', hint: 'Towards a date and time' },
+] as const;
 
 watch(sortMode, (newMode) => {
   if (newMode === 'manual') {
@@ -240,7 +172,71 @@ const form = ref({
   sort_order: 0,
 });
 
-// Auto-derive key from label
+// --- Presentation ------------------------------------------------------------
+const activeMeta = computed(() => controlTypeMeta(form.value.type));
+const isPresetMode = computed(() => !!selectedServicePreset.value);
+const accent = computed(() => (isPresetMode.value ? SERVICE_ACCENT : activeMeta.value.accent));
+
+const dialogTitle = computed(() => {
+  if (isEditing.value) return 'Edit control';
+  if (isCopying.value) return 'Duplicate control';
+  return 'Add a control';
+});
+
+const dialogDescription = computed(() => {
+  if (isEditing.value) {
+    return 'The name and description are yours to change any time. The key and the type are fixed once a control exists, because your templates already point at them.';
+  }
+  if (step.value === 'pick') {
+    return 'Controls are the parts of your overlay you can change while you are live. Pick what you want to add.';
+  }
+  if (isPresetMode.value && servicePresetSource.value && selectedServicePreset.value) {
+    return `${selectedServicePreset.value.label}, straight from ${presetSourceLabel(servicePresetSource.value)}. Give it a name you will recognise and choose where it sits.`;
+  }
+  return activeMeta.value.tagline;
+});
+
+/**
+ * Placeholders follow the chosen type. A switch suggesting "Death counter"
+ * teaches the wrong thing about what a switch is for, so the example comes from
+ * the catalog entry and matches that type's demo.
+ */
+const labelPlaceholder = computed(() => {
+  if (selectedServicePreset.value) return selectedServicePreset.value.label;
+  return `e.g. ${activeMeta.value.exampleName}`;
+});
+
+// Slugified with the same function that derives the real key, so the two
+// placeholders always demonstrate the actual name-to-key transformation.
+const keyPlaceholder = computed(() => `e.g. ${slugifyLabel(activeMeta.value.exampleName)}`);
+
+/** The tag the user will actually paste into their template. */
+const tagPreview = computed(() => {
+  if (selectedServicePreset.value && servicePresetSource.value) {
+    return `[[[c:${servicePresetSource.value}:${selectedServicePreset.value.key}]]]`;
+  }
+  return form.value.key ? `[[[c:${form.value.key}]]]` : '';
+});
+
+const tagCopied = ref(false);
+let tagCopyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function copyTag() {
+  if (!tagPreview.value || !navigator.clipboard) return;
+  navigator.clipboard.writeText(tagPreview.value).then(() => {
+    tagCopied.value = true;
+    if (tagCopyTimeout) clearTimeout(tagCopyTimeout);
+    tagCopyTimeout = setTimeout(() => {
+      tagCopied.value = false;
+    }, 1500);
+  });
+}
+
+onBeforeUnmount(() => {
+  if (tagCopyTimeout) clearTimeout(tagCopyTimeout);
+});
+
+// --- Key derivation ----------------------------------------------------------
 const keyManuallyEdited = ref(false);
 const keyWarning = ref('');
 
@@ -274,21 +270,22 @@ watch(() => form.value.key, (key) => {
   keyWarning.value = validateKey(key);
 });
 
-// Expression control state
+// --- Expression / list writer state -----------------------------------------
 const expressionText = ref('');
 
-// List writer control state (type='list_writer'). Stored separately from
-// form.config so the picker bindings stay typed as IDs not strings.
+// Stored outside form.config so the picker bindings stay typed as IDs, not strings.
 const listWriter = ref({
   source_control_id: '' as number | '',
   target_list_id: '' as number | '',
 });
 
-// Controls available as watch targets for expression controls.
-// Service-managed controls can exist as both a user-scoped row (overlay_template_id=null,
-// auto-provisioned/backfilled) and a template-scoped row created when the user adds the
-// preset to this template. Both share the same `c.source.key` reference, so we dedupe
-// by (source, key) and prefer the template-scoped one.
+/**
+ * Controls available as watch targets for expression and list-writer controls.
+ * A service control can exist as both a user-scoped row (auto-provisioned) and
+ * a template-scoped row created when the preset was added here. Both share the
+ * same `c.source.key` reference, so dedupe by (source, key), preferring the
+ * template-scoped one.
+ */
 const availableWatchControls = computed(() => {
   const templateControls = (props.existingControls ?? []).filter(
     (c) => c.id !== props.control?.id,
@@ -302,89 +299,118 @@ const availableWatchControls = computed(() => {
 });
 
 watch(() => props.open, (open) => {
-  if (open) {
-    errors.value = {};
-    keyManuallyEdited.value = false;
-    keyWarning.value = '';
-    servicePresetKey.value = '';
-    servicePresetSource.value = null;
-    if (props.control) {
-      const c = props.control;
-      const cfg = c.config ?? {};
-      form.value = {
-        key: c.key,
-        label: c.label ?? '',
-        description: c.description ?? '',
-        type: c.type,
-        value: c.value ?? '',
-        config: {
-          min: cfg.min ?? undefined,
-          max: cfg.max ?? undefined,
-          step: cfg.step ?? 1,
-          reset_value: cfg.reset_value ?? 0,
-          random: cfg.random ?? false,
-          random_interval: cfg.random_interval ?? 1000,
-          mode: cfg.mode ?? 'countup',
-          base_seconds: cfg.base_seconds ?? 0,
-          target_datetime: cfg.target_datetime ?? '',
-        },
-        sort_order: c.sort_order,
-      };
-      booleanValue.value = c.value === '1';
-      sortMode.value = 'manual';
-      expressionText.value = c.type === 'expression' ? (cfg.expression ?? '') : '';
-      listWriter.value = c.type === 'list_writer'
-        ? {
-            source_control_id: (cfg.source_control_id ?? '') as number | '',
-            target_list_id: (cfg.target_list_id ?? '') as number | '',
-          }
-        : { source_control_id: '', target_list_id: '' };
-    } else if (props.copyFrom) {
-      const c = props.copyFrom;
-      const cfg = c.config ?? {};
-      form.value = {
-        key: '',
-        label: `${c.label || c.key} (copy)`,
-        description: c.description ?? '',
-        type: c.type,
-        value: c.value ?? '',
-        config: {
-          min: cfg.min ?? undefined,
-          max: cfg.max ?? undefined,
-          step: cfg.step ?? 1,
-          reset_value: cfg.reset_value ?? 0,
-          random: cfg.random ?? false,
-          random_interval: cfg.random_interval ?? 1000,
-          mode: cfg.mode ?? 'countup',
-          base_seconds: cfg.base_seconds ?? 0,
-          target_datetime: cfg.target_datetime ?? '',
-        },
-        sort_order: 0,
-      };
-      booleanValue.value = c.value === '1';
-      sortMode.value = 'after';
-      expressionText.value = c.type === 'expression' ? (cfg.expression ?? '') : '';
-      listWriter.value = c.type === 'list_writer'
-        ? {
-            source_control_id: (cfg.source_control_id ?? '') as number | '',
-            target_list_id: (cfg.target_list_id ?? '') as number | '',
-          }
-        : { source_control_id: '', target_list_id: '' };
-    } else {
-      form.value = {
-        key: '',
-        label: '',
-        description: '',
-        type: 'text',
-        value: '',
-        config: { min: undefined, max: undefined, step: 1, reset_value: 0, random: false, random_interval: 1000, mode: 'countup', base_seconds: 0, target_datetime: '' },
-        sort_order: 0,
-      };
-      booleanValue.value = false;
-      sortMode.value = 'after';
-      expressionText.value = '';
-      listWriter.value = { source_control_id: '', target_list_id: '' };
+  if (!open) return;
+
+  errors.value = {};
+  keyManuallyEdited.value = false;
+  keyWarning.value = '';
+  servicePresetKey.value = '';
+  servicePresetSource.value = null;
+  tagCopied.value = false;
+
+  if (props.control) {
+    const c = props.control;
+    const cfg = c.config ?? {};
+    form.value = {
+      key: c.key,
+      label: c.label ?? '',
+      description: c.description ?? '',
+      type: c.type,
+      value: c.value ?? '',
+      config: {
+        min: cfg.min ?? undefined,
+        max: cfg.max ?? undefined,
+        step: cfg.step ?? 1,
+        reset_value: cfg.reset_value ?? 0,
+        random: cfg.random ?? false,
+        random_interval: cfg.random_interval ?? 1000,
+        mode: cfg.mode ?? 'countup',
+        base_seconds: cfg.base_seconds ?? 0,
+        target_datetime: cfg.target_datetime ?? '',
+      },
+      sort_order: c.sort_order,
+    };
+    // An existing service control keeps its service identity in the rail.
+    if (c.source && getPresetsForSource(c.source).some((p) => p.key === c.key)) {
+      servicePresetKey.value = `${c.source}:${c.key}`;
+      servicePresetSource.value = c.source;
     }
+    booleanValue.value = c.value === '1';
+    sortMode.value = 'manual';
+    expressionText.value = c.type === 'expression' ? (cfg.expression ?? '') : '';
+    listWriter.value = c.type === 'list_writer'
+      ? {
+          source_control_id: (cfg.source_control_id ?? '') as number | '',
+          target_list_id: (cfg.target_list_id ?? '') as number | '',
+        }
+      : { source_control_id: '', target_list_id: '' };
+    step.value = 'configure';
+  } else if (props.copyFrom) {
+    const c = props.copyFrom;
+    const cfg = c.config ?? {};
+    form.value = {
+      key: '',
+      label: `${c.label || c.key} (copy)`,
+      description: c.description ?? '',
+      type: c.type,
+      value: c.value ?? '',
+      config: {
+        min: cfg.min ?? undefined,
+        max: cfg.max ?? undefined,
+        step: cfg.step ?? 1,
+        reset_value: cfg.reset_value ?? 0,
+        random: cfg.random ?? false,
+        random_interval: cfg.random_interval ?? 1000,
+        mode: cfg.mode ?? 'countup',
+        base_seconds: cfg.base_seconds ?? 0,
+        target_datetime: cfg.target_datetime ?? '',
+      },
+      sort_order: 0,
+    };
+    booleanValue.value = c.value === '1';
+    sortMode.value = 'after';
+    expressionText.value = c.type === 'expression' ? (cfg.expression ?? '') : '';
+    listWriter.value = c.type === 'list_writer'
+      ? {
+          source_control_id: (cfg.source_control_id ?? '') as number | '',
+          target_list_id: (cfg.target_list_id ?? '') as number | '',
+        }
+      : { source_control_id: '', target_list_id: '' };
+    step.value = 'configure';
+  } else {
+    form.value = {
+      key: '',
+      label: '',
+      description: '',
+      type: 'text',
+      value: '',
+      config: { min: undefined, max: undefined, step: 1, reset_value: 0, random: false, random_interval: 1000, mode: 'countup', base_seconds: 0, target_datetime: '' },
+      sort_order: 0,
+    };
+    booleanValue.value = false;
+    sortMode.value = 'after';
+    expressionText.value = '';
+    listWriter.value = { source_control_id: '', target_list_id: '' };
+    step.value = 'pick';
+  }
+});
+
+/** Land focus where the user is about to type, on open and on every step change. */
+function focusStep() {
+  nextTick(() => {
+    if (step.value === 'pick') pickerRef.value?.focusSearch();
+    else labelInputRef.value?.focus();
+  });
+}
+
+function onOpenAutoFocus(event: Event) {
+  event.preventDefault();
+  focusStep();
+}
+
+watch(step, (value) => {
+  if (value === 'configure') {
+    nextTick(() => labelInputRef.value?.focus());
   }
 });
 
@@ -502,429 +528,434 @@ async function save() {
 
 <template>
   <Dialog :open="open" @update:open="emit('update:open', $event)">
-    <DialogContent :class="form.type === 'expression' ? 'max-w-300' : 'max-w-lg'" @open-auto-focus="focusLabelInput">
-      <DialogHeader>
-        <DialogTitle>{{ isEditing ? 'Edit Control' : copyFrom ? 'Duplicate Control' : 'Add Control' }}</DialogTitle>
-      </DialogHeader>
-
-      <div :class="form.type === 'expression' ? 'grid grid-cols-1 gap-6 py-2 md:grid-cols-2' : 'space-y-4 py-2'">
-        <!-- Left column (or single column for non-expression types) -->
-        <div class="space-y-4">
-          <p v-if="errors.general" class="text-sm text-destructive">{{ errors.general }}</p>
-
-          <!-- Service Presets -->
-          <div v-if="showTwitchPresets || showAlertsPresets || showKofiPresets || showGpsPresets || showStreamLabsPresets || showFourthwallPresets || showBmacPresets || showThronePresets" class="space-y-2 border border-violet-400/30 bg-violet-400/5 p-3">
-            <div class="flex items-center justify-between gap-2">
-              <p class="text-sm font-medium text-violet-500 dark:text-violet-400">Stream Controls</p>
-              <a
-                href="/help/integration-presets"
-                target="_blank"
-                rel="noopener"
-                class="cursor-pointer text-xs text-violet-500 hover:underline dark:text-violet-400"
-              >
-                Browse all presets &rarr;
-              </a>
-            </div>
-            <p class="text-xs text-foreground">
-              Service controls are shared across all your overlays automatically - adding one here makes it
-              available everywhere, you don't add it per overlay.
-            </p>
-            <Combobox v-model="servicePresetKey" open-on-click open-on-focus ignore-filter>
-              <ComboboxAnchor>
-                <ComboboxInput
-                  v-model="presetSearch"
-                  :display-value="displayPresetValue"
-                  placeholder="Search preset controls..."
-                />
-                <ComboboxTrigger>
-                  <ChevronsUpDownIcon class="size-4 shrink-0" />
-                </ComboboxTrigger>
-              </ComboboxAnchor>
-              <ComboboxContent>
-                <ComboboxEmpty>No presets found.</ComboboxEmpty>
-                <ComboboxGroup v-if="showTwitchPresets && availableTwitchPresets.length">
-                  <ComboboxLabel>Twitch - Per-Stream Counters</ComboboxLabel>
-                  <ComboboxItem
-                    v-for="preset in availableTwitchPresets"
-                    :key="'twitch:' + preset.key"
-                    :value="'twitch:' + preset.key"
-                  >
-                    {{ preset.label }} ({{ preset.type }})
-                  </ComboboxItem>
-                </ComboboxGroup>
-                <ComboboxGroup v-if="showAlertsPresets && availableAlertsPresets.length">
-                  <ComboboxLabel>Overlabels - Alerts</ComboboxLabel>
-                  <ComboboxItem
-                    v-for="preset in availableAlertsPresets"
-                    :key="'alerts:' + preset.key"
-                    :value="'alerts:' + preset.key"
-                  >
-                    {{ preset.label }} ({{ preset.type }})
-                  </ComboboxItem>
-                </ComboboxGroup>
-                <ComboboxGroup v-if="showKofiPresets && availableKofiPresets.length">
-                  <ComboboxLabel>Ko-fi</ComboboxLabel>
-                  <ComboboxItem
-                    v-for="preset in availableKofiPresets"
-                    :key="'kofi:' + preset.key"
-                    :value="'kofi:' + preset.key"
-                  >
-                    {{ preset.label }} ({{ preset.type }})
-                  </ComboboxItem>
-                </ComboboxGroup>
-                <ComboboxGroup v-if="showGpsPresets && availableGpsPresets.length">
-                  <ComboboxLabel>Overlabels GPS</ComboboxLabel>
-                  <ComboboxItem
-                    v-for="preset in availableGpsPresets"
-                    :key="'gps:' + preset.key"
-                    :value="'gps:' + preset.key"
-                  >
-                    {{ preset.label }} ({{ preset.type }})
-                  </ComboboxItem>
-                </ComboboxGroup>
-                <ComboboxGroup v-if="showStreamLabsPresets && availableStreamLabsPresets.length">
-                  <ComboboxLabel>StreamLabs</ComboboxLabel>
-                  <ComboboxItem
-                    v-for="preset in availableStreamLabsPresets"
-                    :key="'streamlabs:' + preset.key"
-                    :value="'streamlabs:' + preset.key"
-                  >
-                    {{ preset.label }} ({{ preset.type }})
-                  </ComboboxItem>
-                </ComboboxGroup>
-                <ComboboxGroup v-if="showFourthwallPresets && availableFourthwallPresets.length">
-                  <ComboboxLabel>Fourthwall</ComboboxLabel>
-                  <ComboboxItem
-                    v-for="preset in availableFourthwallPresets"
-                    :key="'fourthwall:' + preset.key"
-                    :value="'fourthwall:' + preset.key"
-                  >
-                    {{ preset.label }} ({{ preset.type }})
-                  </ComboboxItem>
-                </ComboboxGroup>
-                <ComboboxGroup v-if="showBmacPresets && availableBmacPresets.length">
-                  <ComboboxLabel>Buy Me a Coffee</ComboboxLabel>
-                  <ComboboxItem
-                    v-for="preset in availableBmacPresets"
-                    :key="'bmac:' + preset.key"
-                    :value="'bmac:' + preset.key"
-                  >
-                    {{ preset.label }} ({{ preset.type }})
-                  </ComboboxItem>
-                </ComboboxGroup>
-                <ComboboxGroup v-if="showThronePresets && availableThronePresets.length">
-                  <ComboboxLabel>Throne</ComboboxLabel>
-                  <ComboboxItem
-                    v-for="preset in availableThronePresets"
-                    :key="'throne:' + preset.key"
-                    :value="'throne:' + preset.key"
-                  >
-                    {{ preset.label }} ({{ preset.type }})
-                  </ComboboxItem>
-                </ComboboxGroup>
-              </ComboboxContent>
-            </Combobox>
-            <p v-if="selectedServicePreset && servicePresetSource" class="text-xs text-muted-foreground">
-              Use <code class="rounded bg-black/10 px-1 dark:bg-white/10">[[[c:{{ servicePresetSource }}:{{ selectedServicePreset.key }}]]]</code>
-              in your template. Value is managed automatically{{ servicePresetSource === 'twitch' ? ' - resets when you go live' : '' }}.
-            </p>
-          </div>
-
-          <!-- Label (always shown) -->
-          <div class="space-y-2">
-            <Label for="ctrl-label">Give your control a name <span class="text-muted-foreground text-xs">(be descriptive)</span></Label>
-            <input
-              id="ctrl-label"
-              ref="labelInputRef"
-              v-model="form.label"
-              :placeholder="selectedServicePreset ? selectedServicePreset.label : 'e.g. Death Counter'"
-              class="input-border w-full"
-              :class="{ 'border-destructive': errors.label }"
-            />
-            <p v-if="errors.label" class="text-xs text-destructive">{{ errors.label }}</p>
-          </div>
-
-          <!-- Description (always shown) -->
-          <div class="space-y-2">
-            <Label for="ctrl-description">Description <span class="text-muted-foreground text-xs">(optional)</span></Label>
-            <textarea
-              id="ctrl-description"
-              v-model="form.description"
-              rows="2"
-              maxlength="1000"
-              placeholder="What does this control do? Notes for your future self."
-              class="input-border w-full"
-              :class="{ 'border-destructive': errors.description }"
-            />
-            <p v-if="errors.description" class="text-xs text-destructive">{{ errors.description }}</p>
-          </div>
-
-          <!-- Only show manual fields if no service preset selected -->
-          <template v-if="!selectedServicePreset">
-            <!-- Key (immutable after creation) -->
-            <div class="space-y-2">
-              <Label for="ctrl-key">Key <span class="text-muted-foreground text-xs">(auto-generated from name)</span></Label>
-              <input
-                id="ctrl-key"
-                v-model="form.key"
-                :disabled="isEditing"
-                placeholder="e.g. death_counter"
-                class="input-border w-full"
-                :class="{ 'border-destructive': errors.key, 'border-amber-500': !errors.key && keyWarning }"
-                @input="keyManuallyEdited = true"
-              />
-              <p v-if="errors.key" class="text-xs text-destructive">{{ errors.key }}</p>
-              <p v-else-if="keyWarning" class="text-xs text-amber-500">{{ keyWarning }}</p>
-              <p v-if="form.key && !errors.key && !keyWarning" class="text-xs text-muted-foreground">
-                Template tag: <code class="rounded bg-black/10 px-1 dark:bg-white/10">[[[c:{{ form.key }}]]]</code>
-              </p>
-              <p v-if="!isEditing && !form.key" class="text-xs text-muted-foreground">Cannot be changed after creation.</p>
-            </div>
-          </template>
-
-
-          <!-- Only show type/value/config if no service preset selected -->
-          <template v-if="!selectedServicePreset">
-            <!-- Type -->
-            <div v-if="!isEditing" class="space-y-2">
-              <Label for="ctrl-type">Type</Label>
-              <select
-                id="ctrl-type"
-                v-model="form.type"
-                class="w-full input-border"
-              >
-                <option value="text">Text</option>
-                <option value="number">Number</option>
-                <option value="counter">Counter</option>
-                <option value="timer">Timer</option>
-                <option value="datetime">Date/Time</option>
-                <option value="boolean">Boolean (on/off switch)</option>
-                <option value="expression">Expression (formula)</option>
-                <option value="list_writer">List writer (log values to a list)</option>
-              </select>
-              <p v-if="errors.type" class="text-xs text-destructive">{{ errors.type }}</p>
-            </div>
-
-            <!-- Value (text/number/counter) -->
-            <div v-if="['text', 'number', 'counter'].includes(form.type)" class="space-y-2">
-              <Label for="ctrl-value">{{ isEditing ? 'Value' : 'Initial Value' }} <span class="text-muted-foreground text-xs">(optional)</span></Label>
-              <input
-                id="ctrl-value"
-                v-model="form.value"
-                :type="form.type === 'number' || form.type === 'counter' ? 'number' : 'text'"
-                placeholder="Leave blank to start empty"
-                class="input-border w-full"
-              />
-              <p v-if="errors.value" class="text-xs text-destructive">{{ errors.value }}</p>
-            </div>
-
-            <!-- Value (datetime) -->
-            <div v-if="form.type === 'datetime'" class="space-y-2">
-              <Label for="ctrl-value-dt">{{ isEditing ? 'Value' : 'Initial Value' }} <span class="text-muted-foreground text-xs">(optional)</span></Label>
-              <input
-                id="ctrl-value-dt"
-                v-model="form.value"
-                type="datetime-local"
-                class="input-border w-full"
-              />
-              <p v-if="errors.value" class="text-xs text-destructive">{{ errors.value }}</p>
-            </div>
-
-            <!-- Value (boolean) -->
-            <div v-if="form.type === 'boolean'" class="space-y-2">
-              <Label>{{ isEditing ? 'Value' : 'Initial Value' }}</Label>
-              <div class="flex items-center gap-3 pt-1">
-                <label class="relative inline-flex cursor-pointer items-center">
-                  <input type="checkbox" v-model="booleanValue" class="peer sr-only" />
-                  <span
-                    class="peer h-6 w-10 rounded-full bg-gray-300 peer-checked:bg-green-400 peer-focus:outline-none
-                    after:absolute after:inset-s-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white
-                    after:transition-all after:content-[''] peer-checked:after:translate-x-4 dark:bg-gray-600
-                    dark:peer-checked:bg-green-800 dark:after:bg-gray-100"
-                  ></span>
-                </label>
-                <span class="text-sm text-muted-foreground">{{ booleanValue ? 'On (true)' : 'Off (false)' }}</span>
-              </div>
-              <p v-if="errors.value" class="text-xs text-destructive">{{ errors.value }}</p>
-            </div>
-
-            <!-- Number/Counter config -->
-            <div v-if="form.type === 'number' || form.type === 'counter'" class="space-y-3 rounded-sm border border-sidebar p-3">
-              <p class="text-sm font-medium">Numeric settings</p>
-              <div class="grid grid-cols-2 gap-3">
-                <div class="space-y-2">
-                  <Label for="ctrl-min">Min</Label>
-                  <input id="ctrl-min" class="input-border" v-model.number="form.config.min" type="number" placeholder="No limit" />
-                </div>
-                <div class="space-y-2">
-                  <Label for="ctrl-max">Max</Label>
-                  <input id="ctrl-max" class="input-border" v-model.number="form.config.max" type="number" placeholder="No limit" />
-                </div>
-                <div class="space-y-2">
-                  <Label for="ctrl-step">Step</Label>
-                  <input id="ctrl-step" class="input-border" v-model.number="form.config.step" type="number" min="0" step="any" />
-                </div>
-                <div class="space-y-2">
-                  <Label for="ctrl-reset">Reset value</Label>
-                  <input id="ctrl-reset" class="input-border" v-model.number="form.config.reset_value" type="number" step="any" />
-                </div>
-              </div>
-              <div class="flex items-center gap-2">
-                <input
-                  id="ctrl-random"
-                  type="checkbox"
-                  v-model="form.config.random"
-                  class="size-4 rounded border-input"
-                />
-                <Label for="ctrl-random" class="cursor-pointer">Random mode</Label>
-              </div>
-              <div v-if="form.config.random" class="space-y-2">
-                <Label for="ctrl-random-interval">Update interval (ms)</Label>
-                <input
-                  id="ctrl-random-interval"
-                  class="w-full input-border"
-                  v-model.number="form.config.random_interval"
-                  type="number" min="100" step="100" placeholder="1000"
-                />
-                <p class="text-xs text-muted-foreground">
-                  How often to generate a new random value. Default: 1000ms (1 second).
-                </p>
-              </div>
-            </div>
-
-            <!-- List writer config: source control + target list -->
-            <div v-if="form.type === 'list_writer'" class="space-y-3 rounded-sm border border-sidebar p-3">
-              <p class="text-xs text-muted-foreground">
-                Every time the source control's value changes, the new value is appended to the
-                target list. Works for any control type including Expression Controls.
-              </p>
-              <div class="space-y-2">
-                <Label for="ctrl-lw-source">Source control</Label>
-                <select
-                  id="ctrl-lw-source"
-                  v-model="listWriter.source_control_id"
-                  class="input-border w-full"
-                >
-                  <option value="">— pick a control —</option>
-                  <option
-                    v-for="c in availableWatchControls"
-                    :key="c.id"
-                    :value="c.id"
-                  >
-                    {{ c.label || c.key }} ({{ c.type }}{{ c.source ? `, ${c.source}` : '' }})
-                  </option>
-                </select>
-                <p v-if="errors['config.source_control_id']" class="text-xs text-destructive">
-                  {{ errors['config.source_control_id'] }}
-                </p>
-              </div>
-              <div class="space-y-2">
-                <Label for="ctrl-lw-target">Target list</Label>
-                <select
-                  id="ctrl-lw-target"
-                  v-model="listWriter.target_list_id"
-                  class="input-border w-full"
-                >
-                  <option value="">— pick a list —</option>
-                  <option
-                    v-for="l in (props.userLists ?? [])"
-                    :key="l.id"
-                    :value="l.id"
-                  >
-                    {{ l.label || l.slug }} ({{ l.items_count }} item{{ l.items_count === 1 ? '' : 's' }}{{ l.disabled ? ', disabled' : '' }})
-                  </option>
-                </select>
-                <p v-if="errors['config.target_list_id']" class="text-xs text-destructive">
-                  {{ errors['config.target_list_id'] }}
-                </p>
-                <p v-if="(props.userLists ?? []).length === 0" class="text-xs text-amber-500">
-                  You don't have any Lists yet. Create one from the Lists dashboard first.
-                </p>
-              </div>
-            </div>
-
-            <!-- Timer config -->
-            <div v-if="form.type === 'timer'" class="space-y-3 rounded-sm border border-sidebar p-3">
-              <p class="text-sm font-medium">Timer settings</p>
-              <div class="space-y-2">
-                <Label>Mode</Label>
-                <div class="flex flex-wrap gap-4">
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input type="radio" v-model="form.config.mode" value="countup" />
-                    <span class="text-sm">Count up</span>
-                  </label>
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input type="radio" v-model="form.config.mode" value="countdown" />
-                    <span class="text-sm">Count down</span>
-                  </label>
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input type="radio" v-model="form.config.mode" value="countto" />
-                    <span class="text-sm">Count to date/time</span>
-                  </label>
-                </div>
-              </div>
-              <div v-if="form.config.mode === 'countdown'" class="space-y-2">
-                <Label for="ctrl-base">Base duration (seconds)</Label>
-                <input id="ctrl-base" class="w-full input-border" v-model.number="form.config.base_seconds" type="number" min="0" />
-              </div>
-              <div v-if="form.config.mode === 'countto'" class="space-y-2">
-                <Label for="ctrl-target">Target date/time</Label>
-                <input
-                  id="ctrl-target"
-                  v-model="form.config.target_datetime"
-                  type="datetime-local"
-                  class="w-full input-border"
-                />
-                <p class="text-xs text-muted-foreground">The timer will count down the seconds remaining until this date and time.</p>
-              </div>
-            </div>
-          </template>
-
-          <!-- Sort order -->
-          <div class="space-y-2">
-            <Label for="ctrl-sort">Position</Label>
-            <select
-              id="ctrl-sort"
-              v-model="sortMode"
-              class="w-full input-border"
-            >
-              <option value="after">After existing (last)</option>
-              <option value="before">Before existing (first)</option>
-              <option value="manual">Enter sort order manually</option>
-            </select>
-            <label
-              v-if="sortMode === 'manual'"
-              for="position-manual-input" class="mt-1.5 block text-sm font-medium text-foreground">Enter manual sort order</label>
-
-            <input
-              v-if="sortMode === 'manual'"
-              id="position-manual-input"
-              v-model.number="form.sort_order"
-              ref="manualInputRef"
-              type="number"
-              min="0"
-              placeholder="0"
-              class="w-full input-border"
-            />
-            <p v-if="errors.sort_order" class="text-xs text-destructive">{{ errors.sort_order }}</p>
-          </div>
-        </div>
-
-        <!-- Right column: Expression builder (only when type is expression) -->
-        <ExpressionBuilder
-          v-if="form.type === 'expression' && !selectedServicePreset"
-          v-model="expressionText"
-          :available-controls="availableWatchControls"
-          :errors="errors"
-        />
+    <DialogContent
+      class="grid h-[92vh] max-h-[92vh] w-[95vw] max-w-[1500px] gap-0 overflow-hidden p-0"
+      style="grid-template-rows: auto minmax(0, 1fr) auto"
+      @open-auto-focus="onOpenAutoFocus"
+    >
+      <div class="border-b border-sidebar-border px-6 py-5 sm:px-8">
+        <DialogTitle class="text-2xl font-semibold tracking-tight text-foreground">{{ dialogTitle }}</DialogTitle>
+        <DialogDescription class="mt-1.5 max-w-4xl text-sm text-foreground/75">
+          {{ dialogDescription }}
+        </DialogDescription>
       </div>
 
-      <DialogFooter>
-        <button class="btn btn-cancel" @click="emit('update:open', false)">Cancel</button>
-        <button class="btn btn-primary" :disabled="saving" @click="save">
-          {{ saving ? 'Saving...' : isEditing ? 'Save changes' : 'Add control' }}
+      <!-- Body: the only scroll container, so the footer is always reachable. -->
+      <div class="overflow-y-auto px-6 py-6 sm:px-8">
+        <!-- v-show, not v-if: the search survives a trip into configure and back.
+             display:none also keeps these controls out of the tab order. -->
+        <ControlTypePicker
+          v-show="step === 'pick'"
+          ref="pickerRef"
+          :template="template"
+          :connected-services="connectedServices"
+          :existing-controls="existingControls"
+          @select-type="selectType"
+          @select-preset="selectPreset"
+        />
+
+        <div
+          v-if="step === 'configure'"
+          class="grid gap-8 lg:grid-cols-3"
+          :class="form.type === 'expression' && !isPresetMode ? 'xl:grid-cols-4' : ''"
+        >
+          <!-- Rail: what you picked, why it is good, and the tag you will paste. -->
+          <aside class="space-y-5 lg:col-span-1">
+            <ControlTypeCard v-if="!isPresetMode" :meta="activeMeta" selected />
+
+            <div v-else class="border bg-background p-4" :class="SERVICE_ACCENT.ring">
+              <div class="flex items-start gap-3">
+                <span class="flex size-10 shrink-0 items-center justify-center" :class="SERVICE_ACCENT.icon">
+                  <ProviderIcon :source="servicePresetSource ?? ''" class="size-5" />
+                </span>
+                <div class="min-w-0 flex-1">
+                  <h3 class="text-base leading-tight font-semibold text-foreground">
+                    {{ selectedServicePreset?.label }}
+                  </h3>
+                  <p class="mt-1 text-sm leading-snug text-foreground/75">
+                    Managed by {{ presetSourceLabel(servicePresetSource ?? '') }}. The value keeps itself up to date,
+                    you never set it by hand.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <!-- Good for -->
+            <div v-if="!isPresetMode" class="space-y-2">
+              <h4 class="text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">Good for</h4>
+              <ul class="space-y-1.5">
+                <li v-for="use in activeMeta.goodFor" :key="use" class="flex items-start gap-2 text-sm text-foreground">
+                  <!-- Accent comes from a catalog literal. Never build a class
+                       string at runtime here: Tailwind only generates what it
+                       can see spelled out in source. -->
+                  <Check class="mt-0.5 size-3.5 shrink-0" :class="accent.text" />
+                  <span>{{ use }}</span>
+                </li>
+              </ul>
+            </div>
+
+            <p v-if="!isPresetMode" class="text-sm text-foreground/75">{{ activeMeta.blurb }}</p>
+
+            <p
+              v-if="isPresetMode && servicePresetSource === 'twitch'"
+              class="flex items-start gap-2 border-l-2 border-amber-400/50 pl-3 text-xs text-foreground/75"
+            >
+              <Lightbulb class="mt-0.5 size-3.5 shrink-0 text-amber-500 dark:text-amber-400" />
+              <span>Per-stream counters reset themselves the moment you go live. The "latest" values do not, they
+                carry over between streams.</span>
+            </p>
+
+            <!-- The tag you paste -->
+            <div class="space-y-2">
+              <h4 class="text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                Paste this in your template
+              </h4>
+              <button
+                v-if="tagPreview"
+                type="button"
+                class="flex w-full cursor-pointer items-center justify-between gap-2 border border-border/60 bg-foreground/3 px-3 py-2 text-left transition hover:border-violet-500/50 dark:bg-black/25 dark:hover:border-violet-400/50"
+                :title="tagCopied ? 'Copied' : 'Copy to clipboard'"
+                @click="copyTag"
+              >
+                <code class="truncate font-mono text-xs text-foreground">{{ tagPreview }}</code>
+                <Check v-if="tagCopied" class="size-3.5 shrink-0 text-green-500" />
+                <Copy v-else class="size-3.5 shrink-0 text-muted-foreground" />
+              </button>
+              <p v-else class="border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
+                Give it a name and your tag appears here.
+              </p>
+            </div>
+
+            <button
+              v-if="!isEditing"
+              type="button"
+              class="flex cursor-pointer items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+              @click="backToPicker"
+            >
+              <ArrowLeft class="size-3.5" />
+              Pick a different control
+            </button>
+            <p v-else class="text-xs text-muted-foreground">
+              The type cannot be changed after a control is created.
+            </p>
+          </aside>
+
+          <!-- The form itself -->
+          <div
+            class="space-y-8 lg:col-span-2"
+            :class="form.type === 'expression' && !isPresetMode ? 'xl:col-span-1' : ''"
+          >
+            <p v-if="errors.general" class="border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+              {{ errors.general }}
+            </p>
+
+            <!-- Name it -->
+            <section class="space-y-4">
+              <h3 class="border-b border-border/60 pb-2 text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                Name it
+              </h3>
+
+              <div class="grid gap-4" :class="isPresetMode ? '' : 'sm:grid-cols-2'">
+                <div class="space-y-2">
+                  <Label for="ctrl-label">Name</Label>
+                  <input
+                    id="ctrl-label"
+                    ref="labelInputRef"
+                    v-model="form.label"
+                    :placeholder="labelPlaceholder"
+                    class="input-border w-full"
+                    :class="{ 'border-destructive': errors.label }"
+                  />
+                  <p v-if="errors.label" class="text-xs text-destructive">{{ errors.label }}</p>
+                  <p v-else class="text-xs text-muted-foreground">
+                    This is what you will see in your dashboard while you are live. Be descriptive.
+                  </p>
+                </div>
+
+                <div v-if="!isPresetMode" class="space-y-2">
+                  <Label for="ctrl-key">Key</Label>
+                  <input
+                    id="ctrl-key"
+                    v-model="form.key"
+                    :disabled="isEditing"
+                    :placeholder="keyPlaceholder"
+                    class="input-border w-full font-mono disabled:cursor-not-allowed disabled:opacity-60"
+                    :class="{ 'border-destructive': errors.key, 'border-amber-500': !errors.key && keyWarning }"
+                    @input="keyManuallyEdited = true"
+                  />
+                  <p v-if="errors.key" class="text-xs text-destructive">{{ errors.key }}</p>
+                  <p v-else-if="keyWarning" class="text-xs text-amber-500">{{ keyWarning }}</p>
+                  <p v-else-if="isEditing" class="text-xs text-muted-foreground">
+                    Fixed. Your templates already point at this.
+                  </p>
+                  <p v-else class="text-xs text-muted-foreground">
+                    Written for you from the name. Cannot be changed after you save.
+                  </p>
+                </div>
+              </div>
+
+              <div class="space-y-2">
+                <Label for="ctrl-description">Description <span class="text-xs text-muted-foreground">(optional)</span></Label>
+                <textarea
+                  id="ctrl-description"
+                  v-model="form.description"
+                  rows="2"
+                  maxlength="1000"
+                  placeholder="What does this control do? Notes for your future self."
+                  class="input-border w-full"
+                  :class="{ 'border-destructive': errors.description }"
+                />
+                <p v-if="errors.description" class="text-xs text-destructive">{{ errors.description }}</p>
+              </div>
+            </section>
+
+            <template v-if="!isPresetMode">
+              <!-- Starting value -->
+              <section
+                v-if="['text', 'number', 'counter', 'datetime', 'boolean'].includes(form.type)"
+                class="space-y-4"
+              >
+                <h3 class="border-b border-border/60 pb-2 text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                  {{ isEditing ? 'Value' : 'Starting value' }}
+                </h3>
+
+                <div v-if="['text', 'number', 'counter'].includes(form.type)" class="space-y-2">
+                  <input
+                    id="ctrl-value"
+                    v-model="form.value"
+                    :type="form.type === 'number' || form.type === 'counter' ? 'number' : 'text'"
+                    placeholder="Leave blank to start empty"
+                    class="input-border w-full"
+                  />
+                  <p v-if="errors.value" class="text-xs text-destructive">{{ errors.value }}</p>
+                </div>
+
+                <div v-if="form.type === 'datetime'" class="space-y-2">
+                  <input id="ctrl-value-dt" v-model="form.value" type="datetime-local" class="input-border w-full" />
+                  <p v-if="errors.value" class="text-xs text-destructive">{{ errors.value }}</p>
+                </div>
+
+                <div v-if="form.type === 'boolean'" class="space-y-2">
+                  <div class="flex items-center gap-3">
+                    <label class="relative inline-flex cursor-pointer items-center">
+                      <input v-model="booleanValue" type="checkbox" class="peer sr-only" />
+                      <span
+                        class="peer h-6 w-10 rounded-full bg-gray-300 after:absolute after:inset-s-0.5 after:top-0.5
+                        after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-all after:content-['']
+                        peer-checked:bg-green-400 peer-checked:after:translate-x-4 peer-focus:outline-none
+                        dark:bg-gray-600 dark:after:bg-gray-100 dark:peer-checked:bg-green-800"
+                      ></span>
+                    </label>
+                    <span class="text-sm text-foreground">{{ booleanValue ? 'On (true)' : 'Off (false)' }}</span>
+                  </div>
+                  <p v-if="errors.value" class="text-xs text-destructive">{{ errors.value }}</p>
+                </div>
+              </section>
+
+              <!-- Number / counter settings -->
+              <section v-if="form.type === 'number' || form.type === 'counter'" class="space-y-4">
+                <h3 class="border-b border-border/60 pb-2 text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                  Limits and steps
+                </h3>
+
+                <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                  <div class="space-y-2">
+                    <Label for="ctrl-min">Min</Label>
+                    <input id="ctrl-min" v-model.number="form.config.min" class="input-border w-full" type="number" placeholder="No limit" />
+                  </div>
+                  <div class="space-y-2">
+                    <Label for="ctrl-max">Max</Label>
+                    <input id="ctrl-max" v-model.number="form.config.max" class="input-border w-full" type="number" placeholder="No limit" />
+                  </div>
+                  <div class="space-y-2">
+                    <Label for="ctrl-step">Step</Label>
+                    <input id="ctrl-step" v-model.number="form.config.step" class="input-border w-full" type="number" min="0" step="any" />
+                  </div>
+                  <div class="space-y-2">
+                    <Label for="ctrl-reset">Reset to</Label>
+                    <input id="ctrl-reset" v-model.number="form.config.reset_value" class="input-border w-full" type="number" step="any" />
+                  </div>
+                </div>
+                <p class="text-xs text-muted-foreground">
+                  Step is how far one click of plus or minus moves it. Reset is where the reset button puts it back to.
+                </p>
+
+                <div class="flex items-center gap-2 pt-1">
+                  <input id="ctrl-random" v-model="form.config.random" type="checkbox" class="size-4 cursor-pointer rounded border-input" />
+                  <Label for="ctrl-random" class="cursor-pointer">Roll a random value on a timer instead</Label>
+                </div>
+                <div v-if="form.config.random" class="max-w-xs space-y-2">
+                  <Label for="ctrl-random-interval">How often (milliseconds)</Label>
+                  <input
+                    id="ctrl-random-interval"
+                    v-model.number="form.config.random_interval"
+                    class="input-border w-full"
+                    type="number"
+                    min="100"
+                    step="100"
+                    placeholder="1000"
+                  />
+                  <p class="text-xs text-muted-foreground">Default is 1000, which is once a second.</p>
+                </div>
+              </section>
+
+              <!-- Timer settings -->
+              <section v-if="form.type === 'timer'" class="space-y-4">
+                <h3 class="border-b border-border/60 pb-2 text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                  How it counts
+                </h3>
+
+                <div class="grid gap-2 sm:grid-cols-3">
+                  <button
+                    v-for="mode in TIMER_MODES"
+                    :key="mode.value"
+                    type="button"
+                    class="cursor-pointer border px-3 py-2 text-left transition duration-150"
+                    :class="
+                      form.config.mode === mode.value
+                        ? 'border-amber-500/60 bg-amber-500/8 dark:border-amber-400/50 dark:bg-amber-400/8'
+                        : 'border-border/60 hover:border-amber-500/40 dark:hover:border-amber-400/40'
+                    "
+                    @click="form.config.mode = mode.value"
+                  >
+                    <span class="block text-sm font-medium text-foreground">{{ mode.label }}</span>
+                    <span class="block text-xs text-muted-foreground">{{ mode.hint }}</span>
+                  </button>
+                </div>
+
+                <div v-if="form.config.mode === 'countdown'" class="max-w-xs space-y-2">
+                  <Label for="ctrl-base">Starting duration (seconds)</Label>
+                  <input id="ctrl-base" v-model.number="form.config.base_seconds" class="input-border w-full" type="number" min="0" />
+                  <p class="text-xs text-muted-foreground">3600 is one hour. Format it as hh:mm:ss in your template.</p>
+                </div>
+
+                <div v-if="form.config.mode === 'countto'" class="max-w-sm space-y-2">
+                  <Label for="ctrl-target">Target date and time</Label>
+                  <input id="ctrl-target" v-model="form.config.target_datetime" type="datetime-local" class="input-border w-full" />
+                  <p class="text-xs text-muted-foreground">Counts down the seconds remaining until this moment.</p>
+                </div>
+              </section>
+
+              <!-- List writer settings -->
+              <section v-if="form.type === 'list_writer'" class="space-y-4">
+                <h3 class="border-b border-border/60 pb-2 text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                  What it watches, where it writes
+                </h3>
+
+                <div class="grid gap-4 sm:grid-cols-2">
+                  <div class="space-y-2">
+                    <Label for="ctrl-lw-source">Watch this control</Label>
+                    <select id="ctrl-lw-source" v-model="listWriter.source_control_id" class="input-border w-full cursor-pointer">
+                      <option value="">Pick a control</option>
+                      <option v-for="c in availableWatchControls" :key="c.id" :value="c.id">
+                        {{ c.label || c.key }} ({{ c.type }}{{ c.source ? `, ${c.source}` : '' }})
+                      </option>
+                    </select>
+                    <p v-if="errors['config.source_control_id']" class="text-xs text-destructive">
+                      {{ errors['config.source_control_id'] }}
+                    </p>
+                  </div>
+
+                  <div class="space-y-2">
+                    <Label for="ctrl-lw-target">Append to this list</Label>
+                    <select id="ctrl-lw-target" v-model="listWriter.target_list_id" class="input-border w-full cursor-pointer">
+                      <option value="">Pick a list</option>
+                      <option v-for="l in (props.userLists ?? [])" :key="l.id" :value="l.id">
+                        {{ l.label || l.slug }} ({{ l.items_count }} item{{ l.items_count === 1 ? '' : 's' }}{{ l.disabled ? ', disabled' : '' }})
+                      </option>
+                    </select>
+                    <p v-if="errors['config.target_list_id']" class="text-xs text-destructive">
+                      {{ errors['config.target_list_id'] }}
+                    </p>
+                    <p v-if="(props.userLists ?? []).length === 0" class="text-xs text-amber-500">
+                      You do not have any Lists yet. Create one from the Lists dashboard first.
+                    </p>
+                  </div>
+                </div>
+                <p class="text-xs text-muted-foreground">
+                  Every time the watched control changes, its new value is appended to the list. Works with any control
+                  type, expressions included.
+                </p>
+              </section>
+            </template>
+
+            <!-- Position -->
+            <section class="space-y-4">
+              <h3 class="border-b border-border/60 pb-2 text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                Where it sits in your dashboard
+              </h3>
+
+              <div class="grid gap-2 sm:grid-cols-3">
+                <button
+                  v-for="mode in SORT_MODES"
+                  :key="mode.value"
+                  type="button"
+                  class="cursor-pointer border px-3 py-2 text-left transition duration-150"
+                  :class="
+                    sortMode === mode.value
+                      ? 'border-violet-500/60 bg-violet-500/8 dark:border-violet-400/50 dark:bg-violet-400/8'
+                      : 'border-border/60 hover:border-violet-500/40 dark:hover:border-violet-400/40'
+                  "
+                  @click="sortMode = mode.value"
+                >
+                  <span class="block text-sm font-medium text-foreground">{{ mode.label }}</span>
+                  <span class="block text-xs text-muted-foreground">{{ mode.hint }}</span>
+                </button>
+              </div>
+
+              <div v-if="sortMode === 'manual'" class="max-w-xs space-y-2">
+                <Label for="position-manual-input">Sort order</Label>
+                <input
+                  id="position-manual-input"
+                  ref="manualInputRef"
+                  v-model.number="form.sort_order"
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  class="input-border w-full"
+                />
+              </div>
+              <p v-if="errors.sort_order" class="text-xs text-destructive">{{ errors.sort_order }}</p>
+            </section>
+          </div>
+
+          <!-- Expression builder gets its own column, because a formula needs room. -->
+          <div
+            v-if="form.type === 'expression' && !isPresetMode"
+            class="lg:col-span-3 xl:col-span-2"
+          >
+            <ExpressionBuilder
+              v-model="expressionText"
+              :available-controls="availableWatchControls"
+              :errors="errors"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer: outside the scroll area, so Save never runs off the bottom. -->
+      <div class="flex items-center justify-between gap-3 border-t border-sidebar-border bg-sidebar-accent/40 px-6 py-4 sm:px-8">
+        <p v-if="step === 'pick'" class="text-sm text-muted-foreground">
+          Pick a control to carry on. You can change your mind on the next screen.
+        </p>
+        <button
+          v-else-if="!isEditing"
+          type="button"
+          class="flex cursor-pointer items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+          @click="backToPicker"
+        >
+          <ArrowLeft class="size-3.5" />
+          Back
         </button>
-      </DialogFooter>
+        <span v-else />
+
+        <div class="flex items-center gap-3">
+          <button class="btn btn-cancel" @click="emit('update:open', false)">Cancel</button>
+          <button v-if="step === 'configure'" class="btn btn-primary" :disabled="saving" @click="save">
+            {{ saving ? 'Saving...' : isEditing ? 'Save changes' : 'Add control' }}
+          </button>
+        </div>
+      </div>
     </DialogContent>
   </Dialog>
 </template>

--- a/resources/js/components/controls/ControlTypeCard.vue
+++ b/resources/js/components/controls/ControlTypeCard.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { Check } from '@lucide/vue';
+import type { ControlTypeMeta } from './controlTypeCatalog';
+
+/**
+ * One control type, sold. Renders the icon, the name, the one-line pitch and a
+ * small demo of what the control actually looks like once it is live.
+ *
+ * Used twice: as a clickable card in the picker grid, and as a static summary
+ * in the configure rail so the choice stays visible while the form is filled in.
+ */
+const props = withDefaults(
+  defineProps<{
+    meta: ControlTypeMeta;
+    /** Renders as a button and reacts to hover/focus. Off for the rail. */
+    selectable?: boolean;
+    /** Accent border plus a check badge. The rail uses this to affirm the choice. */
+    selected?: boolean;
+  }>(),
+  { selectable: false, selected: false },
+);
+
+// The timer demo actually ticks. A static "00:00:00" sells nothing; a clock
+// that is visibly running tells you what you are getting in one glance.
+const TIMER_BASE = 4 * 3600 + 32 * 60 + 9;
+const elapsed = ref(0);
+let ticker: ReturnType<typeof setInterval> | null = null;
+
+onMounted(() => {
+  if (props.meta.demo.kind !== 'timer') return;
+  ticker = setInterval(() => {
+    elapsed.value += 1;
+  }, 1000);
+});
+
+onBeforeUnmount(() => {
+  if (ticker) clearInterval(ticker);
+});
+
+const demoClock = computed(() => {
+  const total = TIMER_BASE + elapsed.value;
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  return [h, m, s].map((n) => String(n).padStart(2, '0')).join(':');
+});
+</script>
+
+<template>
+  <component
+    :is="selectable ? 'button' : 'div'"
+    :type="selectable ? 'button' : undefined"
+    :aria-pressed="selectable ? selected : undefined"
+    class="relative flex w-full flex-col overflow-hidden border bg-background p-4 text-left transition duration-150"
+    :class="[
+      selected ? meta.accent.ringSelected : meta.accent.ring,
+      selectable
+        ? ['cursor-pointer', meta.accent.ringHover, meta.accent.ringFocus, 'focus-visible:ring-2 focus-visible:outline-none']
+        : '',
+    ]"
+  >
+    <span
+      v-if="selected"
+      class="absolute top-3 right-3 flex size-5 items-center justify-center border"
+      :class="[meta.accent.ring, meta.accent.text]"
+      aria-hidden="true"
+    >
+      <Check class="size-3" />
+    </span>
+
+    <div class="relative flex items-start gap-3">
+      <span class="flex size-10 shrink-0 items-center justify-center" :class="meta.accent.icon">
+        <component :is="meta.icon" class="size-5" />
+      </span>
+      <div class="min-w-0 flex-1">
+        <h3 class="text-base leading-tight font-semibold text-foreground">{{ meta.name }}</h3>
+        <p class="mt-1 text-sm leading-snug text-foreground/75">{{ meta.tagline }}</p>
+      </div>
+    </div>
+
+    <!-- Demo: what this looks like once it is on screen. -->
+    <div class="relative mt-4 border border-border/50 bg-foreground/3 px-3 py-2.5 dark:bg-black/25">
+      <template v-if="meta.demo.kind === 'text'">
+        <span class="text-sm text-foreground">{{ meta.demo.value }}</span>
+      </template>
+
+      <template v-else-if="meta.demo.kind === 'stat'">
+        <div class="flex items-baseline justify-between gap-3">
+          <span class="text-xs tracking-wide text-muted-foreground uppercase">{{ meta.demo.label }}</span>
+          <span class="font-mono text-lg leading-none font-semibold text-foreground">{{ meta.demo.value }}</span>
+        </div>
+      </template>
+
+      <template v-else-if="meta.demo.kind === 'counter'">
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-xs tracking-wide text-muted-foreground uppercase">{{ meta.demo.label }}</span>
+          <span class="flex items-center gap-1.5">
+            <span class="flex size-5 items-center justify-center border border-border/60 text-xs text-muted-foreground">-</span>
+            <span class="min-w-8 text-center font-mono text-lg leading-none font-semibold text-foreground">{{ meta.demo.value }}</span>
+            <span class="flex size-5 items-center justify-center border border-border/60 text-xs text-muted-foreground">+</span>
+          </span>
+        </div>
+      </template>
+
+      <template v-else-if="meta.demo.kind === 'timer'">
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-xs tracking-wide text-muted-foreground uppercase">Subathon</span>
+          <span class="font-mono text-lg leading-none font-semibold tabular-nums text-foreground">{{ demoClock }}</span>
+        </div>
+      </template>
+
+      <template v-else-if="meta.demo.kind === 'datetime'">
+        <div class="flex items-baseline justify-between gap-3">
+          <span class="text-xs tracking-wide text-muted-foreground uppercase">Next stream</span>
+          <span class="text-sm font-medium text-foreground">{{ meta.demo.value }}</span>
+        </div>
+      </template>
+
+      <template v-else-if="meta.demo.kind === 'boolean'">
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-sm text-foreground">{{ meta.demo.label }}</span>
+          <span class="relative flex h-5 w-9 shrink-0 items-center rounded-full bg-violet-500/70 dark:bg-violet-400/60">
+            <span class="absolute right-0.5 size-4 rounded-full bg-white" />
+          </span>
+        </div>
+      </template>
+
+      <template v-else-if="meta.demo.kind === 'formula'">
+        <div class="space-y-1.5">
+          <code class="block truncate font-mono text-[11px] text-muted-foreground">{{ meta.demo.expression }}</code>
+          <div class="flex items-baseline justify-between gap-3">
+            <span class="text-xs tracking-wide text-muted-foreground uppercase">Win rate</span>
+            <span class="font-mono text-lg leading-none font-semibold text-foreground">{{ meta.demo.result }}%</span>
+          </div>
+        </div>
+      </template>
+
+      <template v-else-if="meta.demo.kind === 'pipe'">
+        <div class="flex items-center gap-2 overflow-hidden">
+          <code class="truncate font-mono text-[11px] text-muted-foreground">{{ meta.demo.from }}</code>
+          <span class="shrink-0 text-muted-foreground">&rarr;</span>
+          <span class="truncate text-xs text-foreground">{{ meta.demo.to }}</span>
+        </div>
+      </template>
+    </div>
+  </component>
+</template>

--- a/resources/js/components/controls/ControlTypePicker.vue
+++ b/resources/js/components/controls/ControlTypePicker.vue
@@ -1,0 +1,210 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { ExternalLink, Search } from '@lucide/vue';
+import ControlTypeCard from './ControlTypeCard.vue';
+import ProviderIcon from '@/components/ProviderIcon.vue';
+import { CONTROL_TYPES, PRESET_GROUPS } from './controlTypeCatalog';
+import { getPresetsForSource, type ServicePreset } from './controlPresets';
+import { fuzzyMatch, presetHaystack } from '@/utils/services';
+import type { OverlayControl, OverlayTemplate } from '@/types';
+
+/**
+ * Step one of "Add a control": choose what you are adding.
+ *
+ * Two routes sit side by side rather than behind tabs, because they answer
+ * different questions and hiding either one costs a discovery. On the left,
+ * the eight kinds you build yourself, each with a demo of what it looks like
+ * on screen. On the right, the ready-made controls that come wired up from
+ * Twitch and whichever services are connected.
+ *
+ * Each column owns its own search, sitting directly above the thing it
+ * filters. One shared search box read as if it drove the column it sat in
+ * while actually reshaping the other one.
+ */
+const props = defineProps<{
+  template: OverlayTemplate;
+  connectedServices?: string[];
+  existingControls?: OverlayControl[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'select-type', type: OverlayControl['type']): void;
+  (e: 'select-preset', source: string, preset: ServicePreset): void;
+}>();
+
+const typeSearch = ref('');
+const presetSearch = ref('');
+const typeSearchInput = ref<HTMLInputElement | null>(null);
+
+function focusSearch() {
+  typeSearchInput.value?.focus();
+}
+
+defineExpose({ focusSearch });
+
+const typeQuery = computed(() => typeSearch.value.trim());
+const presetQuery = computed(() => presetSearch.value.trim());
+
+/** Presets already on this template are not offered again. */
+function isAlreadyAdded(source: string, key: string): boolean {
+  return (props.existingControls ?? []).some((c) => c.source === source && c.key === key);
+}
+
+interface RenderedPresetGroup {
+  source: string;
+  label: string;
+  blurb: string;
+  presets: ServicePreset[];
+}
+
+/**
+ * One pass over the group table, replacing what used to be sixteen near
+ * identical computeds (a `show*` and an `available*` per service). Adding a
+ * ninth service is now a row in PRESET_GROUPS and nothing else.
+ */
+function buildGroups(applySearch: boolean): RenderedPresetGroup[] {
+  if (props.template?.type !== 'static') return [];
+  const connected = props.connectedServices ?? [];
+
+  return PRESET_GROUPS.filter((g) => g.requiresService === null || connected.includes(g.requiresService))
+    .map((g) => ({
+      source: g.source,
+      label: g.label,
+      blurb: g.blurb,
+      presets: getPresetsForSource(g.source).filter(
+        (p) =>
+          !isAlreadyAdded(g.source, p.key) &&
+          (!applySearch || fuzzyMatch(presetQuery.value, presetHaystack(g.source, p.label))),
+      ),
+    }))
+    .filter((g) => g.presets.length > 0);
+}
+
+const presetGroups = computed(() => buildGroups(true));
+
+// Whether the lane exists at all, independent of what is typed in its search.
+// Without this the whole column would vanish mid-search and the layout would jump.
+const hasPresetLane = computed(() => buildGroups(false).length > 0);
+
+const visibleTypes = computed(() => {
+  if (!typeQuery.value) return CONTROL_TYPES;
+  return CONTROL_TYPES.filter((meta) =>
+    fuzzyMatch(typeQuery.value, `${meta.name} ${meta.tagline} ${meta.goodFor.join(' ')}`),
+  );
+});
+</script>
+
+<template>
+  <div class="grid gap-10" :class="hasPresetLane ? 'xl:grid-cols-3' : ''">
+    <!-- Build your own -->
+    <section :class="hasPresetLane ? 'xl:col-span-2' : ''">
+      <header class="mb-4">
+        <h3 class="text-lg font-semibold text-foreground">Build your own</h3>
+        <p class="mt-1 text-sm text-foreground/75">
+          Eight kinds of control. Pick the one that matches the thing you want to change while you are live.
+        </p>
+      </header>
+
+      <div class="relative mb-4">
+        <Search class="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+        <input
+          ref="typeSearchInput"
+          v-model="typeSearch"
+          type="search"
+          class="input-border w-full pl-9"
+          placeholder="Search control types..."
+          aria-label="Search control types"
+        />
+      </div>
+
+      <div v-if="visibleTypes.length" class="grid gap-4 sm:grid-cols-2" :class="hasPresetLane ? '' : '2xl:grid-cols-3'">
+        <ControlTypeCard
+          v-for="meta in visibleTypes"
+          :key="meta.type"
+          :meta="meta"
+          selectable
+          @click="emit('select-type', meta.type)"
+        />
+      </div>
+      <p v-else class="border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+        No control type matches "{{ typeQuery }}".
+      </p>
+    </section>
+
+    <!-- Ready-made, from connected services -->
+    <section v-if="hasPresetLane" class="xl:col-span-1">
+      <div class="xl:sticky xl:top-0">
+        <header class="mb-4">
+          <div class="flex items-baseline justify-between gap-3">
+            <h3 class="text-lg font-semibold text-foreground">Ready-made</h3>
+            <a
+              href="/help/integration-presets"
+              target="_blank"
+              rel="noopener"
+              class="flex shrink-0 cursor-pointer items-center gap-1 text-xs text-violet-500 hover:underline dark:text-violet-400"
+            >
+              <ExternalLink class="size-3" />
+              Reference
+            </a>
+          </div>
+          <p class="mt-1 text-sm text-foreground/75">
+            Already wired up. These fill themselves in from Twitch and the services you connected, so you only pick
+            where they appear.
+          </p>
+          <p class="mt-2 border-l-2 border-violet-400/40 pl-3 text-xs text-foreground/70">
+            Service controls are shared across all your overlays. Adding one here makes it available everywhere, you do
+            not add it per overlay.
+          </p>
+        </header>
+
+        <div class="relative mb-4">
+          <Search class="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            v-model="presetSearch"
+            type="search"
+            class="input-border w-full pl-9"
+            placeholder="Search ready-made controls..."
+            aria-label="Search ready-made controls"
+          />
+        </div>
+
+        <div class="space-y-5 xl:max-h-[52vh] xl:overflow-y-auto xl:pr-2">
+          <p v-if="!presetGroups.length" class="text-sm text-muted-foreground">
+            No ready-made control matches "{{ presetQuery }}".
+          </p>
+
+          <div v-for="group in presetGroups" :key="group.source" class="space-y-2">
+            <div class="flex items-center gap-2">
+              <ProviderIcon :source="group.source" class="size-3.5 shrink-0 text-violet-500 dark:text-violet-400" />
+              <h4 class="text-sm font-semibold text-foreground">{{ group.label }}</h4>
+              <span class="text-xs text-muted-foreground">{{ group.presets.length }}</span>
+            </div>
+            <p class="text-xs text-muted-foreground">{{ group.blurb }}</p>
+
+            <div class="space-y-1.5">
+              <button
+                v-for="preset in group.presets"
+                :key="preset.key"
+                type="button"
+                class="flex w-full cursor-pointer flex-col gap-0.5 border border-border/60 bg-background px-3 py-2 text-left transition duration-150 hover:border-violet-500/60 focus-visible:ring-2 focus-visible:ring-violet-400/40 focus-visible:outline-none dark:hover:border-violet-400/50"
+                @click="emit('select-preset', group.source, preset)"
+              >
+                <span class="flex items-center justify-between gap-2">
+                  <span class="truncate text-sm font-medium text-foreground">{{ preset.label }}</span>
+                  <span
+                    class="shrink-0 border border-border/60 px-1.5 py-0.5 text-[10px] tracking-wide text-muted-foreground uppercase"
+                  >
+                    {{ preset.type }}
+                  </span>
+                </span>
+                <code class="truncate font-mono text-[10px] text-muted-foreground">
+                  [[[c:{{ group.source }}:{{ preset.key }}]]]
+                </code>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/resources/js/components/controls/controlTypeCatalog.ts
+++ b/resources/js/components/controls/controlTypeCatalog.ts
@@ -67,10 +67,13 @@ export const CONTROL_TYPES: ControlTypeMeta[] = [
     type: 'text',
     name: 'Text',
     tagline: 'Any words you want on screen, changed whenever you like.',
-    exampleName: 'Now playing',
+    exampleName: 'Welcome message',
     blurb:
-      'A free-form line of text. Type a new value in your dashboard and every overlay showing it updates straight away. No reload, no restarting the browser source.',
-    goodFor: ['What you are playing right now', 'A shoutout to the last raider', 'The current chapter, quest or task'],
+      'A free-form line of text. It holds whatever you type and nothing else changes it. When you do type a new value, every overlay showing it updates straight away. No reload, no restarting the browser source.',
+    // Deliberately generic. A text control never fills itself in, so examples
+    // like "Now playing" or "Last raider" imply an automatic update that does
+    // not exist. Anything live belongs in a Ready-made control or an Expression.
+    goodFor: ['Any words you want to write yourself', 'A welcome message for your viewers', 'Your handle, socials or pronouns'],
     icon: Type,
     accent: {
       icon: 'bg-sky-500/12 text-sky-600 dark:bg-sky-400/12 dark:text-sky-300',
@@ -80,7 +83,7 @@ export const CONTROL_TYPES: ControlTypeMeta[] = [
       ringFocus: 'focus-visible:ring-sky-500/40 dark:focus-visible:ring-sky-400/30',
       text: 'text-sky-600 dark:text-sky-300',
     },
-    demo: { kind: 'text', value: 'Now playing: Hollow Knight' },
+    demo: { kind: 'text', value: 'Hello world' },
   },
   {
     type: 'number',
@@ -105,10 +108,10 @@ export const CONTROL_TYPES: ControlTypeMeta[] = [
     type: 'counter',
     name: 'Counter',
     tagline: 'One number, one click. Up, down, reset.',
-    exampleName: 'Death counter',
+    exampleName: 'Win counter',
     blurb:
       'A number built for using while you are live. Your dashboard gives it plus and minus buttons and a reset, so you are one click away from bumping it mid-sentence.',
-    goodFor: ['Deaths, wins, attempts', 'Times you said the thing', 'Anything chat likes to keep score of'],
+    goodFor: ['Wins, losses, attempts', 'Times you said the thing', 'Anything chat likes to keep score of'],
     icon: Hash,
     accent: {
       icon: 'bg-emerald-500/12 text-emerald-600 dark:bg-emerald-400/12 dark:text-emerald-300',
@@ -118,7 +121,7 @@ export const CONTROL_TYPES: ControlTypeMeta[] = [
       ringFocus: 'focus-visible:ring-emerald-500/40 dark:focus-visible:ring-emerald-400/30',
       text: 'text-emerald-600 dark:text-emerald-300',
     },
-    demo: { kind: 'counter', label: 'Deaths', value: 12 },
+    demo: { kind: 'counter', label: 'Wins', value: 12 },
   },
   {
     type: 'timer',

--- a/resources/js/components/controls/controlTypeCatalog.ts
+++ b/resources/js/components/controls/controlTypeCatalog.ts
@@ -1,0 +1,298 @@
+import type { Component } from 'vue';
+import { CalendarClock, Gauge, Hash, ListPlus, Sigma, Timer, ToggleLeft, Type } from '@lucide/vue';
+import type { OverlayControl } from '@/types';
+
+/**
+ * Everything the "Add a control" picker needs to sell one control type before
+ * the user commits to it: what it is, what it is good for, and a small demo of
+ * what it actually looks like once it is on screen.
+ *
+ * This lives next to `controlPresets.ts` on purpose. That file is the catalog
+ * of ready-made service controls; this one is the catalog of the eight kinds
+ * you can build yourself. The picker renders both.
+ *
+ * Accent class strings are FULL LITERALS, never interpolated. Tailwind scans
+ * source text, so `text-sky-500` has to appear verbatim or the class is never
+ * generated. Same rule as `useEventColors.ts`.
+ */
+
+export interface ControlAccent {
+  /** Icon tile: tinted background plus the icon color. */
+  icon: string;
+  /** Resting border color. */
+  ring: string;
+  /** Border color on hover, applied through the card's `group`. */
+  ringHover: string;
+  /** Border color when the card is the current choice, with no hover needed. */
+  ringSelected: string;
+  /** Focus ring, for keyboard selection. */
+  ringFocus: string;
+  /** Accent-colored text, for headings and the selected badge. */
+  text: string;
+}
+
+export type ControlTypeDemo =
+  | { kind: 'text'; value: string }
+  | { kind: 'stat'; label: string; value: string }
+  | { kind: 'counter'; label: string; value: number }
+  | { kind: 'timer' }
+  | { kind: 'datetime'; value: string }
+  | { kind: 'boolean'; label: string }
+  | { kind: 'formula'; expression: string; result: string }
+  | { kind: 'pipe'; from: string; to: string };
+
+export interface ControlTypeMeta {
+  type: OverlayControl['type'];
+  name: string;
+  /** One line, shown on the card in the picker grid. */
+  tagline: string;
+  /**
+   * A name someone would plausibly give this kind of control, used as the
+   * placeholder in the form. The key placeholder is slugified from it at the
+   * call site with the same function that derives the real key, so the pair
+   * always demonstrates the actual derivation rather than a hand-written guess.
+   */
+  exampleName: string;
+  /** The longer pitch, shown in the rail once the type is chosen. */
+  blurb: string;
+  /** Three concrete things streamers actually use this for. */
+  goodFor: string[];
+  icon: Component;
+  accent: ControlAccent;
+  demo: ControlTypeDemo;
+}
+
+export const CONTROL_TYPES: ControlTypeMeta[] = [
+  {
+    type: 'text',
+    name: 'Text',
+    tagline: 'Any words you want on screen, changed whenever you like.',
+    exampleName: 'Now playing',
+    blurb:
+      'A free-form line of text. Type a new value in your dashboard and every overlay showing it updates straight away. No reload, no restarting the browser source.',
+    goodFor: ['What you are playing right now', 'A shoutout to the last raider', 'The current chapter, quest or task'],
+    icon: Type,
+    accent: {
+      icon: 'bg-sky-500/12 text-sky-600 dark:bg-sky-400/12 dark:text-sky-300',
+      ring: 'border-sky-500/25 dark:border-sky-400/20',
+      ringHover: 'hover:border-sky-500/60 dark:hover:border-sky-400/50',
+      ringSelected: 'border-sky-500/60 dark:border-sky-400/50',
+      ringFocus: 'focus-visible:ring-sky-500/40 dark:focus-visible:ring-sky-400/30',
+      text: 'text-sky-600 dark:text-sky-300',
+    },
+    demo: { kind: 'text', value: 'Now playing: Hollow Knight' },
+  },
+  {
+    type: 'number',
+    name: 'Number',
+    tagline: 'A single number, with limits if you want them.',
+    exampleName: 'Sub goal',
+    blurb:
+      'A number you type in. Set a minimum, a maximum and a step so you cannot fat-finger it while you are live. Switch on random mode and it rolls a fresh value on a timer instead.',
+    goodFor: ['A follower or sub goal', 'Your personal best, in seconds', 'A random value that keeps a scene alive'],
+    icon: Gauge,
+    accent: {
+      icon: 'bg-indigo-500/12 text-indigo-600 dark:bg-indigo-400/12 dark:text-indigo-300',
+      ring: 'border-indigo-500/25 dark:border-indigo-400/20',
+      ringHover: 'hover:border-indigo-500/60 dark:hover:border-indigo-400/50',
+      ringSelected: 'border-indigo-500/60 dark:border-indigo-400/50',
+      ringFocus: 'focus-visible:ring-indigo-500/40 dark:focus-visible:ring-indigo-400/30',
+      text: 'text-indigo-600 dark:text-indigo-300',
+    },
+    demo: { kind: 'stat', label: 'Sub goal', value: '250' },
+  },
+  {
+    type: 'counter',
+    name: 'Counter',
+    tagline: 'One number, one click. Up, down, reset.',
+    exampleName: 'Death counter',
+    blurb:
+      'A number built for using while you are live. Your dashboard gives it plus and minus buttons and a reset, so you are one click away from bumping it mid-sentence.',
+    goodFor: ['Deaths, wins, attempts', 'Times you said the thing', 'Anything chat likes to keep score of'],
+    icon: Hash,
+    accent: {
+      icon: 'bg-emerald-500/12 text-emerald-600 dark:bg-emerald-400/12 dark:text-emerald-300',
+      ring: 'border-emerald-500/25 dark:border-emerald-400/20',
+      ringHover: 'hover:border-emerald-500/60 dark:hover:border-emerald-400/50',
+      ringSelected: 'border-emerald-500/60 dark:border-emerald-400/50',
+      ringFocus: 'focus-visible:ring-emerald-500/40 dark:focus-visible:ring-emerald-400/30',
+      text: 'text-emerald-600 dark:text-emerald-300',
+    },
+    demo: { kind: 'counter', label: 'Deaths', value: 12 },
+  },
+  {
+    type: 'timer',
+    name: 'Timer',
+    tagline: 'Counts up, counts down, or counts to a moment.',
+    exampleName: 'Subathon clock',
+    blurb:
+      'A clock you start, stop and reset from your dashboard. Count up from zero, count down from a duration you set, or count towards a date and time you pick.',
+    goodFor: ['A subathon clock', 'A "back in five" break timer', 'Time left until your next big stream'],
+    icon: Timer,
+    accent: {
+      icon: 'bg-amber-500/12 text-amber-600 dark:bg-amber-400/12 dark:text-amber-300',
+      ring: 'border-amber-500/25 dark:border-amber-400/20',
+      ringHover: 'hover:border-amber-500/60 dark:hover:border-amber-400/50',
+      ringSelected: 'border-amber-500/60 dark:border-amber-400/50',
+      ringFocus: 'focus-visible:ring-amber-500/40 dark:focus-visible:ring-amber-400/30',
+      text: 'text-amber-600 dark:text-amber-300',
+    },
+    demo: { kind: 'timer' },
+  },
+  {
+    type: 'datetime',
+    name: 'Date and time',
+    tagline: 'A fixed moment, formatted however you like.',
+    exampleName: 'Next stream',
+    blurb:
+      'One date and time, stored once. Format it per tag with the pipe syntax, so the same value can read as "Sat 14 Jun" in one corner of your overlay and "14-06-2026 20:00" in another.',
+    goodFor: ['When your next stream starts', 'A release or launch date', 'The day the channel turned one'],
+    icon: CalendarClock,
+    accent: {
+      icon: 'bg-rose-500/12 text-rose-600 dark:bg-rose-400/12 dark:text-rose-300',
+      ring: 'border-rose-500/25 dark:border-rose-400/20',
+      ringHover: 'hover:border-rose-500/60 dark:hover:border-rose-400/50',
+      ringSelected: 'border-rose-500/60 dark:border-rose-400/50',
+      ringFocus: 'focus-visible:ring-rose-500/40 dark:focus-visible:ring-rose-400/30',
+      text: 'text-rose-600 dark:text-rose-300',
+    },
+    demo: { kind: 'datetime', value: 'Sat 14 Jun, 20:00' },
+  },
+  {
+    type: 'boolean',
+    name: 'Switch',
+    tagline: 'On or off, for showing and hiding parts of your overlay.',
+    exampleName: 'Be right back',
+    blurb:
+      'A single switch. On its own it reads as on or off, but its real job is driving conditional blocks: wrap anything in an if block and this switch shows or hides it live.',
+    goodFor: ['A "be right back" banner', 'Spoiler mode during a boss fight', 'Hiding your donation bar on a chill stream'],
+    icon: ToggleLeft,
+    accent: {
+      icon: 'bg-violet-500/12 text-violet-600 dark:bg-violet-400/12 dark:text-violet-300',
+      ring: 'border-violet-500/25 dark:border-violet-400/20',
+      ringHover: 'hover:border-violet-500/60 dark:hover:border-violet-400/50',
+      ringSelected: 'border-violet-500/60 dark:border-violet-400/50',
+      ringFocus: 'focus-visible:ring-violet-500/40 dark:focus-visible:ring-violet-400/30',
+      text: 'text-violet-600 dark:text-violet-300',
+    },
+    demo: { kind: 'boolean', label: 'Be right back' },
+  },
+  {
+    type: 'expression',
+    name: 'Expression',
+    tagline: 'A formula over your other controls and your live Twitch data.',
+    exampleName: 'Win rate',
+    blurb:
+      'Write a formula once and it recalculates itself the moment anything it references changes. Reach any other control plus every live Twitch value, with functions for maths, time, and picking the largest or most recent of a set.',
+    goodFor: ['Win rate as a percentage', 'How far you still are from a goal', 'Speed, pace or distance from GPS'],
+    icon: Sigma,
+    accent: {
+      icon: 'bg-fuchsia-500/12 text-fuchsia-600 dark:bg-fuchsia-400/12 dark:text-fuchsia-300',
+      ring: 'border-fuchsia-500/25 dark:border-fuchsia-400/20',
+      ringHover: 'hover:border-fuchsia-500/60 dark:hover:border-fuchsia-400/50',
+      ringSelected: 'border-fuchsia-500/60 dark:border-fuchsia-400/50',
+      ringFocus: 'focus-visible:ring-fuchsia-500/40 dark:focus-visible:ring-fuchsia-400/30',
+      text: 'text-fuchsia-600 dark:text-fuchsia-300',
+    },
+    demo: { kind: 'formula', expression: 'c.wins / (c.wins + c.losses) * 100', result: '68' },
+  },
+  {
+    type: 'list_writer',
+    name: 'List writer',
+    tagline: 'Quietly logs every new value into one of your Lists.',
+    exampleName: 'Supporter log',
+    blurb:
+      'Point it at another control and at a List. Every time that control changes, the new value is appended to the List. You never touch this one again, it just keeps the history for you.',
+    goodFor: ['A running roll of everyone who tipped', 'Every song that played tonight', 'A log of every raid you got'],
+    icon: ListPlus,
+    accent: {
+      icon: 'bg-teal-500/12 text-teal-600 dark:bg-teal-400/12 dark:text-teal-300',
+      ring: 'border-teal-500/25 dark:border-teal-400/20',
+      ringHover: 'hover:border-teal-500/60 dark:hover:border-teal-400/50',
+      ringSelected: 'border-teal-500/60 dark:border-teal-400/50',
+      ringFocus: 'focus-visible:ring-teal-500/40 dark:focus-visible:ring-teal-400/30',
+      text: 'text-teal-600 dark:text-teal-300',
+    },
+    demo: { kind: 'pipe', from: 'latest_donor_name', to: 'Supporters tonight' },
+  },
+];
+
+const BY_TYPE = new Map(CONTROL_TYPES.map((meta) => [meta.type, meta]));
+
+export function controlTypeMeta(type: OverlayControl['type']): ControlTypeMeta {
+  // Every member of the union is in the catalog, so the fallback is only a
+  // guard against a type added to the DB before it is added here.
+  return BY_TYPE.get(type) ?? CONTROL_TYPES[0];
+}
+
+/**
+ * Neutral accent for the ready-made service controls. They are not one of the
+ * eight buildable types, so they get their own identity rather than borrowing
+ * whichever type the preset happens to be.
+ */
+export const SERVICE_ACCENT: ControlAccent = {
+  icon: 'bg-violet-500/12 text-violet-600 dark:bg-violet-400/12 dark:text-violet-300',
+  ring: 'border-violet-500/25 dark:border-violet-400/20',
+  ringHover: 'hover:border-violet-500/60 dark:hover:border-violet-400/50',
+  ringSelected: 'border-violet-500/60 dark:border-violet-400/50',
+  ringFocus: 'focus-visible:ring-violet-500/40 dark:focus-visible:ring-violet-400/30',
+  text: 'text-violet-600 dark:text-violet-300',
+};
+
+export interface PresetGroupMeta {
+  source: string;
+  label: string;
+  /** One line on what this group is, shown under the group heading. */
+  blurb: string;
+  /**
+   * Connected-service key this group needs, or null when the group needs no
+   * integration at all (Twitch is always there, alerts is a system namespace).
+   */
+  requiresService: string | null;
+}
+
+export const PRESET_GROUPS: PresetGroupMeta[] = [
+  {
+    source: 'twitch',
+    label: 'Twitch',
+    blurb: 'Counters that fill themselves from your channel, and reset when you go live.',
+    requiresService: null,
+  },
+  {
+    source: 'alerts',
+    label: 'Overlabels alerts',
+    blurb: 'The alert state your overlay can read, so it can react to it.',
+    requiresService: null,
+  },
+  { source: 'kofi', label: 'Ko-fi', blurb: 'Tips and supporters, straight from Ko-fi.', requiresService: 'kofi' },
+  {
+    source: 'streamlabs',
+    label: 'Streamlabs',
+    blurb: 'Donations as they land in Streamlabs.',
+    requiresService: 'streamlabs',
+  },
+  {
+    source: 'fourthwall',
+    label: 'Fourthwall',
+    blurb: 'Donations and support from your Fourthwall shop.',
+    requiresService: 'fourthwall',
+  },
+  {
+    source: 'bmac',
+    label: 'Buy Me a Coffee',
+    blurb: 'Supporters, memberships and one-off coffees.',
+    requiresService: 'bmac',
+  },
+  {
+    source: 'throne',
+    label: 'Throne',
+    blurb: 'Gifts from your Throne wishlist, including the item itself.',
+    requiresService: 'throne',
+  },
+  {
+    source: 'gps',
+    label: 'Overlabels GPS',
+    blurb: 'Live telemetry from the Overlabels mobile app.',
+    requiresService: 'gps',
+  },
+];


### PR DESCRIPTION
## What

The Add Control dialog was one scrolling column of form inputs. Only the Text type fit on a 1080p screen; Number, Counter and List writer ran off the bottom entirely, taking the Save button with them.

It is now two screens inside a near-fullscreen dialog:

- **Pick** shows the eight control types as cards, each with a one-line pitch and a demo of what it actually renders (the Timer demo ticks). Ready-made service presets sit alongside in their own column, each showing the exact tag to paste.
- **Configure** keeps the choice visible in a rail (the card, what it is good for, a click-to-copy tag that fills in live) next to the form.

Editing and duplicating skip the picker, since the type is already settled in both cases.

## The vertical fit is structural now, not tuned

The dialog is a fixed-height grid of `auto / minmax(0,1fr) / auto`. Only the middle band scrolls and the footer sits outside it, so Save is reachable for every type regardless of how much config that type needs.

## Bugs fixed along the way

- **Card hover was dead.** It used `group-hover:`, which compiles to a descendant selector (`.group:hover .group-hover\:x`) and so can never match the element carrying `.group`. `focus-visible:` worked because it is a plain self-variant, which is what made the asymmetry visible. Both are self-variants now, and the generated CSS was checked to confirm all eight hover borders exist.
- **Preset selection was order-dependent.** It was a combobox `v-model` plus a watcher that reset the form when it emptied, so "clear the preset, then set a type" let the watcher clobber the type that had just been set. Explicit functions now.
- **Text control copy implied live data.** A text control never fills itself in, so "Now playing: Hollow Knight" promised an automatic update that does not exist. Rewritten to describe writing your own words.

## Simplifications

- `PRESET_GROUPS` replaces sixteen near-identical computeds (a `show*` and an `available*` per service). A ninth service is now one row in a table.
- Form placeholders come from the catalog, so a Switch suggests "Be right back" rather than "Win counter". The key placeholder is slugified from the name placeholder using the same function that derives the real key, so the pair demonstrates the actual transformation rather than being two strings that can drift.

## Note for reviewers

Accent classes are full literals in `controlTypeCatalog.ts`. Never build one at runtime: Tailwind only generates what it can see spelled out in source. Two such bugs were caught during development and the built CSS was grepped to verify the classes land.

## Testing

`vue-tsc`, `eslint` and `npm run build` are clean. Verified interactively in the app; no changelog entry yet, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)