### PR TITLE
fix(bot): drop a chat reply that missed its moment, don't post it late

### DIFF
--- a/app/Http/Controllers/Api/Internal/BotOutboxController.php
+++ b/app/Http/Controllers/Api/Internal/BotOutboxController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\BotChatOutbox;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 class BotOutboxController extends Controller
@@ -16,6 +17,18 @@ class BotOutboxController extends Controller
      * responsible for actually delivering them - we don't retry on failure
      * because duplicate chat messages are worse than a missed mention.
      *
+     * ANYTHING STALE IS DROPPED HERE, NOT DELIVERED. This is the moment of
+     * decision: if the bot was down for six hours, the rows waiting for it are
+     * answers to questions nobody remembers asking, and posting them all at
+     * once on reconnect is worse than staying quiet. Rows older than
+     * BotChatOutbox::STALE_AFTER_SECONDS are marked discarded and never handed
+     * out. A daily prune cannot do this job - the bot reconnects and claims
+     * long before the sweep runs.
+     *
+     * Discarded rather than deleted so the drop is visible for as long as the
+     * prune keeps it, and so a run of discards can be spotted for what it is:
+     * the bot flapping.
+     *
      * @throws Throwable
      */
     public function index(): JsonResponse
@@ -23,6 +36,7 @@ class BotOutboxController extends Controller
         $messages = DB::transaction(function () {
             $rows = BotChatOutbox::query()
                 ->whereNull('sent_at')
+                ->whereNull('discarded_at')
                 ->with('user:id,twitch_data')
                 ->orderBy('id')
                 ->lockForUpdate()
@@ -32,10 +46,30 @@ class BotOutboxController extends Controller
                 return collect();
             }
 
-            BotChatOutbox::whereIn('id', $rows->pluck('id'))
+            // Split on age inside the same transaction and the same row set, so
+            // a message can never be both delivered and discarded, and nothing
+            // is left pending for a later poll to pick up.
+            $cutoff = now()->subSeconds(BotChatOutbox::STALE_AFTER_SECONDS);
+            [$fresh, $stale] = $rows->partition(fn (BotChatOutbox $row) => $row->created_at >= $cutoff);
+
+            if ($stale->isNotEmpty()) {
+                BotChatOutbox::whereIn('id', $stale->pluck('id'))
+                    ->update(['discarded_at' => now()]);
+
+                Log::info('bot_outbox.discarded_stale', [
+                    'count' => $stale->count(),
+                    'oldest_seconds' => (int) $stale->min('created_at')?->diffInSeconds(now()),
+                ]);
+            }
+
+            if ($fresh->isEmpty()) {
+                return collect();
+            }
+
+            BotChatOutbox::whereIn('id', $fresh->pluck('id'))
                 ->update(['sent_at' => now()]);
 
-            return $rows;
+            return $fresh;
         });
 
         $payload = $messages

--- a/app/Models/BotChatOutbox.php
+++ b/app/Models/BotChatOutbox.php
@@ -11,14 +11,36 @@ class BotChatOutbox extends Model
 
     public const null UPDATED_AT = null;
 
+    /**
+     * How long a queued message stays worth posting.
+     *
+     * Chat replies are perishable in a way almost nothing else here is: a
+     * `!wins` answer, a sub thank-you or a gamejam round result means nothing
+     * once the conversation has moved on, and posting one late is worse than
+     * not posting it - it reads as the bot malfunctioning. So the claim path
+     * drops anything older than this instead of delivering it.
+     *
+     * 60 seconds is 30x the normal 2s poll (and the push usually delivers
+     * inside a second), so ordinary jitter can never trip it. It is also long
+     * enough to cover a bot restart, which is the common case for a message
+     * sitting unclaimed - a deploy should not silently eat replies queued
+     * while the container swaps.
+     *
+     * Tune with the discard rate in mind: a steady trickle of discarded rows
+     * means the bot is flapping, not that this number is wrong.
+     */
+    public const int STALE_AFTER_SECONDS = 60;
+
     protected $fillable = [
         'user_id',
         'message',
         'sent_at',
+        'discarded_at',
     ];
 
     protected $casts = [
         'sent_at' => 'datetime',
+        'discarded_at' => 'datetime',
     ];
 
     public function user(): BelongsTo

--- a/database/migrations/2026_08_15_140000_add_discarded_at_to_bot_chat_outbox.php
+++ b/database/migrations/2026_08_15_140000_add_discarded_at_to_bot_chat_outbox.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Chat replies are perishable. A message queued while the bot was down is
+     * worthless by the time it comes back, so the claim path now drops stale
+     * rows instead of posting them into a conversation that has moved on.
+     *
+     * Dropped rows are marked rather than deleted so the behaviour is visible:
+     * "did the bot eat my message" is answerable for as long as the prune keeps
+     * them, and a sudden run of discards is the clearest signal that the bot is
+     * flapping. Nothing else would show that.
+     */
+    public function up(): void
+    {
+        Schema::table('bot_chat_outbox', function (Blueprint $table) {
+            $table->timestamp('discarded_at')->nullable()->after('sent_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bot_chat_outbox', function (Blueprint $table) {
+            $table->dropColumn('discarded_at');
+        });
+    }
+};

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,19 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 15th, 2026 - fix(bot): a chat reply that missed its moment is dropped, not posted late
+
+If the bot was offline for six hours, every message queued in that time went out the instant it came back. A `!wins` answer, a sub thank-you and a gamejam round result, all landing at once, all replying to conversations that ended hours ago. Chat replies are the most perishable thing in the app: outside a window of seconds they are not just worthless, they are actively worse than silence, because a bot answering a question nobody remembers asking reads as broken.
+
+The claim path now drops anything older than 60 seconds instead of delivering it.
+
+- **The cutoff has to live at claim time, not in the prune.** A daily sweep cannot help: the bot reconnects and claims its backlog long before the sweep next runs. `BotOutboxController` is the moment of decision, so that is where the decision belongs.
+- **60 seconds is 30x the 2 second poll** (and the push usually delivers inside a second), so ordinary jitter can never trip it. It is also long enough to survive a container swap - a deploy should not silently eat replies queued while the bot restarts, and there is a test pinning exactly that.
+- **Dropped rows are marked, not deleted.** `discarded_at` makes "did the bot eat my message" answerable for as long as the prune keeps the row, and makes a run of discards legible as what it is: the bot flapping. Deleting them would have been simpler and would have thrown away the only signal that this is happening at all. The count and the age of the oldest are logged on every discard.
+- **Fresh and stale are split inside one transaction over one locked row set**, so a message can never be both delivered and discarded, and nothing is left pending for the next poll to find.
+- **The prune got simpler, not more complex.** It now sweeps on `created_at` regardless of state. Unsent rows used to be exempt because an unclaimed row was still owed to a channel - that stopped being true the moment the claim path started discarding stale ones, so the exemption became dead weight.
+- **Four tests were verified to fail** with the cutoff disabled, including the one that matters: six hours of backlog, claimed, and nothing handed to the bot.
+
 ## August 15th, 2026 - feat(bot): chat replies go out on a push, and the outbox stops growing forever
 
 Two things, both downstream of getting Reverb actually working this morning.

--- a/routes/console.php
+++ b/routes/console.php
@@ -190,19 +190,19 @@ Schedule::call(fn () => TwitchEvent::where('created_at', '<', now()->subDays(90)
 Schedule::call(fn () => ExternalEvent::where('created_at', '<', now()->subDays(90))->delete())
     ->weekly()->name('prune:external-events')->withoutOverlapping();
 
-// Auto-prune delivered chat messages after 7 days. bot_chat_outbox is a queue,
-// not a log: once the bot has claimed a row and posted it, the row's only
-// remaining value is answering "why did the bot say that" for a few days.
-// Nothing else reads it, and it was growing without bound.
+// Auto-prune chat messages after 7 days, whatever became of them.
+// bot_chat_outbox is a queue, not a log: once a row has been posted or dropped,
+// its only remaining value is answering "why did the bot say that" (or not say
+// it) for a few days. Nothing else reads it, and it was growing without bound.
 //
-// Only rows the bot has actually taken (sent_at set) are swept. An unsent row
-// is still owed to a channel - BotOutboxController hands those out on the next
-// claim - so deleting one would silently drop a message the bot was going to
-// post. See the note in that controller about why nothing here retries.
-Schedule::call(fn () => BotChatOutbox::whereNotNull('sent_at')
-    ->where('sent_at', '<', now()->subDays(7))
-    ->delete()
-)->daily()->name('prune:bot-chat-outbox')->withoutOverlapping();
+// Sweeping on created_at covers all three states in one pass, including rows
+// still unsent. Those used to be exempt because an unclaimed row was owed to a
+// channel - that stopped being true when BotOutboxController started discarding
+// anything older than BotChatOutbox::STALE_AFTER_SECONDS at claim time. A row
+// that has sat here for seven days is never going out, so leaving it would only
+// grow the table.
+Schedule::call(fn () => BotChatOutbox::where('created_at', '<', now()->subDays(7))->delete())
+    ->daily()->name('prune:bot-chat-outbox')->withoutOverlapping();
 
 // Auto-prune handled overlay reports after 180 days. Only reports an admin has
 // actually marked as read are swept, so nothing disappears out of the queue

--- a/tests/Feature/BotOutboxPushAndPruneTest.php
+++ b/tests/Feature/BotOutboxPushAndPruneTest.php
@@ -9,6 +9,7 @@ use App\Services\TwitchApiService;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Testing\TestResponse;
 
 uses(DatabaseTransactions::class);
 
@@ -23,6 +24,9 @@ beforeEach(function () {
         }
     };
     app()->instance(TwitchApiService::class, $stub);
+
+    // Matches BotInternalApiTest: the claim endpoint authenticates on this.
+    config(['services.twitchbot.listener_secret' => 'test-bot-secret']);
 });
 
 function outboxUser(): User
@@ -110,25 +114,124 @@ it('carries no payload, so chat text never rides a public channel', function () 
 // Prune: the outbox is a queue, and it was growing without bound.
 // ──────────────────────────────────────────────────────────────────────────────
 
-it('prunes delivered messages older than 7 days and keeps the rest', function () {
+it('prunes everything older than 7 days and keeps the rest', function () {
     $user = outboxUser();
 
-    $old = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'ancient']);
-    $old->forceFill(['sent_at' => now()->subDays(8)])->save();
+    $delivered = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'ancient']);
+    $delivered->forceFill(['created_at' => now()->subDays(8), 'sent_at' => now()->subDays(8)])->save();
+
+    $discarded = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'dropped']);
+    $discarded->forceFill(['created_at' => now()->subDays(9), 'discarded_at' => now()->subDays(9)])->save();
+
+    // Unsent rows are swept too now. They used to be exempt as "still owed",
+    // but the claim path discards anything stale, so a 30-day-old row is never
+    // going out and keeping it only grows the table.
+    $ancientUnsent = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'never claimed']);
+    $ancientUnsent->forceFill(['created_at' => now()->subDays(30)])->save();
 
     $recent = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'recent']);
-    $recent->forceFill(['sent_at' => now()->subDays(2)])->save();
-
-    // Never claimed by the bot. Still owed to the channel, whatever its age -
-    // deleting it would silently drop a message the bot was going to post.
-    $unsent = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'still owed']);
-    $unsent->forceFill(['created_at' => now()->subDays(30)])->save();
+    $recent->forceFill(['created_at' => now()->subDays(2), 'sent_at' => now()->subDays(2)])->save();
 
     $this->artisan('schedule:test', ['--name' => 'prune:bot-chat-outbox'])->assertSuccessful();
 
-    expect(BotChatOutbox::find($old->id))->toBeNull()
-        ->and(BotChatOutbox::find($recent->id))->not->toBeNull()
-        ->and(BotChatOutbox::find($unsent->id))->not->toBeNull();
+    expect(BotChatOutbox::find($delivered->id))->toBeNull()
+        ->and(BotChatOutbox::find($discarded->id))->toBeNull()
+        ->and(BotChatOutbox::find($ancientUnsent->id))->toBeNull()
+        ->and(BotChatOutbox::find($recent->id))->not->toBeNull();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Staleness. A chat reply is worthless once the conversation has moved on, and
+// posting a backlog on reconnect is worse than staying quiet.
+// ──────────────────────────────────────────────────────────────────────────────
+
+function claimOutbox(): TestResponse
+{
+    return test()->getJson('/api/internal/bot/outbox', ['X-Internal-Secret' => 'test-bot-secret']);
+}
+
+it('hands out a fresh message and marks it sent', function () {
+    $user = outboxUser();
+    $row = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'won 1 times']);
+
+    $response = claimOutbox()->assertOk();
+
+    expect($response->json('messages'))->toHaveCount(1)
+        ->and($response->json('messages.0.message'))->toBe('won 1 times')
+        ->and($row->fresh()->sent_at)->not->toBeNull()
+        ->and($row->fresh()->discarded_at)->toBeNull();
+});
+
+it('drops a message queued while the bot was down instead of posting it late', function () {
+    $user = outboxUser();
+
+    // The scenario: bot offline for hours, comes back, claims. Before this,
+    // every one of these went out at once into a chat that had moved on.
+    $stale = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'won 1 times']);
+    $stale->forceFill(['created_at' => now()->subHours(6)])->save();
+
+    $response = claimOutbox()->assertOk();
+
+    expect($response->json('messages'))->toBeEmpty()
+        ->and($stale->fresh()->discarded_at)->not->toBeNull()
+        ->and($stale->fresh()->sent_at)->toBeNull();
+});
+
+it('delivers the fresh messages and drops the stale ones in the same claim', function () {
+    $user = outboxUser();
+
+    $stale = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'ancient reply']);
+    $stale->forceFill(['created_at' => now()->subHours(2)])->save();
+    $fresh = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'current reply']);
+
+    $response = claimOutbox()->assertOk();
+
+    expect($response->json('messages'))->toHaveCount(1)
+        ->and($response->json('messages.0.message'))->toBe('current reply')
+        ->and($fresh->fresh()->sent_at)->not->toBeNull()
+        ->and($stale->fresh()->discarded_at)->not->toBeNull();
+});
+
+it('never hands out a discarded message on a later claim', function () {
+    $user = outboxUser();
+    $stale = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'ancient reply']);
+    $stale->forceFill(['created_at' => now()->subHours(6)])->save();
+
+    claimOutbox()->assertOk();
+    // A second poll two seconds later must not resurrect it.
+    claimOutbox()->assertOk()->assertJsonPath('messages', []);
+
+    expect($stale->fresh()->sent_at)->toBeNull();
+});
+
+it('keeps a message queued during a bot restart', function () {
+    $user = outboxUser();
+
+    // The reason the cutoff is a minute rather than a few seconds: a container
+    // swap should not silently eat replies queued while it happens.
+    $row = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'won 1 times']);
+    $row->forceFill(['created_at' => now()->subSeconds(20)])->save();
+
+    expect(claimOutbox()->assertOk()->json('messages'))->toHaveCount(1)
+        ->and($row->fresh()->discarded_at)->toBeNull();
+});
+
+it('splits exactly on the configured cutoff', function () {
+    $user = outboxUser();
+    $cutoff = BotChatOutbox::STALE_AFTER_SECONDS;
+
+    $justInside = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'inside']);
+    $justInside->forceFill(['created_at' => now()->subSeconds($cutoff - 5)])->save();
+
+    $justOutside = BotChatOutbox::create(['user_id' => $user->id, 'message' => 'outside']);
+    $justOutside->forceFill(['created_at' => now()->subSeconds($cutoff + 5)])->save();
+
+    claimOutbox()->assertOk();
+
+    expect($justInside->fresh()->sent_at)->not->toBeNull()
+        ->and($justInside->fresh()->discarded_at)->toBeNull()
+        ->and($justOutside->fresh()->discarded_at)->not->toBeNull()
+        ->and($justOutside->fresh()->sent_at)->toBeNull();
 });
 
 it('registers the prune on the schedule', function () {


### PR DESCRIPTION
The bug you spotted at the end of #228. If the bot was offline for six hours, every message queued in that time went out the instant it came back - a `!wins` answer, a sub thank-you and a gamejam round result, all at once, all replying to conversations that ended hours ago.

Chat replies are the most perishable thing in the app. Outside a window of seconds they aren't merely worthless, they're **worse than silence**: a bot answering a question nobody remembers asking reads as broken.

The claim path now discards anything older than **60 seconds** instead of delivering it.

## Why claim time, not the prune

A daily sweep can't help here - the bot reconnects and claims its backlog long before the sweep next runs. `BotOutboxController` is the moment of decision, so that's where the decision goes.

## Why 60 seconds

- **30x the 2 second poll**, and the push usually delivers inside a second, so ordinary jitter can never trip it.
- **Long enough to survive a container swap.** A deploy shouldn't silently eat replies queued while the bot restarts. There's a test pinning that case specifically (`keeps a message queued during a bot restart`).
- Tune it with the discard rate in mind: a steady trickle of discards means the bot is flapping, not that the number is wrong.

## Marked, not deleted

Deleting would have been simpler, and would have thrown away the only signal that this is happening at all. `discarded_at` makes "did the bot eat my message" answerable for as long as the prune keeps the row, and makes a run of discards legible as what it is. Count and oldest age are logged on every discard.

Fresh and stale are split **inside one transaction over one locked row set**, so a message can never be both delivered and discarded, and nothing is left pending for the next poll to find.

## The prune got simpler

It now sweeps on `created_at` regardless of state. Unsent rows used to be exempt because an unclaimed row was still owed to a channel - that stopped being true the moment the claim path started discarding stale ones, so the exemption became dead weight.

## Tests

13 in the file. Four were verified to fail with the cutoff disabled, including the one that matters: six hours of backlog, claimed, nothing handed to the bot. Migration rollback tested.

Full suite: **1368 passed, 6 skipped**, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
