### PR TITLE
fix(format): keep Prettier out of the help content

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,19 @@
 resources/js/components/ui/*
 resources/js/ziggy.js
 resources/views/mail/*
+
+# Help content: 166 hand-written markdown pages, served verbatim as .md to
+# people and to language models. Prettier formats code inside fenced blocks,
+# and these pages are mostly fenced examples showing a streamer exactly what
+# to type. On resources/help/pages/blocks.md it collapses
+#
+#     <div class="item">
+#       [[[follower_count]]] followers
+#     </div>
+#
+# onto one line, and mangles the CSS that shares that ```html fence because it
+# is not valid HTML. 30 of the 80 pages Prettier wants to touch contain fences.
+#
+# Formatting a teaching example is not a style fix, it is a content edit, so
+# this is content and stays out - same reasoning as resources/views/mail above.
+resources/help/**

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,18 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 14th, 2026 - fix(format): Prettier was one uncommented line away from rewriting the docs
+
+`resources/help/**` is now in `.prettierignore`. Found while investigating why CI runs Pint and throws the result away, which turned out to be the less interesting half of the story.
+
+- **Prettier formats code inside fenced blocks, and the help pages are mostly fenced code.** On `resources/help/pages/blocks.md` it collapses a four-line `<div class="item">` example onto one line, and mangles the CSS sharing that ```html fence because CSS is not valid HTML. That example exists to show a streamer exactly what to type. Reformatting it is not a style fix, it is a content edit. 30 of the 80 help pages Prettier wanted to touch contain fences.
+- **The pages are served verbatim, so this is user-visible.** Every help page has a `.md` twin that `llms.txt` points at, which is the whole point of the contextual-help work. A mangled example is shipped to both people and language models.
+- **The damage was latent, not active, and that is the uncomfortable part.** `lint.yml` runs `npm run format` (write mode, not `--check`), so CI has been generating these edits on every push for months and discarding them when the runner dies. The step that would have committed them is commented out - and has been since the repo's first commit, `783b81fc "Laravel? Pretty cool!"`, 24 July 2025. Nobody disabled it; it arrived that way in the Laravel scaffold and `lint.yml` has never been edited since. That accident is the only reason 80 doc pages are intact.
+- **Which inverts the obvious fix.** "CI throws away its own work, just uncomment the commit step" would have silently rewritten the documentation on the next push. The ignore rule has to land first, before anything makes those fixes durable.
+- **Verified by running the thing that would have caused the damage.** With the rule in place, `npm run format` in write mode modifies 220 files and exactly **0** under `resources/help`. Before the rule, `--check` listed 301 files; after, 221.
+- **Scoped to the whole directory because it is uniformly content.** All 166 files under `resources/help` are markdown. Same reasoning as the existing `resources/views/mail/*` entry: content directories stay out of the formatter.
+- **The 220 remaining files are real drift and are deliberately not fixed here.** Pint wants 38 more. Both get their own pass; this PR is the one line that has to precede it.
+
 ## August 14th, 2026 - chore(ops): the backup moved to 16:00, because nobody reads an alarm at 03:30
 
 The database backup ran at 03:00 UTC for the reason everyone picks 03:00: backups go at night, when the box is quiet. Someone pointed out that this is inherited convention rather than a decision, and they were right. It now runs at 16:00 UTC, which is 18:00 in Amsterdam.


### PR DESCRIPTION
One line in `.prettierignore`, plus the comment explaining why it must never be removed.

This is **step 1 of 3**. It has to land before the formatting cleanup, for the reason below.

## What Prettier does to the help pages

Prettier formats code *inside* fenced blocks, and the help pages are mostly fenced code. From `resources/help/pages/blocks.md`:

```diff
- <div class="item">
-   [[[follower_count]]] followers
- </div>
+ <div class="item">[[[follower_count]]] followers</div>
```

That fence is ```html and contains **both HTML and CSS**. Prettier collapses the div and mangles the CSS, because CSS is not valid HTML.

That example exists to show a streamer exactly what to type. Reformatting it is a content edit, not a style fix. **30 of the 80 help pages** Prettier wanted to touch contain fences, and every page is served verbatim as a `.md` twin that `llms.txt` points at - so a mangled example ships to people and to language models alike.

## Why this hasn't already happened

`lint.yml` runs `npm run format` - write mode, not `--check`. So CI has been generating these edits on every push for months and discarding them when the runner is destroyed. The `Commit Changes` step that would have made them durable is commented out.

It has been commented out since the repo's **first commit**:

```
783b81fc  Jasper van der Meer  Thu Jul 24 2025  "Laravel? Pretty cool!"
```

Nobody disabled it. It arrived that way in the Laravel scaffold, and `lint.yml` has never been edited since. That accident is the only reason 80 doc pages are intact.

**Which inverts the obvious fix.** "CI throws away its own work, just uncomment the commit step" would have silently rewritten the documentation on the next push. The ignore rule has to come first.

## Verification

Ran the exact thing that would have caused the damage:

| | Result |
|---|---|
| `npm run format` (write mode), files changed under `resources/help` | **0** |
| `npm run format` (write mode), files changed elsewhere | 220 |
| `format:check` file count, before the rule | 301 |
| `format:check` file count, after the rule | 221 |

The 220 were reverted; this PR is two files.

## Scope

The whole directory, because it is uniformly content: all **166** files under `resources/help` are markdown. Same reasoning as the existing `resources/views/mail/*` entry.

## Deliberately not in this PR

The 220 remaining Prettier files and 38 Pint files are real drift, and they get their own pass:

- **Step 2**: the cleanup, on its own so the diff can be skimmed without a real change buried in it
- **Step 3**: flip `lint.yml` to check mode (`pint --test`, `npm run format:check`), which can only go green after step 2

The auto-commit action stays commented out permanently, now deliberately rather than by accident: it needs `contents: write`, does not work on fork PRs (this repo is public and AGPL), and can trigger CI loops. Step 3 gets the same protection without any of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
