### PR TITLE
ci: run Pint, Prettier and ESLint in check mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,10 @@ on:
       - develop
       - main
 
+# Read-only. This job reports; it never writes to the repo. See the note at the
+# bottom about why it does not commit its own fixes.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   quality:
@@ -24,22 +26,53 @@ jobs:
         with:
           php-version: '8.4'
 
+      # Pinned, and installed from the lockfile. A style gate has to be
+      # deterministic: with a bare `npm install` on the runner's default Node,
+      # a Prettier minor could resolve differently here than locally and fail a
+      # PR that is actually fine. Mirrors tests.yml.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
       - name: Install Dependencies
         run: |
           composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-          npm install
+          npm ci
 
+      # All three run in CHECK mode: they report and fail, they do not rewrite.
+      # Until 2026-08-14 these were `pint`, `npm run format` and `npm run lint`
+      # - all write mode - so the job fixed the code, exited 0, and threw the
+      # result away when the runner was destroyed. Thirteen months of style
+      # drift accumulated behind a green tick.
       - name: Run Pint
-        run: vendor/bin/pint
+        run: vendor/bin/pint --test
 
       - name: Format Frontend
-        run: npm run format
+        run: npm run format:check
 
       - name: Lint Frontend
-        run: npm run lint
+        run: npm run lint:check
 
-      # - name: Commit Changes
-      #   uses: stefanzweifel/git-auto-commit-action@v5
-      #   with:
-      #     commit_message: fix code style
-      #     commit_options: '--no-verify'
+# There is deliberately no commit-back step.
+#
+# A `stefanzweifel/git-auto-commit-action` step lived here, commented out, from
+# the repo's first commit (783b81fc, 24 Jul 2025) until it was removed on
+# 2026-08-14. Nobody had disabled it; it arrived that way in the Laravel
+# scaffold and was never revisited.
+#
+# It stays gone, and now on purpose:
+#
+#   - it needs `contents: write`, widening this job from reporting to writing
+#   - it cannot work on pull requests from forks, which get no write token -
+#     and this repo is public and AGPL, so outside PRs are the point
+#   - a push from CI can retrigger CI
+#   - it had already been silently generating WRONG fixes: Prettier reformats
+#     code inside markdown fences, so enabling it would have rewritten the
+#     help pages' teaching examples (hence resources/help/** in
+#     .prettierignore, added in #219)
+#
+# Check mode gets the same protection with none of that. `npm run format` and
+# `npm run lint` still exist for fixing locally; CI just refuses to do it for
+# you.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,18 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 14th, 2026 - ci: the linter now actually says no
+
+Third and last step of the formatting chore. `lint.yml` ran Pint, Prettier and ESLint in write mode for thirteen months: it fixed the code, exited 0, and threw the result away when the runner was destroyed. All three now run in check mode, so the job reports instead of pretending.
+
+- **The gate is six characters and two script names, and it only became possible after the cleanup.** `pint --test`, `npm run format:check`, `npm run lint:check`. Flipping these before the 261-file sweep would have turned CI red on every branch at once, which is why it was the last of three PRs rather than the first.
+- **`lint:check` is new; the other two already existed.** `format:check` has been in `package.json` since the Laravel scaffold and was never wired up. ESLint had only `eslint . --fix`, so the check-mode twin was added alongside it, following the same naming as the pair that was already there. `npm run lint` and `npm run format` are untouched - fixing locally is still one command, CI just will not do it for you.
+- **Each gate was verified to fail before being trusted.** A green run on a clean tree proves nothing, so one deliberate violation per language was planted and confirmed to break the build: a `$a=1;` PHP method for Pint, an over-indented `.ts` export for Prettier, and an unused `const` for ESLint (`@typescript-eslint/no-unused-vars`). Each returned a non-zero exit, and each returned 0 again once the probe was deleted.
+- **Node is pinned and installed from the lockfile now, which a check-mode gate needs and a write-mode one did not.** The job used a bare `npm install` on the runner's default Node with no `actions/setup-node` step. That is survivable when the output is discarded; as a gate it means a Prettier minor could resolve differently on CI than locally and fail a PR that is genuinely fine. Now `node-version: 22` and `npm ci`, matching `tests.yml`.
+- **Permissions dropped from `contents: write` to `contents: read`.** The write scope existed only for the commit-back step. Nothing in this job writes to the repo any more, so it should not be able to.
+- **The commented-out auto-commit step is deleted, and the reasons are written where it used to be.** It sat there from the repo's first commit (`783b81fc`, 24 July 2025) untouched - nobody disabled it, it shipped that way in the Laravel scaffold. Leaving a plausible-looking block commented out is an invitation to uncomment it, and doing so would need `contents: write`, would not work on fork PRs (this repo is public and AGPL, so outside PRs are the point), could retrigger CI from its own push, and - the part nobody would predict - would have rewritten the help pages' teaching examples, since Prettier formats code inside markdown fences.
+- **Both workflow files were parsed with `symfony/yaml` before committing.** A malformed workflow does not fail loudly, it simply never runs - which is the same class of silent-green problem this entire chore was about. Both parse, and every step resolves.
+
 ## August 14th, 2026 - style: 261 files of accumulated drift, formatted once
 
 CI has been generating these exact edits on every push for thirteen months and throwing them away. This is that backlog, applied deliberately instead of discarded silently. No behaviour changes: 1287 tests pass with **3968 assertions, identical to before**.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "format": "prettier --write resources/",
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
+        "lint:check": "eslint .",
         "typecheck": "vue-tsc --noEmit"
     },
     "devDependencies": {


### PR DESCRIPTION
**Step 3 of 3.** The last one, and the point of the other two.

`lint.yml` ran all three tools in **write mode** for thirteen months: it fixed the code, exited 0, and threw the result away when the runner was destroyed. They now report instead of pretending.

```diff
- vendor/bin/pint          + vendor/bin/pint --test
- npm run format           + npm run format:check
- npm run lint             + npm run lint:check
```

This could only land last. Flipping these before the 261-file cleanup in #220 would have turned CI red on every branch simultaneously.

## Each gate was verified to fail before being trusted

A green run on a clean tree proves nothing - a gate pointed at the wrong files is also green. One deliberate violation per language, planted and confirmed to break the build:

| Probe | Gate | Exit |
|---|---|---|
| PHP method with `$a=1;` | `pint --test` | **1** |
| Over-indented `.ts` export | `format:check` | **1** |
| Unused `const` (`@typescript-eslint/no-unused-vars`) | `lint:check` | **1** |

Each returned **0** again once the probe was deleted. All three probes removed; this PR is three files.

## `lint:check` is the only new script

`format:check` has existed in `package.json` since the Laravel scaffold and was simply never wired up. ESLint only had `eslint . --fix`, so the check-mode twin was added beside it using the naming convention already there.

`npm run lint` and `npm run format` are untouched. Fixing locally is still one command; CI just will not do it for you.

## Node is pinned now, which a gate needs and write mode did not

The job used a bare `npm install` on the runner's **default Node**, with no `actions/setup-node` step at all. That is survivable when the output is discarded. As a gate it means a Prettier minor could resolve differently on CI than locally and fail a PR that is genuinely fine.

Now `node-version: 22` with `npm ci`, matching `tests.yml`.

## Permissions reduced

`contents: write` → `contents: read`. The write scope existed only for the commit-back step. Nothing in this job writes to the repo any more, so it should not be able to.

## The commented-out auto-commit step is deleted

It sat untouched from the repo's **first commit** (`783b81fc`, 24 Jul 2025). Nobody disabled it; it shipped that way in the Laravel scaffold.

Leaving a plausible-looking block commented out is an invitation to uncomment it. The reasons not to are now written where it used to be:

- needs `contents: write`, widening this job from reporting to writing
- cannot work on pull requests from forks, which get no write token - and this repo is public and AGPL, so outside PRs are the point
- a push from CI can retrigger CI
- and the part nobody would predict: it had been silently generating **wrong** fixes. Prettier formats code inside markdown fences, so enabling it would have rewritten the help pages' teaching examples (hence `resources/help/**` in `.prettierignore`, added in #219)

## Both workflows were parsed before committing

With `symfony/yaml`, which is already in vendor. A malformed workflow does not fail loudly - it simply never runs, which is the same silent-green problem this entire chore was about.

Both parse. `lint.yml`: 7 steps, `permissions={"contents":"read"}`. `tests.yml`: 12 steps, untouched.

## The chore, end to end

| PR | Step | |
|---|---|---|
| #219 | Keep Prettier out of the help content | merged |
| #220 | The 261-file cleanup, and one tabWidth rule per tool | merged |
| **#221** | **Enforce it** | this one |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
