### PR TITLE
fix(updates): scope a post's compiled CSS so it can't delete the sidebar

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,19 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 10th, 2026 - fix(updates): a blog post could delete the app's navigation
+
+`/updates/overlabels-development-highlights-july-2026` rendered with no sidebar at all. The post body showed up fine, the whole left-hand navigation was simply gone. Every other post on the site was unaffected, which is what made it look like a routing or layout problem rather than a content one.
+
+- **A post's compiled CSS was being injected globally.** `updates/show.vue` takes the `compiled_css` stored on the row and appends it to `<head>` as a plain `<style>` tag. That sheet is a flat set of utility rules, so `.hidden{display:none}` from a post applied to the entire document, not just the post.
+- **Unlayered beats layered, whatever the specificity.** UnoCSS emits its output unlayered; Tailwind v4 keeps every utility inside `@layer utilities`. In the cascade an unlayered declaration outranks a layered one outright, so the post's `.hidden` beat `.md\:block` without being more specific or coming later. Verified against the deployed bundle rather than assumed: `.md\:block{display:block}` does sit inside `@layer utilities{`.
+- **The sidebar is built out of exactly that pair.** `Sidebar.vue` gives the desktop wrapper `hidden md:block` and the fixed panel `hidden ... md:flex`. Both collapsed to `display:none`. `SidebarInset` carries no `hidden`, which is why the article kept rendering and only the navigation vanished, and why it read as a layout bug.
+- **One post in nine triggered it.** Checking the stored CSS of every published post found `.hidden{display:none}` in the July highlights post and nowhere else. It also globally redefined `.fixed`, `.block`, `.grid` and `.border`; those happen to match Tailwind's values, so they were overriding the shell silently rather than visibly.
+- **It does not reproduce locally.** The only post in a fresh database is `welcome-to-overlabels`, whose body carries no classes at all, so its compiled CSS is the inert `--un-*` variable block and nothing collides. Reproducing needs that specific post's markdown.
+- **The fix is `@scope`, not a layer.** Wrapping the sheet in a layer would not have helped, since a later layer still wins; the rules had to stop matching shell elements altogether. `@scope (#updates-post)` confines them to the post container, which now wraps the excerpt and the body and nothing else. The back link, title and tags stay outside it deliberately, since they are app chrome rather than author content.
+- **Scoping happens at injection, not at compile time.** That fixes all nine existing rows without a re-save, and keeps `compileTailwindCss` untouched for overlay templates, where global output is correct and has to stay that way.
+- **Failing without `@scope` support is the safe direction.** A browser that does not understand the at-rule drops the whole block, costing the post its custom utilities but leaving the app navigable. Better than the current failure, which is losing the navigation.
+
 ## August 10th, 2026 - feat(controls): rebuild the Add Control modal as a two-step picker
 
 The Add Control dialog was one scrolling column of form inputs. Only the Text type fit on a 1080p screen. Number, Counter and List writer ran off the bottom entirely, taking the Save button with them, and the only type that got the layout right was Expression, because it happened to open in two columns.

--- a/resources/js/pages/triggers/index.vue
+++ b/resources/js/pages/triggers/index.vue
@@ -133,9 +133,9 @@ function conditionLabel(row: ConditionFields): string | null {
 <template>
   <Head title="Triggers" />
   <AppLayout :breadcrumbs="breadcrumbs">
-    <div class="px-4 py-3">
+    <div class="p-4">
       <div class="mb-4 mt-1 flex items-center gap-2">
-        <Megaphone class="h-6 w-6" />
+        <Megaphone class="mr-2 size-6" />
         <Heading
           title="Triggers"
           description="Read-only view of every event currently bound to an alert template. Edit assignments from each alert template's Triggers tab."

--- a/resources/js/pages/updates/show.vue
+++ b/resources/js/pages/updates/show.vue
@@ -26,13 +26,27 @@ const renderedExcerpt = computed(() =>
 // UnoCSS preset-wind3 and stores them on the row. We inject that CSS into
 // <head> while the post is mounted, then strip it on unmount so it doesn't
 // leak utilities into other pages on client-side navigation.
+//
+// The sheet MUST be scoped to the post container. It is a flat set of global
+// utility rules, and UnoCSS emits it unlayered, while Tailwind v4 keeps every
+// utility inside `@layer utilities` - and an unlayered rule beats a layered
+// one outright, whatever the specificity or source order. So a post whose
+// markdown mentions `hidden` anywhere ships a global `.hidden{display:none}`
+// that outranks the app shell's own `hidden md:block`, and the entire sidebar
+// disappears for as long as that post is open (Sidebar.vue builds both the
+// desktop wrapper and the fixed panel out of `hidden` + a `md:` override).
+// `@scope` confines the sheet to post content so it can never reach the shell.
+// A browser without `@scope` support drops the whole block, which costs the
+// post its custom utilities but leaves the app navigable - the safe way to
+// fail of the two.
 const STYLE_ID = 'updates-post-style';
+const POST_SCOPE_ID = 'updates-post';
 function injectPostStyle(css: string) {
   document.getElementById(STYLE_ID)?.remove();
-  if (!css) return;
+  if (!css.trim()) return;
   const style = document.createElement('style');
   style.id = STYLE_ID;
-  style.textContent = css;
+  style.textContent = `@scope (#${POST_SCOPE_ID}) {\n${css}\n}`;
   document.head.appendChild(style);
 }
 watch(
@@ -96,15 +110,22 @@ const breadcrumbs: BreadcrumbItem[] = [
               {{ tag }}
             </Link>
           </div>
-
-          <div
-            v-if="renderedExcerpt"
-            class="mt-6 prose prose-invert max-w-none text-lg text-foreground"
-            v-html="renderedExcerpt"
-          />
         </div>
 
-        <article class="prose prose-invert max-w-none text-foreground" v-html="renderedBody" />
+        <!-- Scope root for the post's compiled CSS (see injectPostStyle).
+             Everything inside is author-written markdown - the excerpt and the
+             body, which are exactly the two sources the admin form compiles
+             from. Everything outside is app chrome and must stay out of reach,
+             so do not move the back link, title or tags in here. -->
+        <div :id="POST_SCOPE_ID">
+          <div
+            v-if="renderedExcerpt"
+            class="mb-8 prose prose-invert max-w-none text-lg text-foreground"
+            v-html="renderedExcerpt"
+          />
+
+          <article class="prose prose-invert max-w-none text-foreground" v-html="renderedBody" />
+        </div>
       </div>
     </div>
   </AppLayout>


### PR DESCRIPTION
`/updates/overlabels-development-highlights-july-2026` rendered with no sidebar at all. The post body showed up fine, the entire left-hand navigation was gone. Every other post was unaffected, which made it look like a routing or layout problem rather than a content one.

## Cause

`updates/show.vue` injects the post's stored `compiled_css` into `<head>` as a plain global `<style>` tag. That sheet is a flat set of utility rules, so a `.hidden{display:none}` generated from the post body applied to the whole document.

Two facts make that fatal, both checked against the deployed bundle rather than assumed:

- UnoCSS emits its output **unlayered** (the stored CSS contains no `@layer` at all).
- Tailwind v4 keeps every utility inside `@layer utilities` - `.md\:block{display:block}` does sit inside `@layer utilities{` in `app-C3dazhfa.css`.

An unlayered declaration outranks a layered one outright, regardless of specificity or source order. So the post's `.hidden` beat `.md\:block` without being more specific.

`Sidebar.vue` builds the desktop wrapper as `hidden md:block` (L56) and the fixed panel as `hidden ... md:flex` (L76). Both collapsed to `display:none`. `SidebarInset` carries no `hidden`, which is why the article kept rendering and only the navigation vanished.

Checking the stored CSS of all nine published posts, exactly one triggers it. It also globally redefined `.fixed`, `.block`, `.grid` and `.border`; those happen to match Tailwind's values, so they were overriding the shell silently rather than visibly.

## Fix

Wrap the sheet in `@scope (#updates-post)` at injection time.

A layer would not have helped - a later layer still wins, so the rules had to stop matching shell elements altogether. Scoping at injection rather than at compile time fixes all nine existing rows without a re-save, and leaves `compileTailwindCss` untouched for overlay templates, where global output is correct and must stay that way.

The scope root wraps the excerpt and the body, which are exactly the two sources the admin form compiles from. The back link, title and tags stay outside it as app chrome.

Browsers without `@scope` drop the block entirely, costing the post its custom utilities but leaving the app navigable - the safer of the two failure modes.

## Verification

- Fed the real production CSS that causes the bug through postcss wrapped in the new `@scope`: parses clean, all 14 rules land inside the scope, zero escape to the top level.
- `eslint` clean, `npm run build` clean, `vue-tsc --noEmit` reports nothing for the file.
- Confirmed in the browser locally: sidebar gone before, present after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
