### PR TITLE
fix: say what Allowed IPs accepts, and surface why it refused

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,16 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 15th, 2026 - fix: the Allowed IPs field says what it accepts, and says why it refused
+
+Chasing the README's bogus "IP or CIDR range" claim into the token UI found that the UI never made the claim - but it also never said ranges were unsupported, and refused them with a message that named no field.
+
+- **The claim was only ever in the README.** The create-token form says "Comma-separated IP addresses" with an exact-address placeholder, and `allowed_ips.*` validates with Laravel's `ip` rule, which rejects `203.0.113.0/24`. Nothing user-facing needed correcting. Verified rather than assumed, because the interesting outcome here was "there is no bug".
+- **The real defect was next to it: `createToken()` swallowed the 422.** Every failure became `alert('Failed to create token')`, so a user who typed a range got no field, no reason, and no way to guess. It now surfaces the validation messages, rewriting Laravel's `allowed_ips.0` into "Allowed IPs" - accurate is not the same as useful when the reader is a streamer, not a developer.
+- **The hint text now rules ranges out up front**, and adds the sentence the field was missing: leave it empty unless your connection has a fixed IP. Most home connections do not.
+- **My own help page had it wrong too, one day old.** `/help/tokens` warned that a range "will match nothing at all and lock your own overlay out". It cannot: validation refuses it at save time. Downgraded from `[!WARNING]` to `[!NOTE]` and corrected - overstating a danger that the code already prevents is its own kind of inaccurate.
+- **`OverlayTokenAllowedIpsTest` pins all of it (4 tests).** The CIDR rejection was verified to fail by loosening the rule to `string`, then restored. It also pins the exact-match behaviour against a neighbouring address inside the `/24` a user might expect to work, and pins that the allowlist is skipped entirely when no client IP is passed - which is why the help page calls this a fixed-IP convenience and not a security boundary. Loosening the validation to accept ranges without teaching `isValid()` to understand one now breaks the suite instead of the user's overlay.
+
 ## August 15th, 2026 - docs: three help pages for what the README used to be the only home for
 
 Slimming the README yesterday left four topics with no page to link to. Three now have one: [How an overlay renders](/help/rendering), [Testing your alerts](/help/testing), and [Overlay Access Tokens](/help/tokens). Onboarding stays cut on purpose.

--- a/resources/help/pages/tokens.md
+++ b/resources/help/pages/tokens.md
@@ -66,11 +66,12 @@ Every token carries a few optional restrictions, all checked on each use:
 | **IP allowlist** | Restricts use to specific client IP addresses                              |
 | **Abilities**  | Comma-separated scope list. Unset means no restriction                        |
 
-> [!WARNING]
-> **The IP allowlist is an exact address match, not a CIDR range.** `203.0.113.7` matches only
-> `203.0.113.7`. Writing `203.0.113.0/24` will match nothing at all and lock your own overlay out. It is
-> also only enforced when the request has a client IP to check. Most home connections get a new address
-> periodically, so this is a feature for fixed-IP setups, not a default worth turning on.
+> [!NOTE]
+> **The IP allowlist is an exact address match, not a range.** `203.0.113.7` matches only `203.0.113.7`.
+> Range notation like `203.0.113.0/24` is rejected when you save the token, so you cannot accidentally
+> create one that matches nothing. The check is also only enforced when the request has a client IP to
+> read. Most home connections get a new address periodically, so this is a feature for fixed-IP setups,
+> not a default worth turning on.
 
 ## Access logging
 

--- a/resources/js/pages/overlaytokens/index.vue
+++ b/resources/js/pages/overlaytokens/index.vue
@@ -57,6 +57,24 @@ watch(ipInput, (v) => {
     .filter(Boolean);
 });
 
+/**
+ * Pull a readable message out of a 422. Laravel names the offending entry by
+ * its array index ("The allowed_ips.0 field must be a valid IP address"), which
+ * is accurate and useless to a streamer, so the field token is rewritten.
+ */
+const validationMessage = (error: unknown): string | null => {
+  if (!axios.isAxiosError(error) || error.response?.status !== 422) return null;
+
+  const errors = error.response.data?.errors as Record<string, string[]> | undefined;
+  if (!errors) return null;
+
+  const messages = Object.values(errors)
+    .flat()
+    .map((m) => m.replace(/allowed_ips\.\d+/g, 'Allowed IPs').replace(/expires_at/g, 'Expires At'));
+
+  return messages.length > 0 ? messages.join('\n') : null;
+};
+
 const createToken = async () => {
   try {
     const { data } = await axios.post('/tokens', form.value);
@@ -66,7 +84,9 @@ const createToken = async () => {
     router.reload({ only: ['tokens'] });
   } catch (error) {
     console.error('Failed to create token:', error);
-    await alert('Failed to create token');
+    // A 422 here is almost always a malformed entry in Allowed IPs, and the
+    // generic message left the user with no idea which field was wrong.
+    await alert(validationMessage(error) ?? 'Failed to create token');
   }
 };
 
@@ -211,7 +231,10 @@ const formatDate = (date: string | null | undefined) => (date ? new Date(date).t
           <div>
             <label class="block text-sm font-medium">Allowed IPs (Optional)</label>
             <input v-model="ipInput" type="text" class="mt-1 block w-full rounded-md border p-2" placeholder="192.168.1.1, 10.0.0.1" />
-            <p class="mt-1 text-xs text-gray-500">Comma-separated IP addresses</p>
+            <p class="mt-1 text-xs text-gray-500">
+              Comma-separated IP addresses. Exact addresses only - ranges like <code>192.168.1.0/24</code> are not supported. Leave this empty unless
+              your connection has a fixed IP.
+            </p>
           </div>
 
           <div>

--- a/tests/Feature/OverlayTokenAllowedIpsTest.php
+++ b/tests/Feature/OverlayTokenAllowedIpsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\OverlayAccessToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+uses(DatabaseTransactions::class);
+
+/**
+ * The allowed-IP restriction on an overlay token is an EXACT address match:
+ * `isValid()` does `in_array($clientIp, $this->allowed_ips)`. Range notation
+ * never worked, and for four months the README advertised "a specific IP or
+ * CIDR range" anyway.
+ *
+ * The saving grace is that `allowed_ips.*` validates with `ip`, so a range is
+ * refused at creation rather than stored as a rule that silently matches
+ * nothing. The help page at /help/tokens now promises exactly that, so these
+ * tests pin the promise: loosening the rule to `ip_or_cidr` without teaching
+ * `isValid()` to understand a range would make the docs lie and lock users out
+ * of their own overlays.
+ */
+it('refuses a CIDR range in the allowed IP list', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson('/tokens', [
+            'name' => 'OBS',
+            'allowed_ips' => ['203.0.113.0/24'],
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('allowed_ips.0');
+
+    expect($user->overlayAccessTokens()->count())->toBe(0);
+});
+
+it('accepts exact addresses, v4 and v6 alike', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson('/tokens', [
+            'name' => 'OBS',
+            'allowed_ips' => ['203.0.113.7', '2001:db8::1'],
+        ])
+        ->assertOk();
+
+    expect($user->overlayAccessTokens()->sole()->allowed_ips)
+        ->toBe(['203.0.113.7', '2001:db8::1']);
+});
+
+it('matches only the exact address it was given', function () {
+    $user = User::factory()->create();
+    $generated = OverlayAccessToken::generateToken();
+
+    $user->overlayAccessTokens()->create([
+        'name' => 'Pinned',
+        'token_hash' => $generated['hash'],
+        'token_prefix' => $generated['prefix'],
+        'allowed_ips' => ['203.0.113.7'],
+    ]);
+
+    // The neighbouring address is inside the /24 a user might have expected to
+    // work, and is refused - which is the behaviour the help page describes.
+    expect(OverlayAccessToken::findByToken($generated['plain'], '203.0.113.7'))->not->toBeNull()
+        ->and(OverlayAccessToken::findByToken($generated['plain'], '203.0.113.8'))->toBeNull();
+});
+
+it('skips the restriction entirely when there is no client IP to check', function () {
+    // `isValid()` guards the allowlist with `&& $clientIp`, so a caller that
+    // passes nothing bypasses it. Worth pinning: it is the reason the help page
+    // calls this a fixed-IP feature rather than a security boundary.
+    $user = User::factory()->create();
+    $generated = OverlayAccessToken::generateToken();
+
+    $user->overlayAccessTokens()->create([
+        'name' => 'Pinned',
+        'token_hash' => $generated['hash'],
+        'token_prefix' => $generated['prefix'],
+        'allowed_ips' => ['203.0.113.7'],
+    ]);
+
+    expect(OverlayAccessToken::findByToken($generated['plain']))->not->toBeNull();
+});


### PR DESCRIPTION
Follow-up to #223. Chasing that PR's finding - the README's bogus "IP **or CIDR range**" claim - into the token UI.

### The claim was only ever in the README

The create-token form already said "Comma-separated IP addresses" with an exact-address placeholder, and `allowed_ips.*` validates with Laravel's `ip` rule, which rejects `203.0.113.0/24`. **Nothing user-facing needed correcting.** Verified rather than assumed, because "there is no bug" was the interesting outcome.

### The real defect was sitting next to it

`createToken()` swallowed the 422:

```js
} catch (error) {
  console.error('Failed to create token:', error);
  await alert('Failed to create token');   // every failure, no field, no reason
}
```

So a user who typed a range got a dead end with nothing to act on. It now surfaces the validation messages, rewriting Laravel's `allowed_ips.0` into "Allowed IPs" - accurate is not the same as useful when the reader is a streamer, not a developer.

The hint text also now rules ranges out up front, and adds the sentence the field was missing: leave it empty unless your connection has a fixed IP. Most home connections do not.

### And my own help page was wrong, one day old

`/help/tokens` (shipped in #223) warned that a range "will match nothing at all and lock your own overlay out". It cannot - validation refuses it at save time. Corrected, and downgraded from `[!WARNING]` to `[!NOTE]`. Overstating a danger the code already prevents is its own kind of inaccurate.

### Tests

`OverlayTokenAllowedIpsTest`, 4 tests:

- CIDR is rejected at creation. **Verified to fail** by loosening the rule to `string`, then restored.
- Exact addresses accepted, v4 and v6.
- Exact-match pinned against a *neighbouring* address inside the `/24` a user might expect to work.
- The allowlist is skipped entirely when no client IP is passed - which is why the help page calls this a fixed-IP convenience and not a security boundary.

Loosening validation to accept ranges without teaching `isValid()` to understand one now breaks the suite instead of the user's overlay.

### Gates

34 tests / 287 assertions pass. Pint, Prettier, ESLint and `vue-tsc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)