### PR TITLE
docs: slim the README down to a front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,614 +6,115 @@ and external integrations.
 There is no drag-and-drop editor. There is no proprietary file format. There is no runtime you do not control.
 Your overlay is a webpage, and Overlabels is the engine that keeps it alive.
 
+**[overlabels.com](https://overlabels.com)** - free forever, no paywalls, no tiers.
+
 ---
 
-## The Syntax
+## The syntax
 
-Overlabels uses a deliberate, collision-resistant template syntax: triple square brackets. It is distinctive enough to
-never clash with HTML, CSS, JavaScript, or any template engine you might encounter in the wild,
-and simple enough to understand without documentation.
+Overlabels uses one deliberate, collision-resistant syntax: triple square brackets. It never clashes with
+HTML, CSS, JavaScript, or any template engine you might meet in the wild.
 
 ```html
 <span class="followers">[[[followers_total]]]</span>
 ```
 
-That is it. Drop a tag anywhere in your HTML or CSS, and Overlabels replaces it with live data when the overlay renders.
-The entire system - static data, live controls, conditional blocks - runs through this one syntax.
+Drop a tag anywhere in your HTML or CSS and Overlabels replaces it with live data when the overlay renders.
+The whole system - Twitch data, live controls, conditionals, formatting, math - runs through that one form.
 
 ---
 
-## Template Tags
+## Documentation
 
-Template tags are resolved from live Twitch API data fetched on overlay load and updated in real time when events fire.
-Every tag maps deterministically to a value in the Twitch Helix API response.
+Full documentation lives at **[overlabels.com/help](https://overlabels.com/help)**. It is the canonical
+source and it stays in sync with what is actually deployed.
 
-### User & Channel
+**Start here**
 
-| Tag                                              | Description                      |
-|--------------------------------------------------|----------------------------------|
-| `[[[user_name]]]`                                | Display name of the broadcaster  |
-| `[[[user_broadcaster_type]]]`                    | `affiliate`, `partner`, or empty |
-| `[[[user_description]]]`                         | Channel bio                      |
-| `[[[user_view_count]]]`                          | All-time view count              |
-| `[[[user_avatar]]]`                              | Profile image URL                |
-| `[[[channel_title]]]`                            | Current stream title             |
-| `[[[channel_game]]]`                             | Current game/category            |
-| `[[[channel_language]]]`                         | Broadcast language code          |
-| `[[[channel_tags_0]]]` - `[[[channel_tags_10]]]` | Individual stream tags by index  |
+| Page                                                              | What it covers                                      |
+|-------------------------------------------------------------------|-----------------------------------------------------|
+| [Why Overlabels](https://overlabels.com/help/why-overlabels)       | The pitch, for people who write code                |
+| [For Creators](https://overlabels.com/help/for-creators)           | What it actually is beneath the HTML/CSS surface    |
+| [For Designers](https://overlabels.com/help/for-designers)         | Handoff guide: what to deliver, what to avoid       |
+| [Manifesto](https://overlabels.com/help/manifesto)                 | Why it exists and the principles behind it          |
 
-### Followers & Subscriptions
+**Building overlays**
 
-| Tag                                  | Description                          |
-|--------------------------------------|--------------------------------------|
-| `[[[followers_total]]]`              | Total follower count                 |
-| `[[[followers_latest_user_name]]]`   | Most recent follower's display name  |
-| `[[[followers_latest_date]]]`        | Timestamp of most recent follow      |
-| `[[[subscribers_total]]]`            | Total subscriber count               |
-| `[[[subscribers_points]]]`           | Subscriber points total              |
-| `[[[subscribers_latest_user_name]]]` | Most recent subscriber               |
-| `[[[subscribers_latest_tier]]]`      | Subscription tier (1000, 2000, 3000) |
-| `[[[subscribers_latest_is_gift]]]`   | Whether the latest sub was gifted    |
+| Page                                                                    | What it covers                                    |
+|-------------------------------------------------------------------------|---------------------------------------------------|
+| [Overlays vs Alerts](https://overlabels.com/help/overlays-vs-alerts)     | The two surfaces and how they fit together        |
+| [The Builder](https://overlabels.com/help/builder)                       | Compose an overlay on a grid, no code required    |
+| [Blocks](https://overlabels.com/help/blocks)                             | Reusable pieces: authoring, CSS scoping, controls |
 
-### Goals
+**The template language**
 
-| Tag                              | Description                              |
-|----------------------------------|------------------------------------------|
-| `[[[goals_latest_type]]]`        | Goal type (follower, subscription, etc.) |
-| `[[[goals_latest_current]]]`     | Current progress value                   |
-| `[[[goals_latest_target]]]`      | Target value                             |
-| `[[[goals_latest_description]]]` | Goal description                         |
+| Page                                                            | What it covers                                          |
+|-----------------------------------------------------------------|---------------------------------------------------------|
+| [Conditional and event tags](https://overlabels.com/help/conditionals) | if/elseif/else, comparisons, event payload tags   |
+| [Formatting pipes](https://overlabels.com/help/formatting)       | Numbers, durations, currencies, dates. Locale-aware     |
+| [Math engine](https://overlabels.com/help/math)                  | Waves, modulo wheels, timestamp racing                  |
 
-Tags can be used **anywhere** in your HTML or CSS. Font sizes, colour values, content attributes, `aria-label` -
-wherever a value belongs, a tag can go.
+**Live data**
 
-```css
-.follower-bar {
-  width: calc([[[followers_total]]] / [[[goals_latest_target]]] * 100%);
-}
-```
+| Page                                                                        | What it covers                                       |
+|-----------------------------------------------------------------------------|------------------------------------------------------|
+| [Controls](https://overlabels.com/help/controls)                             | Text, numbers, counters, timers, toggles             |
+| [Expression controls](https://overlabels.com/help/expressions)               | Client-side formulas over any other control          |
+| [Integration presets](https://overlabels.com/help/integration-presets)       | Every auto-managed control, searchable               |
+| [Lists](https://overlabels.com/help/lists)                                   | Raffles, queues, quote walls, leaderboards           |
+| [Lists in realtime](https://overlabels.com/help/lists-realtime)              | Read a list as JSON and subscribe over WebSocket     |
 
----
+**Reference**
 
-## Controls
+| Page                                                        | What it covers                                                |
+|-------------------------------------------------------------|---------------------------------------------------------------|
+| [Reference](https://overlabels.com/help/reference)           | Every template tag, EventSub event and foreach field          |
+| [Twitch chat bot](https://overlabels.com/help/bot)           | Letting viewers and mods change controls from chat            |
+| [Free resources](https://overlabels.com/help/resources)      | Colors, fonts, animations and other tools                     |
 
-Controls are typed, persistent, mutable values attached to a template. They are the **state layer** of Overlabels.
-Define a control once, reference it anywhere in your overlay, and update it from your dashboard while the
-overlay is live. The update propagates instantly over WebSocket, no reload required.
-
-Reference a control in your template with the `c:` prefix:
-
-```html
-<span class="username">[[[c:myname]]]</span>
-```
-
-### Control Types
-
-| Type         | Stores                                   | Use Case                                            |
-|--------------|------------------------------------------|-----------------------------------------------------|
-| `text`       | String (up to 1000 chars, HTML stripped) | Names, messages, labels                             |
-| `number`     | Numeric string                           | Scores, goals, counters with arbitrary values       |
-| `counter`    | Integer string                           | Kill counters, death counters, incrementable values |
-| `timer`      | Derived from config state                | Countup, countdown, and count-to-datetime timers    |
-| `datetime`   | ISO 8601 string                          | Scheduled events, stream start times                |
-| `boolean`    | `"1"` or `"0"`                           | Feature flags, show/hide blocks, on/off state       |
-| `expression` | Derived from formula                     | Computed values that reference other controls       |
-
-Each control has a `key` (alphanumeric and underscore, used in your template), a `label` (shown in your dashboard),
-and a `type` that determines how the value is sanitised, resolved, and displayed.
-
-### Timers
-
-The `timer` control type is a first-class citizen with three modes:
-
-- **Count up**: Starts at zero and counts upward
-- **Countdown**: Starts at a configured duration and counts down to zero
-- **Count to**: Counts down the remaining time until a target date and time
-
-```html
-
-<div class="timer">[[[c:round_timer]]]</div>
-```
-
-Timer config drives everything: `mode`, `base_seconds`, `offset_seconds`, `running`, `started_at`,
-and `target_datetime`.
-The display value is derived deterministically from these fields.
-There is no mutable tick state to drift or desync. Count-to timers always tick and need no start/stop interaction.
-
-You can read timer values in your Controls, so you can use them to perform complex calculations through
-Expressions Controls.
-
-### Expression Controls
-
-Expression controls are formulas that reference other controls and evaluate entirely client-side with zero latency.
-They enable derived values without any server round-trips.
-
-```
-c.streamlabs.latest_donor_at > c.kofi.latest_donor_at
-  ? c.streamlabs.latest_donor_name
-  : c.kofi.latest_donor_name
-```
-
-Use them in your template like any other control:
-
-```html
-<span class="latest-donor">[[[c:latest_donor]]]</span>
-```
-
-Expressions re-evaluate reactively whenever any referenced control value changes. They support arithmetic, comparisons,
-ternary operators, and can reference controls from any source, including external integrations.
-
-### Control Timestamps
-
-Every control has a companion `_at` value containing the Unix timestamp of its last update. These are available as
-template tags and in expressions:
-
-```html
-<span class="updated">[[[c:death_counter_at]]]</span>
-```
-
-This enables cross-service timing comparisons - for example, showing whichever donation arrived most recently across
-Ko-fi and StreamLabs.
-
-### Boolean Controls
-
-Combine boolean controls with the conditional syntax to show or hide entire overlay sections from your dashboard
-without touching the template:
-
-```html
-[[[if:c:show_donations]]]
-<div class="donation-bar">...</div>
-[[[endif]]]
-```
-
-Flip the control in your dashboard. The overlay responds instantly.
-
-### Control Limits & Broadcasting
-
-Each template supports up to **~~20~~ 50 controls**. Every control value update is broadcast as a `control.updated`
-event on the `alerts.{twitch_id}` WebSocket channel. The overlay receives the update, replaces the tag value in
-reactive state, and re-renders the affected nodes. The rest of the overlay is untouched.
+> [!TIP]
+> **Reading this as a machine?** Every help page is also plain markdown: append `.md` to any URL
+> (`/help/conditionals.md`). For a single self-contained primer, start at
+> [overlabels.com/llms.txt](https://overlabels.com/llms.txt).
 
 ---
 
-## Conditional Rendering
+## Integrations
 
-Overlabels includes a full conditional rendering engine evaluated client-side in the overlay. Any template tag -
-whether it references Twitch API data, a control value, or an event payload - can drive a conditional block.
-
-### Syntax
-
-```html
-[[[if:variable operator value]]]
-...
-[[[elseif:variable operator value]]]
-...
-[[[else]]]
-...
-[[[endif]]]
-```
-
-### Operators
-
-| Operator | Meaning               |
-|----------|-----------------------|
-| `=`      | Equal                 |
-| `!=`     | Not equal             |
-| `>`      | Greater than          |
-| `<`      | Less than             |
-| `>=`     | Greater than or equal |
-| `<=`     | Less than or equal    |
-
-Numeric comparisons are numeric. String comparisons are lexicographic. Truthiness checks (`[[[if:c:show_alerts]]]`)
-treat `"0"`, `"false"`, empty string, `null`, and `undefined` as falsy - everything else is truthy.
-
-### Examples
-
-```html
-[[[if:channel_language = en]]]
-<p>English stream</p>
-[[[elseif:channel_language = es]]]
-<p>Stream en Espanol</p>
-[[[else]]]
-<p>Welcome</p>
-[[[endif]]]
-
-[[[if:followers_total >= 1000]]]
-<div class="milestone">1K Followers reached</div>
-[[[endif]]]
-
-[[[if:subscribers_latest_is_gift]]]
-<span>Gift sub incoming</span>
-[[[endif]]]
-```
-
-Conditionals evaluate after tag replacement, so the full resolved value of any tag - including live control values -
-is available to every comparison. Nesting is supported up to 10 levels deep.
-
----
-
-## Event Alerts
-
-Event alert templates are separate overlays triggered by Twitch EventSub events. They share the full template tag
-syntax and support all control references and conditional blocks. When a Twitch event fires,
-Overlabels renders the assigned alert template with the event payload merged into the tag context,
-broadcasts it to the overlay via WebSocket, and displays it with a configurable transition and duration.
-
-### Supported Twitch Events
-
-| Event                     | Twitch EventSub Type                                  |
-|---------------------------|-------------------------------------------------------|
-| New Follower              | `channel.follow`                                      |
-| New Subscription          | `channel.subscribe`                                   |
-| Gift Subscriptions        | `channel.subscription.gift`                           |
-| Resubscription            | `channel.subscription.message`                        |
-| Bits Cheer                | `channel.cheer`                                       |
-| Raid                      | `channel.raid`                                        |
-| Channel Points Redemption | `channel.channel_points_custom_reward_redemption.add` |
-| Stream Online             | `stream.online`                                       |
-| Stream Offline            | `stream.offline`                                      |
-
-### Event-Specific Tags
-
-Each event type exposes its payload as template tags. A few examples:
-
-**Follows**
-
-```html
-<span>[[[event.user_name]]] just followed!</span>
-```
-
-**Subscriptions**
-
-```html
-<span>[[[event.user_name]]] subscribed at Tier [[[event.tier]]]</span>
-```
-
-**Gift Subscriptions**
-
-```html
-<span>[[[event.user_name]]] gifted [[[event.total]]] subs!</span>
-```
-
-**Raids**
-
-```html
-<span>[[[event.from_broadcaster_user_name]]] is raiding with [[[event.viewers]]] viewers</span>
-```
-
-**Bits**
-
-```html
-<span>[[[event.user_name]]] cheered [[[event.bits]]] bits</span>
-```
-
-### Alert Targeting
-
-By default, alerts fire on every connected static overlay. Alert targeting lets you restrict specific alerts to
-specific static overlays. This is useful when you have multiple scenes in OBS, for example, showing donation
-alerts only on your main gameplay overlay, not on your BRB screen.
-
-If no targeting is configured, the alert fires everywhere (backward-compatible default).
-
-### Assigning Alerts
-
-The **Alerts Builder** maps event types to alert templates. Each mapping stores a display duration (in milliseconds),
-a transition effect, and an enabled flag. You can disable individual alert types without removing the mapping.
-
-Alerts require a static overlay to act as a container. Without a running static overlay on the same browser source,
-there is no DOM to render into.
-
----
-
-## External Integrations
-
-Overlabels connects to external services that drive controls and trigger alerts alongside Twitch events.
-Each integration normalises incoming data into the same control and alert pipeline, your template syntax stays
-the same regardless of the source.
-
-Overlabels does not sell donation ingest, so it has no reason to care which service the money came through.
-Every donation integration is a first-class citizen.
-
-### The Shared Donation Schema
-
-All five donation integrations - Ko-fi, StreamLabs, Fourthwall, Buy Me a Coffee, and Throne - expose the
-**same six controls**. Only the prefix changes, so a template written against one service ports to another by
-swapping the namespace and nothing else.
-
-| Control                     | Type      | Holds                            |
-|-----------------------------|-----------|----------------------------------|
-| `donations_received`        | `counter` | Number of donations received     |
-| `latest_donor_name`         | `text`    | Most recent donor                |
-| `latest_donation_amount`    | `number`  | Most recent donation amount      |
-| `latest_donation_message`   | `text`    | Most recent donation message     |
-| `latest_donation_currency`  | `text`    | Most recent donation currency    |
-| `total_received`            | `number`  | Running total for the session    |
+Twitch EventSub drives followers, subs, gift subs, resubs, cheers, raids, channel point redemptions and
+stream online/offline. Five donation services sit alongside it - Ko-fi, StreamLabs, Fourthwall,
+Buy Me a Coffee and Throne - and every one of them exposes the same six controls, so a template written
+against one ports to another by swapping the namespace.
 
 ```html
 <span>[[[c:kofi:latest_donor_name]]]</span>
 <span>[[[c:throne:latest_donor_name]]]</span>
 ```
 
-Two services extend the schema with their own keys; the six above are always available.
-
-**Connect a service and its controls appear.** All of them, automatically, the moment the connection is
-made. They are service-managed: read-only to you and to the API, updating only when the service sends new
-data. The presets list in the control editor is there for authoring, so you can see which keys exist while
-writing a template, not because anything needs adding by hand.
-
-Because every control carries an `_at` companion timestamp, you can compare across services to find the
-genuinely most recent supporter regardless of which platform they used:
-
-```
-latest(
-  c.kofi.latest_donor_name_at,       c.kofi.latest_donor_name,
-  c.streamlabs.latest_donor_name_at, c.streamlabs.latest_donor_name,
-  c.throne.latest_donor_name_at,     c.throne.latest_donor_name
-)
-```
-
-### Ko-fi
-
-Ko-fi webhooks deliver donation, subscription, shop order, and commission events.
-Each event can trigger alerts and update controls.
-
-Controls use the `kofi:` namespace:
-
-```html
-<span>[[[c:kofi:donations_received]]]</span>
-<span>[[[c:kofi:latest_donor_name]]]</span>
-```
-
-Event types: `donation`, `subscription`, `shop_order`, `commission`
-
-Ko-fi controls are added from presets in the control editor once the integration is connected.
-
-### StreamLabs
-
-StreamLabs connects via OAuth - one click, no token to paste - and delivers donation events through a
-Socket.IO bridge rather than webhooks. The six shared controls are provisioned automatically on connect.
-
-Event types: `donation`
-
-```html
-
-<div class="donation">
-  [[[c:streamlabs:latest_donor_name]]] donated
-  [[[c:streamlabs:latest_donation_amount]]] [[[c:streamlabs:latest_donation_currency]]]
-</div>
-```
-
-### Fourthwall
-
-Fourthwall connects via OAuth from the integration page - two clicks, no token to paste. The six shared
-controls are provisioned automatically on connect.
-
-Event types: `donation`
-
-```html
-<span>[[[c:fourthwall:latest_donor_name]]] tipped [[[c:fourthwall:latest_donation_amount]]]</span>
-```
-
-### Buy Me a Coffee
-
-Paste your Buy Me a Coffee verification token, set your webhook URL, done. Buy Me a Coffee covers more than
-one-off donations, so it provisions **seven** controls: the shared six plus a support type.
-
-| Control              | Type   | Holds                                                                          |
-|----------------------|--------|--------------------------------------------------------------------------------|
-| `latest_support_type`| `text` | `Supporter`, `Commission`, `Extra`, `Membership`, `Subscription`, or `Wishlist` |
-
-Event types: `donation`, `commission`, `extra`, `membership`, `recurring`, `wishlist`
-
-Combine it with a conditional to render a different alert per support type:
-
-```html
-[[[if:c:bmac:latest_support_type = Membership]]]
-<span>[[[c:bmac:latest_donor_name]]] joined the membership!</span>
-[[[else]]]
-<span>[[[c:bmac:latest_donor_name]]] bought a coffee</span>
-[[[endif]]]
-```
-
-### Throne
-
-Connect Throne and paste your Overlabels webhook URL into Throne. There is no token to copy - Throne signs
-every webhook with its own key, which Overlabels verifies. Throne delivers gifts rather than cash, so it
-provisions **nine** controls: the shared six plus three gift-specific ones.
-
-| Control                     | Type   | Holds                                       |
-|-----------------------------|--------|---------------------------------------------|
-| `latest_item_name`          | `text` | Name of the most recent gift                |
-| `latest_item_thumbnail_url` | `text` | Product image URL, ready for an `<img src>` |
-| `latest_is_surprise_gift`   | `text` | `1` when the gift was a surprise, else `0`  |
-
-Event types: `donation`
-
-`latest_is_surprise_gift` works directly with the truthiness form of a conditional, since `"0"` is falsy:
-
-```html
-<img src="[[[c:throne:latest_item_thumbnail_url]]]" alt="[[[c:throne:latest_item_name]]]">
-
-[[[if:c:throne:latest_is_surprise_gift]]]
-<span>A surprise gift from [[[c:throne:latest_donor_name]]]!</span>
-[[[endif]]]
-```
-
-### Integration Pipeline
-
-All external services follow the same pipeline:
-
-1. Incoming webhook or socket event is verified and parsed
-2. The event is deduplicated and stored
-3. Matching controls are updated and broadcast in real time
-4. If an alert template is mapped to the event type, it fires through the standard alert pipeline
-
-Service-managed controls (auto-provisioned by integrations) cannot be manually edited, they update only when the
-service sends new data.
+Connect a service and its controls appear automatically. See
+[integration presets](https://overlabels.com/help/integration-presets) for the full list.
 
 ---
 
-## The Rendering Pipeline
+## Limits
 
-Understanding the pipeline removes all mystery from how Overlabels works.
-
-### Static Overlays
-
-1. A browser source in OBS loads `https://overlabels.com/overlay/{slug}#token`
-2. The token in the URL fragment is extracted client-side - it is **never sent to the server**
-3. The frontend initialises a WebSocket connection via Laravel Reverb and mounts the `OverlayRenderer` Vue component
-4. The renderer fetches template data and live Twitch values using the token
-5. Tag replacement runs: `[[[tag]]]` patterns are replaced with resolved values
-6. Expression controls are registered and evaluated client-side
-7. Conditional blocks are evaluated and non-matching branches are removed from output
-8. CSS is injected into the document head via a `<style id="overlay-style">` tag
-9. The rendered HTML is mounted into the overlay DOM
-10. The WebSocket channel `alerts.{twitch_id}` is subscribed for live updates
-
-### Live Updates
-
-After initial render, the overlay stays live through three update mechanisms:
-
-- **Control updates**: `control.updated` WebSocket events trigger reactive re-renders of affected tags and
-- re-evaluation of expressions that reference the changed control
-- **EventSub events**: `channel.follow`, `channel.subscribe`, etc. cause relevant aggregate tags
-- (e.g., `followers_total`) to update
-- **Alert triggers**: Alert templates are broadcast as complete render payloads, displayed over the static overlay,
-- and auto-dismissed after their configured duration
-
-### Overlay Health
-
-The overlay includes built-in resilience for the unpredictable environment of OBS browser sources:
-
-- Automatic reconnection with exponential backoff when the WebSocket drops
-- Periodic health checks to detect stale connections
-- Visual error banners (since OBS browser sources cannot show console output)
-- Auto-reload as a last resort when recovery fails
-
-### Alert Render Flow
-
-1. A Twitch EventSub webhook or external service event arrives
-2. The event is validated (HMAC-SHA256 for Twitch, per-service verification for externals)
-3. The event is stored and broadcast over the internal queue
-4. A mapping lookup finds the assigned template for this event type and user
-5. Current overlay data is merged with the event payload
-6. The compiled alert is broadcast to `alerts.{twitch_id}` via WebSocket
-7. The overlay frontend receives the payload, checks alert targeting rules, and renders into the alert DOM node
-8. The configured transition plays, the alert displays for `duration_ms` milliseconds, then auto-dismisses
-
-### Script/Embed/iFrame Tag Policy
-
-`<script>`, `<embed>`, `<iframe>` and any other scary tag are stripped from all template content - `head`, `html`, 
-`css`, and meta fields - before storage. This is visualised client-side but also enforced server-side
-before form submission. External stylesheets, font libraries, icon libraries,
-and CDN-hosted CSS are all permitted. Inline scripts are not. Neither are embeds. This is to prevent
-XSS attacks and to prevent accidental embedding of malicious content. If you need to embed a third-party
-script, you're out of luck. Simple as that.
+- Up to 1000 overlays per account, 50 controls per overlay.
+- No asset hosting.
+- `<script>`, `<iframe>`, `<embed>` and similar tags are stripped from template content before storage.
+  External stylesheets, fonts, icon libraries and CDN-hosted CSS are all fine. Inline scripts are not.
+- Overlay access uses 64-character hex tokens passed in the URL fragment, so they are never sent to the
+  server. Tokens are hashed on storage, revocable, and can expire or be bound to an IP range.
 
 ---
 
-## Overlay Kits
-
-An Overlay Kit is a named collection of templates designed to work together as a cohesive system.
-A kit might include a static overlay, a follower alert, a subscription alert, a raid alert, and a
-channel points redemption alert. All sharing a visual language, matching CSS variables,
-and a consistent tag vocabulary.
-
-Kits can be copied in a single action. Copying a kit creates duplicates of every template it contains,
-owned by you, ready to customise.
-
-**Note:** Kits are user-generated content. They can contain anything you like, or nothing you want. Have a good
-look at the Kit's contents before you copy it to your own account.
-
----
-
-## Copying
-
-Any public template or kit can be copied. Copying creates a full independent duplicate owned by you.
-The original is untouched. Your copy is yours to modify, extend, or break however you like.
-
-When copying a template that has **Controls**, the Import Wizard walks you through which controls to carry over.
-Control references in the template are preserved as-is - you pick what state comes with the copy.
-
-Public templates are public by default. Privacy is opt-in. There are no paywalls, no tiers, no licensing restrictions.
-
----
-
-## Onboarding
-
-When a new account is created, Overlabels runs an automated onboarding pipeline in the background:
-
-1. **Webhook secret** - A per-user 32-byte hex secret is generated for HMAC validation
-2. **Starter kit**: The configured starter kit is automatically copied into your account,
-3. giving you a working set of templates on day one
-4. **Alert assignment**: Copied templates are matched to event types by keyword detection and
-5. auto-assigned in the Alerts Builder
-6. **Tag generation**: A background job fetches your live Twitch data and generates your full personalised tag set
-
-The onboarding status endpoint tracks each step: `kit_forked`, `tags_status`, `alerts_mapped`, `token_created`,
-and `has_webhook_secret`. The dashboard reflects this state in real time as each step completes.
-
----
-
-## Testing
-
-The `/testing` page provides a personalised testing environment for every supported Twitch event.
-Each command is pre-filled with your Twitch ID, your webhook URL, and your per-user webhook secret,
-ready to copy and run directly in your terminal via the [Twitch CLI](https://github.com/twitchdev/twitch-cli).
-
-```bash
-twitch event trigger channel.follow \
-  --transport=webhook \
-  -F https://overlabels.com/api/twitch/webhook \
-  -s your_webhook_secret \
-  --to-user your_twitch_id \
-  --from-user 1234567
-```
-
-Commands are blurred by default and revealed on hover. *Don't leak these commands on stream!*
-
----
-
-## Token Security
-
-Overlay access is authenticated via 64-character hexadecimal tokens (256 bits of randomness). Tokens are:
-
-- **Hashed on storage**: only the SHA-256 hash is stored server-side; the plain token is shown once
-- **Never transmitted in the URL path**: passed as a URL fragment (`#token`), which browsers do not include
-- in HTTP requests
-- **Revocable**: a compromised token can be disabled or deleted without affecting other tokens
-- **Optionally expiring**: set an `expires_at` to time-limit overlay access
-- **Optionally IP-restricted**: bind a token to a specific IP or CIDR range
-
-Public overlays additionally support hash-based shareable links that require no token at all, intended for
-public display or embedding without authentication.
-
----
-
-## Adding to OBS
-
-1. Generate a static overlay in Overlabels. Every alert template requires a static overlay to render into.
-2. A big "Add to OBS" button appears in the template viewer. Click it and a secure overlay URL is copied to your 
-   clipboard. You can also drag the button directly into OBS and it will generate a Browser Source with perfect 
-   defaults for you. This is the recommended way to add an overlay to OBS
-3. If you want to manually add a browser source, copy the URL and paste it into a new Browser Source in OBS.
-4. Set the source dimensions to match your canvas (typically 1920x1080).
-5. Your overlay is live!
-
-When a Twitch event fires - a follow, a sub, a raid - or an external event arrives - a Ko-fi donation, a
-StreamLabs tip&hellip; The alert template renders over the static overlay, transitions in, displays for the configured
-duration, and transitions out. No interaction required.
-
----
-
-## Tech Stack
+## Tech stack
 
 | Layer             | Technology                             |
 |-------------------|----------------------------------------|
 | Backend           | Laravel 12, PHP 8.4                    |
 | Frontend          | Vue 3 (Composition API), TypeScript    |
 | Styling           | TailwindCSS v4                         |
-| UI Components     | RekaUI/Shadcn/Vue                      |
+| UI components     | RekaUI/Shadcn/Vue                      |
 | Full-stack bridge | Inertia.js                             |
 | Real-time         | Laravel Reverb (self-hosted WebSocket) |
 | Code editor       | CodeMirror                             |
@@ -623,9 +124,9 @@ duration, and transitions out. No interaction required.
 
 ---
 
-## Self-Hosting
+## Self-hosting
 
-**No support is provided when you self-host Overlabels.** The following instructions are for development and testing.
+**No support is provided when you self-host Overlabels.** The following is for development and testing.
 
 ```bash
 git clone https://github.com/jasperfrontend/overlabels
@@ -639,7 +140,7 @@ npm run build
 composer run dev
 ```
 
-**Required environment variables:**
+Required environment variables:
 
 ```env
 TWITCH_CLIENT_ID=
@@ -652,10 +153,8 @@ DB_CONNECTION=pgsql
 BROADCAST_CONNECTION=reverb
 ```
 
-**Optional (for external integrations):**
-
-Only the OAuth-based integrations need app credentials. Ko-fi, Buy Me a Coffee, and Throne authenticate
-per-user with a token or signature, so they need no environment configuration at all.
+Optional, for the OAuth-based integrations only. Ko-fi, Buy Me a Coffee and Throne authenticate per-user
+with a token or a signature, so they need no environment configuration at all.
 
 ```env
 # StreamLabs (OAuth + Socket.IO listener)
@@ -671,45 +170,19 @@ FW_REDIRECT_URL=
 FW_HMAC=
 ```
 
-Your `APP_URL` must be publicly reachable for Twitch EventSub webhooks to deliver.
-For local development, use [ngrok](https://ngrok.com) or a similar tunnel.
+Your `APP_URL` must be publicly reachable for Twitch EventSub webhooks to deliver. For local development,
+use [ngrok](https://ngrok.com) or a similar tunnel.
 
 ---
 
-## Philosophy
+## Sustainability
 
-Overlabels is built on one assumption: streamers who can write a `<div>` should not be locked out of good
-overlays by proprietary tools.
+Overlabels is free forever, for anyone. Its footprint is small: the whole backend runs on a few instances
+and hosting costs less than a PhpStorm licence. There are plans beyond that, but nothing that turns the
+overlays into a paywall.
 
-- The triple-bracket syntax exists because simplicity is different from limitation. 
-- The Controls system exists because overlays should respond to a streamer's intent, not just Twitch's event stream.
-- External integrations exist because a streamer's ecosystem extends beyond Twitch.
-- The copying system exists because good design compounds. Every overlay that exists is a starting point for the next 
-  one.
-- Overlabels overlays are free forever, for anyone, anytime. No paywalls. No tiers. Loose limits.
-
-## Limitations of the Overlabels service
-- You can create up to 1000 overlays per account.
-- Each overlay can have up to 50 Controls.
-- We do not offer asset hosting.
-- Any script, iframe, embed is stripped from your overlay templates before saving.
-
-## Limitations of the (NEW) Android GPS location app
-> [!NOTE]
-> The Android GPS Location app is still in active development and not ready for release just yet. 
-- You can only use the app to display a single location.
-- You can only send GPS location data to Overlabels every 5–60 seconds (user setting).
-
-### If everything is free, how do you keep Overlabels sustainable?
-Good question. First and foremost: Overlabels' footprint is actually rather small. The whole backend
-is hosted on a few instances and the total hosting costs are negligible. In fact, the monthly fee
-for my PhpStorm licence is more expensive than the cost of hosting Overlabels itself.
-
-### But that still doesn't explain how you plan on making Overlabels sustainable?
-Don't worry. I have plans ❤. For now, Overlabels is small and easy to maintain.
-
-Of course you're free to send me a [Ko-fi](https://ko-fi.com/jasperfromoverlabels) tip if you like what I do!
-Be sure to mention this README somewhere in your tip so I can link your support back to Overlabels.
+If you like what this is, a [Ko-fi](https://ko-fi.com/jasperfromoverlabels) tip is always welcome. Mention
+this README in your tip so I can link your support back to Overlabels.
 
 ---
 
@@ -718,49 +191,25 @@ Be sure to mention this README somewhere in your tip so I can link your support 
 Overlabels is licensed under the **GNU Affero General Public License, version 3 or later**
 (`AGPL-3.0-or-later`), as of August 9th, 2026. The full text is in [LICENSE](LICENSE).
 
-Before that date this repository carried no licence at all. The `composer.json` metadata declared
-`"license": "MIT"`, but that line arrived untouched in the initial Laravel scaffold commit
-(`783b81fc`) as part of the starter kit's default metadata, and was never a deliberate choice. No
-`LICENSE` file was ever published in this repository granting MIT terms. The AGPL applies going
-forward from the date above; this is a forward-only relicense and no history has been rewritten.
+Before that date this repository carried no licence at all. The `"license": "MIT"` line in `composer.json`
+arrived untouched in the initial Laravel scaffold commit (`783b81fc`) and was never a deliberate choice; no
+`LICENSE` file granting MIT terms was ever published here. The relicense is forward-only and no history has
+been rewritten.
 
-What this means in practice:
-
-- You can read, run, modify and share the source code freely.
-- If you **self-host a modified version** and other people can reach it over a network, section 13
-  of the AGPL requires you to offer those users the source of your modified version. Running an
-  unmodified copy for yourself carries no such obligation.
-- This governs the **Overlabels source code**. It does not govern the overlay templates, kits and
-  controls you create with Overlabels - those are yours, and the copying rules for them are
-  described under [Copying](#copying).
-
-### Copyright notice
-
-```
-Overlabels
-Copyright (c) 2026 JasperDiscovers
-
-This program is free software: you can redistribute it and/or modify it under the terms of the
-GNU Affero General Public License as published by the Free Software Foundation, either version 3
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License along with this program.
-If not, see <https://www.gnu.org/licenses/>.
-```
+In practice: you can read, run, modify and share the source freely. If you self-host a **modified** version
+that other people can reach over a network, AGPL section 13 requires you to offer those users the source of
+your modified version. Running an unmodified copy for yourself carries no such obligation. This governs the
+Overlabels source code, not the overlay templates, kits and controls you create with it - those are yours.
 
 ---
 
 ## Contributing
 
-If you have questions, ideas, or improvements, open an issue or submit a pull request.
-Overlabels grows best when people build on top of it.
+Questions, ideas and improvements are welcome. Open an issue or a pull request.
 
-[CONTRIBUTING.md](CONTRIBUTING.md) covers the workflow, the house rules for user-facing copy, and how
-to sign off your commits. Participation is covered by the [Code of Conduct](CODE_OF_CONDUCT.md).
+[CONTRIBUTING.md](CONTRIBUTING.md) covers the workflow, the house rules for user-facing copy, and how to
+sign off your commits. Participation is covered by the [Code of Conduct](CODE_OF_CONDUCT.md). Security
+issues go through [SECURITY.md](SECURITY.md).
 
 Contributions are accepted under the same AGPL-3.0-or-later terms as the rest of the project.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ source and it stays in sync with what is actually deployed.
 | [Overlays vs Alerts](https://overlabels.com/help/overlays-vs-alerts)     | The two surfaces and how they fit together        |
 | [The Builder](https://overlabels.com/help/builder)                       | Compose an overlay on a grid, no code required    |
 | [Blocks](https://overlabels.com/help/blocks)                             | Reusable pieces: authoring, CSS scoping, controls |
+| [How an overlay renders](https://overlabels.com/help/rendering)          | The pipeline end to end, and why scripts are stripped |
+| [Testing your alerts](https://overlabels.com/help/testing)               | Fire real Twitch events from a terminal           |
 
 **The template language**
 
@@ -69,6 +71,7 @@ source and it stays in sync with what is actually deployed.
 | Page                                                        | What it covers                                                |
 |-------------------------------------------------------------|---------------------------------------------------------------|
 | [Reference](https://overlabels.com/help/reference)           | Every template tag, EventSub event and foreach field          |
+| [Overlay access tokens](https://overlabels.com/help/tokens)  | The credential in your overlay URL, and what to do if it leaks |
 | [Twitch chat bot](https://overlabels.com/help/bot)           | Letting viewers and mods change controls from chat            |
 | [Free resources](https://overlabels.com/help/resources)      | Colors, fonts, animations and other tools                     |
 
@@ -102,8 +105,10 @@ Connect a service and its controls appear automatically. See
 - No asset hosting.
 - `<script>`, `<iframe>`, `<embed>` and similar tags are stripped from template content before storage.
   External stylesheets, fonts, icon libraries and CDN-hosted CSS are all fine. Inline scripts are not.
+  ([why](https://overlabels.com/help/rendering))
 - Overlay access uses 64-character hex tokens passed in the URL fragment, so they are never sent to the
-  server. Tokens are hashed on storage, revocable, and can expire or be bound to an IP range.
+  server. Tokens are hashed on storage, revocable, and can expire or be pinned to specific client IPs.
+  ([details](https://overlabels.com/help/tokens))
 
 ---
 

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,17 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 14th, 2026 - docs: the README stops competing with the help pages
+
+767 lines down to 216, 4192 words down to 1093. The README had grown a second copy of the documentation - tag tables, control types, conditional operators, a section per donation integration, the full render pipeline - and every one of those had a better version at `overlabels.com/help` that is indexable, searchable and actually in sync with what is deployed. The README now points at them instead of paraphrasing them badly.
+
+- **The help pages are the SEO surface, and a duplicate in a repo README competes with them for nothing.** Every page under `/help` renders as indexable HTML with its own `title`, `description` and `canonical`. The README version had no canonical, no search, and drifted the moment a feature shipped - it had grown far enough to contradict itself, stating on line 339 that connecting a service provisions all its controls automatically and on line 369 that Ko-fi's are added from presets by hand. The first is what `DonationIntegrationController` actually does; the second is what it did before the August consolidation.
+- **All 19 help links were verified against the router, not eyeballed.** `HelpPage::all()` registers one route per markdown file, so a renamed page silently 404s a hardcoded link. Every URL in the new README was checked against `route:list --path=help` output, plus `public/llms.txt`, which is a static file and therefore does not appear in the route list at all.
+- **What stayed is what a GitHub visitor cannot get from the website.** Self-hosting and its env vars, the tech stack, the licence and its relicensing history, contributing, and the sustainability answer. Those are repo questions, not overlay-authoring questions.
+- **Limits got compressed rather than dropped, because two of them are safety-relevant.** The script/iframe/embed stripping and the token model are the two things a security-minded reader looks for first, so they survive as four lines under `## Limits` instead of two full sections.
+- **Four topics have no help page and were cut with nothing to link to:** the render pipeline, onboarding, the `/testing` page, and token security in full. The first three are internal detail a reader does not need before they have an account, and token security survives in condensed form. Worth a help page eventually; not worth a README section in the meantime.
+- **The AGPL section keeps the relicensing paragraph and drops the boilerplate copyright block.** The history of the never-granted MIT line matters and is not written down anywhere else. The GPL warranty notice is in `LICENSE`, where it is legally operative, and repeating it in the README added 15 lines of text nobody reads.
+
 ## August 14th, 2026 - feat: the event binding on an alert now has a shape
 
 `/templates?type=alert` showed which event fires each alert as a bare run of coloured text under the description. It read like an unstyled hyperlink, and colour was doing the identifying on its own. It now carries the same provider icon the events feed has used since July - and so do the alert's own show and edit pages, which never named the bound service at all.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,17 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 15th, 2026 - docs: three help pages for what the README used to be the only home for
+
+Slimming the README yesterday left four topics with no page to link to. Three now have one: [How an overlay renders](/help/rendering), [Testing your alerts](/help/testing), and [Overlay Access Tokens](/help/tokens). Onboarding stays cut on purpose.
+
+- **Writing them against the code rather than the old README caught two things the README had wrong.** It claimed overlay tokens could be bound to "a specific IP or CIDR range" - `OverlayAccessToken::isValid()` does `in_array($clientIp, $this->allowed_ips)`, an exact string match, so `203.0.113.0/24` matches nothing and would lock the user out of their own overlay. It also described the `/testing` commands as "blurred by default and revealed on hover"; they are behind a "Show command" checkbox, and clicking a row copies to the clipboard. Both are now documented as built, and the CIDR line is a `[!WARNING]` because getting it wrong is silent.
+- **Onboarding was cut rather than written up, on Jasper's call.** The pipeline still copies a starter kit, which is good, but the experience around it reads as a one-shot ceremony you must not get wrong - and the friction it was mitigating has since been solved in context by the "Add to OBS" button on `templates/show` and `templates/edit`. A help page describing the current flow would preserve something that wants replacing.
+- **`rendering.md` deliberately declares no `context:`.** The obvious claim is `templates.show`, and `HelpContextTest` asserts that `templates.show?type=static` resolves to **nothing** - a bare `templates.show` would match it and fail that test. `templates.edit` was the other candidate and already carries two pages, so claiming it would sit exactly on the three-page cap and hand the failure to whoever writes the next page. It joins `manifesto`, `math` and `for-creators` as a page you go to rather than one that finds you.
+- **The other two claim a context each, both with headroom.** `tokens.md` takes `tokens.index`, joining `lists-realtime` at two of three. `testing.md` takes `testing.index`, which no page had claimed.
+- **The index entries are not optional.** `HelpPageTest` has a test that every markdown page is reachable from `/help`, so a new page without an index line fails the suite rather than quietly existing at a URL nobody links to.
+- **Every internal link was resolved against the router, and Prettier was run before committing.** Seven internal links across the three pages, all checked against `route:list`. `npm run format:check` covers `resources/`, which is where help pages live, and Prettier formats code inside markdown fences - so a new page with a misindented fence is a CI failure now, not a cosmetic nit.
+
 ## August 14th, 2026 - docs: the README stops competing with the help pages
 
 767 lines down to 216, 4192 words down to 1093. The README had grown a second copy of the documentation - tag tables, control types, conditional operators, a section per donation integration, the full render pipeline - and every one of those had a better version at `overlabels.com/help` that is indexable, searchable and actually in sync with what is deployed. The README now points at them instead of paraphrasing them badly.
@@ -10,7 +21,7 @@
 - **All 19 help links were verified against the router, not eyeballed.** `HelpPage::all()` registers one route per markdown file, so a renamed page silently 404s a hardcoded link. Every URL in the new README was checked against `route:list --path=help` output, plus `public/llms.txt`, which is a static file and therefore does not appear in the route list at all.
 - **What stayed is what a GitHub visitor cannot get from the website.** Self-hosting and its env vars, the tech stack, the licence and its relicensing history, contributing, and the sustainability answer. Those are repo questions, not overlay-authoring questions.
 - **Limits got compressed rather than dropped, because two of them are safety-relevant.** The script/iframe/embed stripping and the token model are the two things a security-minded reader looks for first, so they survive as four lines under `## Limits` instead of two full sections.
-- **Four topics have no help page and were cut with nothing to link to:** the render pipeline, onboarding, the `/testing` page, and token security in full. The first three are internal detail a reader does not need before they have an account, and token security survives in condensed form. Worth a help page eventually; not worth a README section in the meantime.
+- **Four topics had no help page to link to.** The render pipeline, onboarding, the `/testing` page, and token security in full. Three of them got one the next day - see the entry above. Onboarding deliberately did not.
 - **The AGPL section keeps the relicensing paragraph and drops the boilerplate copyright block.** The history of the never-granted MIT line matters and is not written down anywhere else. The GPL warranty notice is in `LICENSE`, where it is legally operative, and repeating it in the README added 15 lines of text nobody reads.
 
 ## August 14th, 2026 - feat: the event binding on an alert now has a shape

--- a/resources/help/pages/index.md
+++ b/resources/help/pages/index.md
@@ -33,6 +33,10 @@ canonical: https://overlabels.com/help
   cell, pick a block, save. Compiles to a plain static overlay that works with everything else.
 - [**Blocks**](/help/blocks) - reusable building pieces for the Builder: how to author one, how CSS
   scoping and snapshots keep everyone safe, and how controls travel with your block.
+- [**How an overlay renders**](/help/rendering) - the pipeline end to end: boot, tag replacement,
+  conditionals, live updates, alert render flow, and why scripts are stripped.
+- [**Testing your alerts**](/help/testing) - fire any of 28 real Twitch events at your own account from a
+  terminal, instead of waiting for a real follower.
 
 ## The template language
 
@@ -68,6 +72,8 @@ canonical: https://overlabels.com/help
 
 - [**Reference**](/help/reference) - fuzzy-searchable reference for every template tag, EventSub event,
   and foreach field. Press Alt+r from anywhere.
+- [**Overlay Access Tokens**](/help/tokens) - what the 64-character token in your overlay URL is, why it
+  lives after the `#`, and what to do the moment one leaks.
 - [**Why Ko-fi**](/help/why-kofi) - why we chose Ko-fi as our first External Integration over Patreon,
   Stripe, or built-in payments.
 - [**Free Resources**](/help/resources) - colors, fonts, animations, images, and other tools for building

--- a/resources/help/pages/rendering.md
+++ b/resources/help/pages/rendering.md
@@ -1,0 +1,130 @@
+---
+title: How an overlay renders - the pipeline end to end
+description: "What happens between an OBS browser source opening your overlay URL and a follower alert animating on screen: boot, tag replacement, conditionals, the WebSocket channel, alert render flow, and why scripts are stripped."
+heading: How an overlay renders
+lead: From the browser source opening a URL to a follower alert animating on screen - the whole path, in order. Worth reading once, and worth having when something is not appearing and you need to know which step to suspect.
+canonical: https://overlabels.com/help/rendering
+---
+
+Overlabels is not magic, and knowing the order things happen in turns "my overlay is blank" from a mystery
+into a question with about four possible answers.
+
+## Boot: a static overlay
+
+```
+  OBS browser source
+        |
+        v
+  /overlay/{slug}#token          1. page loads, token read from the fragment
+        |
+        v
+  Echo / Reverb connection       2. WebSocket opens
+        |
+        v
+  GET /api/overlay/render        3. template + live Twitch data
+        |
+        v
+  tags -> conditionals -> CSS    4. resolve, evaluate, inject
+        |
+        v
+  mounted, subscribed            5. listening on alerts.{twitch_id}
+```
+
+In detail:
+
+1. **The page loads and reads the token.** The fragment is pulled off `window.location.hash` and checked
+   for a length of 64. If it is missing or the wrong length, you get the "your overlay link is broken"
+   screen instead of a silent blank page - that message exists because OBS cannot show you a console.
+2. **A WebSocket connection opens** to Laravel Reverb, authenticated against your token. This happens
+   early and independently, so a render failure and a connection failure are separately diagnosable.
+3. **The renderer fetches your template and your live data** in one call, using the token.
+4. **Tag replacement runs.** Every `[[[tag]]]` is resolved in a single pass - Twitch values, control
+   values, formatting pipes and all. This happens exactly once per render.
+5. **Expression controls are registered** and evaluated client-side, so derived values cost no round trip.
+6. **Conditional blocks are evaluated** and branches that did not match are removed from the output
+   entirely, rather than hidden with CSS.
+7. **Your CSS is injected** into the document head as a single `<style id="overlay-style">` element.
+8. **The rendered HTML is mounted**, and the overlay subscribes to `alerts.{your_twitch_id}` for
+   everything that happens next.
+
+> [!IMPORTANT]
+> Tags are parsed **once**, and resolved values are never re-scanned for tags. This is deliberate: if a
+> control value containing `[[[something]]]` were reparsed, anyone who could set a control could inject
+> into your overlay. A value that looks like a tag renders as text.
+
+## Staying live
+
+After the first render, three things update the overlay in place. None of them reload the page.
+
+| Mechanism           | What arrives                          | What happens                                                        |
+|---------------------|----------------------------------------|---------------------------------------------------------------------|
+| **Control updates** | `control.updated`                      | The value updates in reactive state; expressions that read it re-evaluate |
+| **Twitch events**   | EventSub webhook, relayed              | Aggregate tags like `followers_total` move                          |
+| **Alerts**          | A complete pre-rendered alert payload  | Rendered over the static overlay, then auto-dismissed               |
+
+Only the affected nodes change. The rest of the overlay is untouched, which is why a counter ticking over
+does not restart a CSS animation running elsewhere on the page.
+
+## Alert render flow
+
+```
+  Twitch EventSub webhook  /  external service webhook
+        |
+        v  verified (HMAC-SHA256 for Twitch, per-service for the rest)
+  stored + deduplicated
+        |
+        v  which template is mapped to this event type, for this user?
+  merged with current overlay data and rendered server-side
+        |
+        v  broadcast on alerts.{twitch_id}
+  overlay checks targeting rules -> renders -> transition -> auto-dismiss
+```
+
+The alert arrives at your overlay as **finished HTML**. Your browser source is not fetching anything or
+deciding anything; it is being handed a rendered payload and asked to display it for `duration_ms`.
+
+Two consequences worth knowing:
+
+- **An alert needs a static overlay to render into.** There is no DOM otherwise. If your alerts are not
+  appearing, confirm a static overlay is actually running in that browser source. See
+  [Overlays vs Alerts](/help/overlays-vs-alerts).
+- **Targeting is checked at the overlay, not at the server.** An alert with no targeting configured fires
+  everywhere; one with targeting is ignored by overlays not on its list.
+
+## Overlay health
+
+An OBS browser source is a hostile place to run a web page. It gets suspended, the machine sleeps, the
+network drops mid-stream, and nobody is watching a console. So the overlay defends itself:
+
+- **Reconnects with exponential backoff** when the WebSocket drops
+- **Periodic health checks** to notice a connection that is technically open but actually dead
+- **Visible error banners**, because a console error in OBS reaches nobody
+- **Auto-reload as a last resort** when recovery fails
+
+The banner styles are defined in the page itself rather than in the Vue app, specifically so an error can
+be displayed even when the app failed to mount.
+
+## Why scripts are stripped
+
+`<script>`, `<iframe>`, `<embed>` and friends are removed from all template content - HTML, CSS, head and
+meta fields alike - before it is stored. This is enforced on the server, not just flagged in the editor.
+
+**What still works:** external stylesheets, web fonts, icon libraries, CDN-hosted CSS, and every animation
+CSS can express. That covers the overwhelming majority of overlay design.
+
+**What does not:** inline scripts, third-party embeds, and anything that needs to execute JavaScript
+inside the overlay.
+
+Overlays are shared and copied between users by design. A template that could run arbitrary JavaScript
+would be running it with your overlay token in scope, on a machine that is live to an audience. Stripping
+scripts is what makes "copy this stranger's overlay" a safe thing to do.
+
+If you need real JavaScript - a wheel, a canvas, a custom visualisation - the supported path is to host
+your own page and add it to OBS as its own browser source, reading your data over the API.
+[Lists in realtime](/help/lists-realtime) walks through exactly that.
+
+## Related
+
+- [Overlays vs Alerts](/help/overlays-vs-alerts) - why alerts belong inside a static overlay
+- [Overlay Access Tokens](/help/tokens) - the credential used in step 1
+- [Testing your alerts](/help/testing) - firing real events at this pipeline on demand

--- a/resources/help/pages/testing.md
+++ b/resources/help/pages/testing.md
@@ -1,0 +1,98 @@
+---
+title: Testing your alerts with the Twitch CLI
+description: "Fire any of 28 real Twitch EventSub events at your own Overlabels account from a terminal. Setting up the Twitch CLI, using the Testing page, what your webhook secret is for, and why you should never show these commands on stream."
+heading: Testing your alerts
+lead: Fire real Twitch events at your own account from a terminal, without waiting for an actual follower. What the Testing page gives you, how to set up the Twitch CLI, and the one rule about never showing these commands on stream.
+canonical: https://overlabels.com/help/testing
+context: testing.index
+---
+
+You have built a follower alert. To see it, you need a follower. That is a bad development loop.
+
+The [Testing page](/testing) fixes it: it hands you a ready-to-run command for every Twitch event
+Overlabels supports, pre-filled with your Twitch ID, your webhook URL and your webhook secret. Paste one
+into a terminal and a real EventSub webhook arrives at your account, taking exactly the same path a real
+follow would.
+
+## Setup, once
+
+You need the [Twitch CLI](https://dev.twitch.tv/docs/cli/) installed, and you need to have run:
+
+```bash
+twitch configure
+```
+
+once, with a client ID and secret from a Twitch application. That is the entire setup. The CLI is Twitch's
+own tool, not an Overlabels one.
+
+## Using the Testing page
+
+Every event is a row. **Click a row and its command is copied to your clipboard.** Paste it into a
+terminal, press enter, and watch your overlay.
+
+- **Filter box** - type `raid`, `poll`, `hype` or any part of an event name to narrow the list.
+- **"Show command" checkbox** - reveals the full command inline for every row. It is off by default,
+  which is a deliberate choice covered below.
+- Events are grouped into 8 families: Basic, Channel Points, Stream, Hype Train, Charity, Goals, Polls
+  and Predictions. 28 event types in total.
+
+A copied command looks like this:
+
+```bash
+twitch event trigger channel.follow \
+  --transport=webhook \
+  -F https://overlabels.com/api/twitch/webhook \
+  -s your_webhook_secret \
+  --to-user your_twitch_id \
+  --from-user 1234567
+```
+
+`--from-user` is the fake viewer the event comes from. Change that number and the alert shows a different
+user ID - handy for checking how your layout copes with a long name versus a short one.
+
+> [!WARNING]
+> **Never show these commands on stream, and never paste one into chat.** The `-s` flag is your webhook
+> secret in plain text. Anyone who has it can send your account convincing fake events - fake raids, fake
+> donations, fake subs - and your overlay will believe every one of them. This is why the commands are
+> hidden behind a checkbox rather than shown by default: the page is designed to be safe to have open
+> while you are live.
+
+## Your webhook secret
+
+The secret is what proves an incoming webhook genuinely came from Twitch. Every request is signed with it
+using HMAC-SHA256, and Overlabels rejects anything whose signature does not verify.
+
+Each account gets its own 32-byte secret, generated when the account is set up. If yours has not been
+generated yet the Testing page tells you so and falls back to the instance-wide secret - the commands
+still work, they are just not unique to you.
+
+## What to expect
+
+A triggered event is a **real** event as far as Overlabels is concerned. It is verified, stored,
+deduplicated, and it will:
+
+- Fire the alert template mapped to that event type, if you have mapped one
+- Update any controls the event feeds
+- Appear in your events feed alongside genuine events
+
+That last point is the one that surprises people. Test events are not marked as tests - the whole value is
+that they are indistinguishable from the real thing. If you fire twenty test cheers, your events feed has
+twenty cheers in it.
+
+> [!NOTE]
+> **Alerts need a static overlay to render into.** If a command runs cleanly and nothing appears, the
+> usual cause is that no static overlay is open in the browser source, not that the event failed. See
+> [Overlays vs Alerts](/help/overlays-vs-alerts).
+
+## Testing things that are not Twitch
+
+The Twitch CLI only speaks Twitch. For the donation integrations - Ko-fi, StreamLabs, Fourthwall, Buy Me a
+Coffee, Throne - each service has its own test facility, and Overlabels can replay any external event it
+has already received from your events feed. Replay is usually the faster loop: get one real donation, then
+replay it as often as you like while you build the alert.
+
+## Related
+
+- [How an overlay renders](/help/rendering) - the pipeline your test event travels through
+- [Overlays vs Alerts](/help/overlays-vs-alerts) - why an alert needs a static overlay
+- [Twitch EventSub Reference](https://dev.twitch.tv/docs/eventsub/eventsub-reference/) - the payload of every event

--- a/resources/help/pages/tokens.md
+++ b/resources/help/pages/tokens.md
@@ -1,0 +1,115 @@
+---
+title: Overlay Access Tokens - how overlay URLs stay private
+description: "How Overlabels overlay tokens work: 256 bits of randomness, hashed on storage, carried in the URL fragment so they are never sent to a server. Expiry, IP allowlists, access logs, and what to do when one leaks."
+heading: Overlay Access Tokens
+lead: The 64-character token at the end of your overlay URL is the thing that makes the overlay yours. Here is what it is, why it lives after the # instead of in the path, and what to do the moment you think one has leaked.
+canonical: https://overlabels.com/help/tokens
+context: tokens.index
+---
+
+Your overlay URL looks like this:
+
+```
+https://overlabels.com/overlay/my-overlay#7f3a9c...  <- 64 hex characters
+```
+
+Everything before the `#` is public and boring. Everything after it is the credential. This page explains
+what that credential is and how it is handled, because "paste this URL into OBS" deserves a better answer
+than "trust us".
+
+## What the token is
+
+When you generate a token, Overlabels asks the operating system for **32 random bytes** and renders them
+as hexadecimal. That is 64 characters and **256 bits of randomness**. There is no pattern, no encoded user
+ID, no timestamp inside it. It is not guessable, and it is not derived from anything about you.
+
+The first 8 characters are stored separately as a **prefix**, purely so your [tokens page](/tokens) can
+show you which token is which without ever holding the real thing.
+
+## Why it lives after the `#`
+
+This is the part worth understanding, because it is the whole security design in one sentence:
+
+> **Browsers never send the URL fragment to the server.**
+
+The fragment - everything after the `#` - is a client-side-only construct. It does not appear in the HTTP
+request line, so it never lands in a server access log, a proxy log, a CDN log, or a `Referer` header on
+an outbound request. A page that logs every URL it serves still never sees your token.
+
+The overlay page reads it with `window.location.hash`, checks it is 64 characters, and hands it to the
+renderer, which sends it to the API deliberately and only for the calls that need it.
+
+> [!NOTE]
+> This is why you cannot "fix" a broken overlay by putting the token in the path. `/overlay/my-overlay/7f3a9c...`
+> would work exactly once and then sit in a log file forever.
+
+## What the server stores
+
+Not the token. The server stores **`sha256(token)`**, and the column is hidden from every model
+serialisation by default.
+
+That has a consequence you will notice: the plain token is shown to you **once**, at the moment you
+generate it. Overlabels cannot show it to you again later, because it genuinely does not have it. If you
+lose it, you generate a new one - it is two clicks, and the old one keeps working until you revoke it.
+
+When a token is used, Overlabels hashes what it was given and looks for a matching row. Same input, same
+hash, match. A copy of the database contains no usable overlay credentials.
+
+## Controls on a token
+
+Every token carries a few optional restrictions, all checked on each use:
+
+| Control        | What it does                                                                 |
+|----------------|------------------------------------------------------------------------------|
+| **Active**     | The kill switch. An inactive token fails to resolve at all                    |
+| **Expiry**     | Set `expires_at` and the token stops working after that moment                |
+| **IP allowlist** | Restricts use to specific client IP addresses                              |
+| **Abilities**  | Comma-separated scope list. Unset means no restriction                        |
+
+> [!WARNING]
+> **The IP allowlist is an exact address match, not a CIDR range.** `203.0.113.7` matches only
+> `203.0.113.7`. Writing `203.0.113.0/24` will match nothing at all and lock your own overlay out. It is
+> also only enforced when the request has a client IP to check. Most home connections get a new address
+> periodically, so this is a feature for fixed-IP setups, not a default worth turning on.
+
+## Access logging
+
+Each successful use increments an access counter and stamps `last_used_at`, so your tokens page can show
+you a token that has not been touched in six months and is safe to clean up.
+
+Overlabels also writes an access log row per use: which template slug was loaded, the client IP, the user
+agent, and when. If you ever need to answer "is something using this token that should not be", that is
+the record that answers it.
+
+## If a token leaks
+
+Showing your overlay URL on stream is the usual way this happens - a browser source dragged into frame, an
+alt-tab, a screenshot of your OBS setup.
+
+Do this:
+
+1. Go to [your tokens page](/tokens) and **revoke** the exposed token. It stops working immediately.
+2. Generate a new one.
+3. Update the browser source in OBS. Only the part after the `#` changes.
+
+Revoking one token does not affect any other token, so a per-scene or per-machine token is a reasonable
+habit if you want a small blast radius.
+
+**What could someone actually do with a leaked token?** Read your overlay and the live data it renders -
+follower counts, your latest subscriber, whatever your controls hold. A token identifies you and can only
+ever reach your own data, never another user's. It is not a login: it cannot change your Twitch account,
+your templates, or your settings.
+
+## Public overlays
+
+Not every overlay needs a token. An overlay you have marked **public** can be shared with a link that
+carries no credential at all, which is what you want for a Discord preview, a portfolio, or showing
+someone a design.
+
+The trade is exactly what it sounds like: a public link is public. Use tokens for the overlay that is
+actually in your scene, and public links for showing the thing off.
+
+## Related
+
+- [Lists in realtime](/help/lists-realtime) - the same token authenticates the Lists API
+- [How an overlay renders](/help/rendering) - where the token is used in the boot sequence


### PR DESCRIPTION
The README had grown a second, worse copy of the help pages: tag tables, control types, conditional operators, a section per donation integration, the full render pipeline. **767 lines to 216, 4192 words to 1093.** Three new help pages back-fill the topics that had no home.

Every one of those topics has a better version at `overlabels.com/help`, which renders as indexable HTML with its own `title`, `description` and `canonical`, is searchable, and stays in sync with what is deployed. The README now points at them instead of paraphrasing them.

### Why

A duplicate in a repo README competes with the help pages for nothing, and drifts. The old one had grown far enough to contradict itself: line 339 said connecting a service provisions all its controls automatically, line 369 said Ko-fi's are added from presets by hand. The first is what `DonationIntegrationController` actually does; the second is what it did before the August consolidation.

### Three new help pages

`/help/rendering`, `/help/testing` and `/help/tokens`. Writing them against the code rather than the old README caught two more things the README had wrong:

- **Tokens were documented as bindable to "a specific IP or CIDR range".** `OverlayAccessToken::isValid()` does `in_array($clientIp, $this->allowed_ips)` - an exact string match. A CIDR entry like `203.0.113.0/24` matches nothing and locks the user out of their own overlay. Now documented as exact-match, behind a `[!WARNING]`, because the failure mode is silent.
- **The `/testing` commands were described as "blurred by default and revealed on hover".** They are behind a "Show command" checkbox, and clicking a row copies to the clipboard.

`rendering.md` deliberately declares **no** `context:`. The obvious claim is `templates.show`, and `HelpContextTest` asserts `templates.show?type=static` resolves to nothing - a bare claim would match it and fail. `templates.edit` already carries two pages, so claiming it would sit exactly on the three-page cap and hand the failure to the next person. The other two claim `tokens.index` and `testing.index`, both with headroom.

### Onboarding stays cut

Deliberate, not an oversight. The pipeline still copies a starter kit, which is good, but the experience around it reads as a one-shot ceremony you must not get wrong - and the friction it was mitigating is now handled in context by the "Add to OBS" button on `templates/show` and `templates/edit`. Documenting the current flow would preserve something that wants replacing.

### What else stayed in the README

What a GitHub visitor cannot get from the website: self-hosting and its env vars, the tech stack, the licence and its relicensing history, contributing, and the sustainability answer.

Limits got compressed rather than dropped: the `<script>`/`<iframe>`/`<embed>` stripping policy and the overlay token model are the two things a security-minded reader looks for first, so they survive as four lines under `## Limits`, now each linking to the page that explains them.

The AGPL section keeps the relicensing paragraph, since the history of the never-granted MIT line is not written down anywhere else, and drops the boilerplate copyright block, which is in `LICENSE` where it is legally operative.

### Verification

- All README help links and all seven internal links in the new pages checked against `php artisan route:list`. `HelpPage::all()` registers one route per markdown file, so a renamed page silently 404s a hardcoded link.
- `public/llms.txt` checked separately; it is a static file and does not appear in the route list.
- `HelpContextTest` + `HelpPageTest`: **30 passed, 278 assertions.** Includes the test that every markdown page is reachable from `/help`, so the index entries are load-bearing.
- `npm run format:check` clean. Prettier covers `resources/` and formats code inside markdown fences, so a misindented fence in a help page is a CI failure now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)