### PR TITLE
chore(bot): delete the deprecated /expressions/fire alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,12 +173,17 @@ alongside the foreach tag-injection fix (PR #230), which had no automated covera
   and `AlertMessageRenderer` (was `AlertExpressionRenderer`).
 - `BotCommandMapController` serves the whole command map (`GET /internal/bot/commands`).
   `BotCommandController` is the fire endpoint. Do not conflate them.
-- **The command map `type` discriminator and the fire URL are cross-repo contracts.** The bot lives in
-  its own repo and deploys independently, so any change to either is a three-step rollout: the bot
-  learns the new value first, the app then emits it, the bot drops the old value last. `type` is
-  `builtin | custom | alias | recipe_trigger | list_append | list_meta`; `custom` was `expression`.
-- `POST /api/internal/bot/expressions/fire` survives as a deprecated alias of `/commands/fire`, pinned by
-  a test in `BotCommandsApiTest`. Delete both together once the bot has shipped its URL switch.
+- **The command map `type` discriminator and every `/internal/bot/*` URL are cross-repo contracts.** The
+  bot lives in its own repo and deploys independently, so changing one is a four-step rollout, in order:
+  the bot learns the new value while still accepting the old, the app switches to emitting the new one
+  behind a compatibility alias, the bot drops the old value, the app deletes the alias. Skipping ahead
+  breaks every custom chat command in every channel for the length of the gap. `type` is
+  `builtin | custom | alias | recipe_trigger | list_append | list_meta`; `custom` was `expression` until
+  Aug 2026, and the rename above is the worked example of the full sequence.
+- In the bot's `src/bot.js`, a local dispatcher must never share a name with the API function it
+  imports from `overlabelsApi.js` - the inner call resolves to the dispatcher itself and recurses
+  forever. Convention there is API `fireX`, local `fireXInvocation`. The bot repo has no test or lint
+  script, so `node --check` every file you touch.
 - Migrations and past changelog entries were deliberately NOT rewritten by the rename. They record what
   was true when they ran. Same for the dated design specs in `resources/help/reference/*.md` (depth 0,
   not served - `HelpReferenceService` scans `depth == 1` only).

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,17 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - chore: the rename's last scaffolding comes down
+
+The Bot Commands rename shipped behind two compatibility shims, because the bot deploys from its own repo and the two sides are never updated in the same instant. Both are now redundant, and this removes the app's half.
+
+- **`POST /api/internal/bot/expressions/fire` is gone**, along with the test that pinned it. The bot has shipped and deployed its switch to `/commands/fire`, so the alias was answering nobody.
+- **Verified against the bot's `main` before deleting**, not assumed: it POSTs to `/commands/fire` and its dispatcher accepts `type === 'custom'` only. An alias is only safe to remove once you have looked at what is actually calling it.
+
+That closes the four-step sequence a cross-repo rename needs: the bot learns the new value while still accepting the old, the app switches behind an alias, the bot drops the old value, the app deletes the alias. `CLAUDE.md` now describes it that way rather than as three steps, with this rename as the worked example, because the fourth step is the one that is easy to forget and leaves dead surface area behind forever.
+
+It also records a trap found on the bot side: a local dispatcher in `bot.js` must never share a name with the API function it imports, or the inner call resolves to itself and recurses forever on every fire. `node --check` caught it; the bot repo has no test or lint script, so that is the only net there is.
+
 ## August 15th, 2026 - refactor: "expression" meant six things, and now it means one
 
 A joke made in passing, "oh you mean bot expressions, expression controls and control's expressions?", turned out to be an accurate census. The word was doing six jobs: jsep formulas in Expression Controls, user-authored chat commands, the pipe formatter, the string an alert speaks, the string an alert posts to chat, and a `bot_commands` table that held something else entirely.

--- a/routes/api.php
+++ b/routes/api.php
@@ -203,11 +203,6 @@ Route::prefix('/internal/bot')
             Route::post('/tokens', [BotTokenController::class, 'store']);
             Route::get('/commands', [BotCommandMapController::class, 'index']);
             Route::post('/commands/fire', [BotCommandController::class, 'fire']);
-            // Deprecated alias. The bot and this app deploy independently, so
-            // the endpoint has to answer to both names across the window where
-            // one is updated and the other is not. Remove once the bot has
-            // shipped its switch to /commands/fire.
-            Route::post('/expressions/fire', [BotCommandController::class, 'fire']);
             Route::post('/recipe-triggers/fire', [BotRecipeTriggerController::class, 'fire']);
             Route::post('/list-appenders/fire', [BotListAppenderController::class, 'fire']);
             Route::post('/list-actions/fire', [BotListActionController::class, 'fire']);

--- a/tests/Feature/BotCommandsApiTest.php
+++ b/tests/Feature/BotCommandsApiTest.php
@@ -102,30 +102,6 @@ test('fire returns command_not_found when there is no matching command', functio
         ->assertJson(['queued' => false, 'reason' => 'command_not_found']);
 });
 
-// The bot deploys from a separate repo, so there is always a window where one
-// side has the rename and the other does not. A bot still POSTing to the old
-// path must keep firing commands, not silently stop. Delete this test in the
-// same change that deletes the alias route.
-test('the deprecated expressions/fire path still fires a command', function () {
-    $user = makeOptedInBotUser();
-
-    BotCommand::create([
-        'user_id' => $user->id,
-        'command' => 'hi',
-        'permission_level' => 'everyone',
-        'cooldown_seconds' => 0,
-        'reply' => 'hello there',
-        'enabled' => true,
-        'hidden' => false,
-    ]);
-
-    $this->postJson(
-        '/api/internal/bot/expressions/fire',
-        firePayload(['command' => 'hi']),
-        ['X-Internal-Secret' => 'test-bot-secret'],
-    )->assertOk()->assertJson(['queued' => true]);
-});
-
 // ──────────────────────────────────────────────────────────────────────────────
 // Fire endpoint - gating
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Step 2 of 2 in the post-rename cleanup, and the last of the scaffolding from #231.

## What changed

- `POST /api/internal/bot/expressions/fire` removed from `routes/api.php`.
- The test pinning it removed from `BotCommandsApiTest`. Route and test were always meant to go together.
- `CLAUDE.md` updated.

## Why it is safe now

overlabels-bot#7 is merged and deployed. Checked against the bot's `main` rather than assumed:

- `src/overlabelsApi.js:109` POSTs to `/api/internal/bot/commands/fire`
- `src/bot.js:172` dispatches on `entry.type === 'custom'` only

Nothing calls the alias. `php artisan route:list --path=internal/bot` confirms only `/commands/fire` remains.

## The doc change is the point of this PR outliving itself

`CLAUDE.md` described a cross-repo contract change as a three-step rollout. It is four:

1. bot learns the new value, still accepting the old
2. app switches to emitting the new one, behind a compatibility alias
3. bot drops the old value
4. app deletes the alias

Step 4 is the one that is easy to forget, and forgetting it leaves dead surface area behind permanently. The `expression` -> `custom` rename is now written up as the worked example of the whole sequence.

It also records the trap found during #7: in the bot's `bot.js`, a local dispatcher must never share a name with the API function it imports from `overlabelsApi.js`, or the inner call resolves to itself and recurses forever on every fire. The bot repo has no test or lint script, so `node --check` is the only net.

## Checks

`pest` 1368 passed / 6 skipped / 0 failed. `typecheck`, `lint:check`, `format:check`, `npm test` (11) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)