### PR TITLE
fix(templates): stop a chat-supplied tag resolving inside a foreach

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,18 @@ jobs:
       - name: Typecheck Frontend
         run: npm run typecheck
 
+      # Vitest covers the pure TypeScript that Pest cannot reach: the DSL, the
+      # tag parser and the two-pass template renderer. That pipeline decides
+      # what a chatter-supplied string is allowed to do inside an overlay, so it
+      # needs a gate of its own - the single-pass invariant it guards was
+      # already broken across the pass boundary and nothing caught it.
+      #
+      # Sits next to typecheck, and for the same reason: it needs only
+      # node_modules and committed source, so it fails in seconds instead of
+      # after the install-migrate-build chain.
+      - name: Unit Test Frontend
+        run: npm test
+
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,23 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 15th, 2026 - fix(templates): a tag typed in chat could resolve inside a foreach
+
+Overlay data is not trustworthy, and the rule that keeps that survivable is old and well documented: a value the renderer substitutes is data, and is never re-read as template source. `tagParser.ts` has carried that note since day one, calling out donor names and chat messages containing `[[[c:foo]]]` as exactly the thing it exists to stop.
+
+It held for the pass it was written about, and not for the boundary between two passes. `renderTemplateSource` resolves conditional and foreach blocks first, substituting each loop item's values into the loop body, and then runs the single tag-substitution pass over the whole result. Anything a foreach wrote in the first step was, by the second step, indistinguishable from something the author had typed.
+
+So `!enter [[[c:kofi:total_received]]]` in chat, in any channel whose overlay iterates a chat-writable list, put a live tag into the template. `ListAppendService` stores chatter text verbatim, and `encodeHtml` escapes `& < > " '` but has no reason to touch `[`.
+
+The reach was worse than "a template leaks a tag it already uses". `OverlayTemplateController` allowlists the Twitch data and then merges controls and lists in wholesale, so the payload sitting in the renderer holds every control on the account: all five donation services' running totals, the latest donor name, amount and message, every private counter, and the contents of every list. None of it needs to be mentioned in the template to be readable.
+
+- **The fix already existed twenty lines up.** `[[[raw]]]` has always entity-escaped its brackets, with a comment explaining that a stray `[[[...]]]` in the data must not re-enter the outer pass. That is the same defusing, applied to the same pass, for the same reason. It just was not on the value path. It is now a named helper both branches call.
+- **Defusing is unconditional, not "only when the value already looks like a tag."** One attacker usually controls several fields of the same item, and `[` in one plus `[[c:x]]]` in the next concatenates into a live tag while neither half looks dangerous alone. There is a test for exactly that split.
+- **Entities, not stripping, so nothing is silently eaten.** A browser renders `&#91;` as `[`, so `[AFK] brb` still reads as `[AFK] brb`. The CSS sink gets the same treatment, because it runs the same two passes with only the HTML encoding turned off, and an inert entity in a stylesheet beats a resolved tag.
+- **This was disclosure, not script execution.** HTML escaping was never the thing that failed, and a test pins that it still is not.
+- **The server render path was never affected.** PHP's `extractForeachTags` expands a loop only to discover which data keys to ship; it never substitutes. This was the browser's half of the pipeline alone.
+- **Vitest is here now, and this is why.** Pest cannot reach any of it. The template pipeline is pure TypeScript, it is what decides what a stranger's string is allowed to do inside an overlay, and it had no automated coverage at all. Eleven tests, six of which were watched failing before the fix went in, and a step in `tests.yml` next to typecheck so they run on every PR. Scope is deliberately the pure logic - the DSL, the tag parser, the renderer - which is why there is no jsdom and no component test.
+
 ## August 15th, 2026 - fix(bot): a chat reply that missed its moment is dropped, not posted late
 
 If the bot was offline for six hours, every message queued in that time went out the instant it came back. A `!wins` answer, a sub thank-you and a gamejam round result, all landing at once, all replying to conversations that ended hours ago. Chat replies are the most perishable thing in the app: outside a window of seconds they are not just worthless, they are actively worse than silence, because a bot answering a question nobody remembers asking reads as broken.

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.23.0",
                 "vite": "^8.0.16",
+                "vitest": "^4.1.10",
                 "vue-tsc": "^3.3.4"
             },
             "engines": {
@@ -1082,6 +1083,13 @@
             "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
             "license": "MIT"
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.23",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
@@ -1445,6 +1453,24 @@
             "funding": {
                 "url": "https://github.com/sponsors/d-fischer"
             }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
@@ -1839,6 +1865,129 @@
                 "vue": "^3.2.25"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@volar/language-core": {
             "version": "2.4.28",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
@@ -2204,6 +2353,16 @@
                 "node": ">=10"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2294,6 +2453,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -2424,6 +2593,13 @@
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
             }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/crelt": {
             "version": "1.0.7",
@@ -2613,6 +2789,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
@@ -2908,6 +3091,16 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -3949,6 +4142,20 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/ohash": {
             "version": "2.0.12",
             "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
@@ -4039,6 +4246,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/perfect-debounce": {
             "version": "2.1.0",
@@ -4697,6 +4911,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/socket.io-client": {
             "version": "4.8.3",
             "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -4733,6 +4954,20 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "7.2.0",
@@ -4816,6 +5051,23 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+            "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4859,6 +5111,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+            "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -5329,6 +5591,109 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/vscode-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -5470,6 +5835,23 @@
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
             "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
             "license": "ISC"
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/word-wrap": {
             "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
         "lint:check": "eslint .",
+        "test": "vitest run",
+        "test:watch": "vitest",
         "typecheck": "vue-tsc --noEmit"
     },
     "devDependencies": {
@@ -34,6 +36,7 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.23.0",
         "vite": "^8.0.16",
+        "vitest": "^4.1.10",
         "vue-tsc": "^3.3.4"
     },
     "dependencies": {

--- a/resources/js/composables/useConditionalTemplates.ts
+++ b/resources/js/composables/useConditionalTemplates.ts
@@ -274,6 +274,34 @@ function buildScopedData(outer: Record<string, any>, alias: string, item: any, i
 }
 
 /**
+ * Neutralise `[` / `]` so a `[[[...]]]` sequence that arrived as DATA cannot be
+ * read as template source by the caller's outer substitution pass.
+ *
+ * This is the pass-1 half of the single-pass rule documented in tagParser.ts.
+ * Pass 2 gets that rule for free (one `String.replace` never re-scans its own
+ * output), but anything substituted here is substituted BEFORE pass 2 runs, so
+ * without this a chatter typing `[[[c:kofi:total_received]]]` into a list
+ * appender would have it resolved against the real payload - which carries
+ * every control and list on the account, not just the ones the template names.
+ *
+ * Applied to values only, never to authored template text: an author writing a
+ * tag in their own template is the feature, not the attack.
+ *
+ * Unconditional rather than "only when the value contains `[[[`", because one
+ * attacker usually controls several fields of the same item, and `[` + `[[c:x]]]`
+ * across two adjacent scoped tags concatenates into a live tag while neither
+ * half looks dangerous alone.
+ *
+ * Entities rather than stripping, so nothing is silently eaten: browsers render
+ * these as the literal characters, so `[AFK] brb` still reads as `[AFK] brb`.
+ * The CSS sink (encode=false) gets the same treatment - it has the same pass
+ * boundary, and an inert entity in a stylesheet beats a resolved tag.
+ */
+function defuseBrackets(value: string): string {
+  return value.replace(/\[/g, '&#91;').replace(/]/g, '&#93;');
+}
+
+/**
  * Substitute scoped tokens (`alias.*`, bare `alias`, `loop.*`, bare `loop`) in
  * an already-rendered loop body. Non-scoped tokens are left alone for the
  * caller's outer substitution pass. HTML-encodes by default; honours pipe
@@ -293,10 +321,7 @@ function substituteScopedTokens(template: string, alias: string, scoped: Record<
         json = String(scoped[alias]);
       }
       if (encode) json = encodeHtml(json);
-      // Defuse any `[` / `]` in the JSON so a stray `[[[...]]]` in the
-      // data can't re-enter the outer tag substitution pass. Browsers
-      // still render these as literal brackets.
-      return json.replace(/\[/g, '&#91;').replace(/]/g, '&#93;');
+      return defuseBrackets(json);
     }
 
     const isScoped = key === alias || key.startsWith(`${alias}.`) || key === 'loop' || key.startsWith('loop.');
@@ -314,7 +339,7 @@ function substituteScopedTokens(template: string, alias: string, scoped: Record<
     }
 
     const formatted = pipe ? applyFormatter(strVal, pipe, locale) : strVal;
-    return encode ? encodeHtml(formatted) : formatted;
+    return defuseBrackets(encode ? encodeHtml(formatted) : formatted);
   });
 }
 

--- a/resources/js/utils/renderTemplate.test.ts
+++ b/resources/js/utils/renderTemplate.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { renderTemplateSource } from './renderTemplate';
+
+/**
+ * The single-pass invariant.
+ *
+ * Overlay data is not trustworthy. Chat writes into it (a `!enter` list
+ * appender stores whatever the chatter typed), donors write into it (donation
+ * messages, donor names), and every one of those strings is eventually
+ * substituted into a template. The rule that keeps that safe is: a value
+ * substituted by the renderer is DATA and is never re-read as template source.
+ *
+ * `renderTemplateSource` runs two passes - `processTemplate` resolves
+ * conditional/foreach blocks, then `replaceTagsWithFormatting` does the single
+ * tag substitution. tagParser.ts documents the invariant for pass 2, and pass 2
+ * honours it because one `String.replace` never re-scans its own output.
+ *
+ * The gap this file exists to guard is the boundary BETWEEN the passes: a
+ * foreach body has its scoped `alias.*` tokens substituted during pass 1, and
+ * pass 2 then runs over the result. Without defusing, a `[[[...]]]` sequence
+ * that arrived as data in pass 1 is indistinguishable from authored template
+ * source by the time pass 2 sees it.
+ *
+ * That mattered more than "the template leaks a tag it already uses":
+ * OverlayTemplateController merges the user's controls and lists into the
+ * render payload wholesale (only the Twitch data is allowlisted), so the reach
+ * of a pass-2 resolution is every control value and every list on the account.
+ */
+
+const SECRET_TAG = 'c:kofi:total_received';
+const SECRET_VALUE = 'LEAKED-1234.56';
+const LOCALE = 'en-US';
+
+/** Payload shaped like a real render: the secret is present but unreferenced. */
+function dataWith(extra: Record<string, unknown>): Record<string, unknown> {
+  return { [SECRET_TAG]: SECRET_VALUE, ...extra };
+}
+
+describe('renderTemplateSource / single-pass invariant', () => {
+  it('does not resolve a tag that arrives inside a plain tag value', () => {
+    const out = renderTemplateSource('[[[c:latest_donor_name]]]', dataWith({ 'c:latest_donor_name': `[[[${SECRET_TAG}]]]` }), LOCALE);
+
+    expect(out).not.toContain(SECRET_VALUE);
+  });
+
+  it('does not resolve a tag that arrives inside a foreach item value', () => {
+    // The live path: ListAppendService writes raw chatter text into
+    // option_sets.items, and the renderer flattens them to c:list:<slug>.N.
+    const out = renderTemplateSource(
+      '[[[foreach:c:list:raffle as item]]][[[item]]][[[endforeach]]]',
+      dataWith({ 'c:list:raffle.0': `[[[${SECRET_TAG}]]]`, 'c:list:raffle.count': 1 }),
+      LOCALE,
+    );
+
+    expect(out).not.toContain(SECRET_VALUE);
+    expect(out).toContain('&#91;&#91;&#91;');
+  });
+
+  it('does not resolve a tag that arrives inside a foreach sub-field', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.text]]][[[endforeach]]]',
+      dataWith({ 'chat.0.text': `[[[${SECRET_TAG}]]]`, 'chat.0.author': 'attacker', 'chat.count': 1 }),
+      LOCALE,
+    );
+
+    expect(out).not.toContain(SECRET_VALUE);
+  });
+
+  it('does not resolve a tag split across two adjacent scoped tags', () => {
+    // Defusing only values that already contain `[[[` would be defeatable
+    // here: neither half is a tag on its own, but one attacker controls
+    // both fields of the same item and they concatenate into one.
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.a]]][[[msg.b]]][[[endforeach]]]',
+      dataWith({ 'chat.0.a': '[', 'chat.0.b': `[[${SECRET_TAG}]]]`, 'chat.count': 1 }),
+      LOCALE,
+    );
+
+    expect(out).not.toContain(SECRET_VALUE);
+  });
+
+  it('holds for the CSS sink, where values are not HTML-encoded', () => {
+    // compiledCss runs the same two passes with encode=false, so the pass
+    // boundary is identical. Entity-encoding is skipped there; bracket
+    // defusing must not be.
+    const out = renderTemplateSource(
+      '[[[foreach:c:list:themes as t]]].row{content:"[[[t]]]"}[[[endforeach]]]',
+      dataWith({ 'c:list:themes.0': `[[[${SECRET_TAG}]]]`, 'c:list:themes.count': 1 }),
+      LOCALE,
+      false,
+    );
+
+    expect(out).not.toContain(SECRET_VALUE);
+  });
+
+  it('holds through a nested foreach', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:rooms as room]]][[[foreach:chat as msg]]][[[msg.text]]][[[endforeach]]][[[endforeach]]]',
+      dataWith({
+        'rooms.0': 'main',
+        'rooms.count': 1,
+        'chat.0.text': `[[[${SECRET_TAG}]]]`,
+        'chat.count': 1,
+      }),
+      LOCALE,
+    );
+
+    expect(out).not.toContain(SECRET_VALUE);
+  });
+
+  it('keeps [[[raw]]] dumps inert', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[raw]]][[[endforeach]]]',
+      dataWith({ 'chat.0.text': `[[[${SECRET_TAG}]]]`, 'chat.count': 1 }),
+      LOCALE,
+    );
+
+    expect(out).not.toContain(SECRET_VALUE);
+  });
+
+  it('still HTML-escapes markup arriving in a foreach value', () => {
+    // The handler is deliberately not the usual `alert(1)`: NativeDialogsTest
+    // greps resources/js for native dialog calls, and a payload string reads
+    // exactly like one. The assertion is about the angle brackets, so the
+    // handler name is free.
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.text]]][[[endforeach]]]',
+      { 'chat.0.text': '<img src=x onerror=xss>', 'chat.count': 1 },
+      LOCALE,
+    );
+
+    expect(out).not.toContain('<img');
+    expect(out).toContain('&lt;img');
+  });
+});
+
+describe('renderTemplateSource / defusing does not damage ordinary data', () => {
+  it('renders brackets in everyday text as readable brackets', () => {
+    // "[AFK] brb" is normal chat. Entity-encoded brackets display as the
+    // literal characters, so the viewer sees no difference.
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.text]]][[[endforeach]]]',
+      { 'chat.0.text': '[AFK] brb', 'chat.count': 1 },
+      LOCALE,
+    );
+
+    expect(out).toBe('&#91;AFK&#93; brb');
+  });
+
+  it('leaves an authored ?? default resolvable, since the author owns the template', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.missing ?? nobody]]][[[endforeach]]]',
+      { 'chat.0.text': 'hi', 'chat.count': 1 },
+      LOCALE,
+    );
+
+    expect(out).toBe('nobody');
+  });
+
+  it('still applies pipe formatters to scoped values', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.name|uppercase]]][[[endforeach]]]',
+      { 'chat.0.name': 'jasper', 'chat.count': 1 },
+      LOCALE,
+    );
+
+    expect(out).toBe('JASPER');
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Deliberately separate from vite.config.mts rather than merged into it.
+//
+// The build config exists to produce browser bundles: it loads
+// laravel-vite-plugin, the Vue SFC compiler and Tailwind, and it shells out to
+// `git rev-parse` at module scope to stamp the commit hash. None of that is
+// wanted by a unit test run, and the git call in particular would make the
+// suite fail outside a checkout.
+//
+// Scope is the pure TypeScript under resources/js: the DSL, the tag parser, the
+// two-pass template renderer, the formatters. These are plain functions with no
+// Vue or DOM dependency, which is why `environment: 'node'` is enough and no
+// jsdom is installed. Testing a component would mean adding both, so keep the
+// line here: this suite guards template/tag semantics, not rendering.
+export default defineConfig({
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./resources/js', import.meta.url)),
+        },
+    },
+    test: {
+        environment: 'node',
+        include: ['resources/js/**/*.test.ts'],
+    },
+});


### PR DESCRIPTION
## What was wrong

`renderTemplateSource` runs two passes. `processTemplate` resolves conditional and foreach blocks, substituting each loop item's values into the loop body, and then `replaceTagsWithFormatting` does the single tag-substitution pass over the whole result.

The single-pass rule documented in `tagParser.ts` held *within* pass 2, because one `String.replace` never re-scans its own output. It did not hold across the boundary between the passes. A `[[[...]]]` sequence that arrived as **data** in pass 1 was indistinguishable from authored template source by the time pass 2 saw it.

This needed no new feature to reach. `ListAppendService` stores chatter text verbatim, and `encodeHtml` escapes `& < > " '` but has no reason to touch `[`. So `!enter [[[c:kofi:total_received]]]` in chat, in any channel whose overlay iterates a chat-writable list, put a live tag into the template.

The reach was wider than "a template leaks a tag it already uses". `OverlayTemplateController` allowlists `$twitchData` and then merges `$controlData` and `$listData` in wholesale, so the payload in the renderer holds every control on the account: all five donation services' running totals, latest donor name, amount and message, every private counter, and the contents of every list. None of it has to be mentioned in the template to be readable.

Scope notes:

- **Disclosure, not script execution.** HTML escaping was never the thing that failed, and there is a test pinning that it still is not.
- **Browser only.** PHP's `extractForeachTags` expands a loop to discover which data keys to ship and never substitutes, so the server render path was never affected.

## The fix

The defusing that `[[[raw]]]` has always done, extracted to a named `defuseBrackets()` helper and applied to the value path too.

- **Unconditional**, not "only when the value already contains `[[[`". One attacker controls several fields of the same item, so `[` in one plus `[[c:x]]]` in the next concatenates into a live tag while neither half looks dangerous alone. There is a test for that split.
- **Entities, not stripping**, so nothing is silently eaten. A browser renders `&#91;` as `[`, so `[AFK] brb` still reads as `[AFK] brb`.
- **Values only, never authored template text.** An author writing a tag in their own template is the feature, not the attack.
- **The CSS sink gets it too**, since `compiledCss` runs the same two passes with only the HTML encoding turned off.

## Why vitest

Pest cannot reach any of this. The template pipeline is pure TypeScript, it decides what a stranger's string is allowed to do inside an overlay, and it had no automated coverage at all.

- `vitest.config.mts` is deliberately separate from `vite.config.mts`, which loads laravel-vite-plugin, the Vue SFC compiler and Tailwind, and shells out to `git rev-parse` at module scope. That last one would fail a suite run outside a checkout.
- Scope is the pure TypeScript under `resources/js`: the DSL, the tag parser, the renderer, the formatters. `environment: 'node'`, no jsdom. Component testing stays an explicit future decision rather than something that creeps in.
- `npm test` and `npm run test:watch`. CI runs it in `tests.yml` next to typecheck, where it needs only `node_modules` and committed source and so fails in seconds rather than after the install-migrate-build chain.

## Tests

Eleven, of which **six were verified failing against the old behaviour** before the fix went in: foreach scalar item, foreach sub-field, the split-across-two-tags case, the CSS sink, nested foreach, and the collateral-behaviour assertion.

The other five pin invariants that were already holding, so a future change cannot quietly take them away: the pass-2 baseline, `[[[raw]]]`, HTML escaping, `?? default`, and pipe formatters.

## Verification

`npm test` 11/11 · `format:check` · `lint:check` · `typecheck` · `npm run build` · full Pest suite 1367 passed, 6 skipped.

One self-inflicted note: the Pest run initially failed because `NativeDialogsTest` greps `resources/js` for native dialog calls and my XSS payload `onerror=alert(1)` reads exactly like one. The payload changed rather than the guard gaining a `*.test.ts` exclusion, since the assertion is about angle brackets and the handler name is free. There is a comment in the test, because the next person writing a frontend test with an XSS payload will hit the same thing.

## Deliberately not in here

Allowlisting `$controlData` and `$listData` at `OverlayTemplateController:788` the way `$twitchData` already is. It would shrink the payload and cut the blast radius of anything similar in future, but it changes behaviour for every existing overlay, so it wants to be its own decision rather than a passenger on a security fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
