### PR TITLE
chore: the last five "expression" leftovers

### DIFF
--- a/app/Http/Controllers/TwitchEventSubController.php
+++ b/app/Http/Controllers/TwitchEventSubController.php
@@ -500,7 +500,7 @@ class TwitchEventSubController extends Controller
             // event references (acting user, broadcaster, raid source, hype
             // train top_contributions[] and last_contribution, ...). Single
             // batched lookup, memoised per user id, then mutates $event so
-            // DB persist, alert render, raw broadcast, and tts expression
+            // DB persist, alert render, raw broadcast, and tts message
             // all see the same `<prefix>_avatar` keys.
             $enrichmentToken = $user?->access_token ?: $this->eventSubService->getAppAccessToken();
             if ($enrichmentToken) {

--- a/app/Services/Messages/AlertMessageRenderer.php
+++ b/app/Services/Messages/AlertMessageRenderer.php
@@ -53,26 +53,26 @@ class AlertMessageRenderer
      * @param  array<string,mixed>  $templateData  Flat dot-keyed map already
      *                                             built for the alert payload.
      */
-    public function render(User $user, ?string $expression, array $templateData): ?string
+    public function render(User $user, ?string $message, array $templateData): ?string
     {
         if ($this->isGatedOff($user)) {
             return null;
         }
 
-        return $this->resolve($user, $expression, $templateData);
+        return $this->resolve($user, $message, $templateData);
     }
 
     /**
-     * Render an expression for posting to chat via BotChatOutbox. Identical tag
+     * Render a message for posting to chat via BotChatOutbox. Identical tag
      * resolution to render(), but WITHOUT the `tts` mute gate - bot chat
      * messages are gated only by the user's `bot_enabled` flag, checked at the
      * dispatch site. The 500-char cap doubles as a fit for Twitch's chat limit.
      *
      * @param  array<string,mixed>  $templateData
      */
-    public function renderMessage(User $user, ?string $expression, array $templateData): ?string
+    public function renderMessage(User $user, ?string $message, array $templateData): ?string
     {
-        return $this->resolve($user, $expression, $templateData);
+        return $this->resolve($user, $message, $templateData);
     }
 
     /**
@@ -80,9 +80,9 @@ class AlertMessageRenderer
      *
      * @param  array<string,mixed>  $templateData
      */
-    private function resolve(User $user, ?string $expression, array $templateData): ?string
+    private function resolve(User $user, ?string $message, array $templateData): ?string
     {
-        if ($expression === null || trim($expression) === '') {
+        if ($message === null || trim($message) === '') {
             return null;
         }
 
@@ -108,7 +108,7 @@ class AlertMessageRenderer
 
                 return $value;
             },
-            $expression
+            $message
         );
 
         if (mb_strlen($resolved) > self::MAX_RESOLVED_LENGTH) {

--- a/app/Services/TwitchApiService.php
+++ b/app/Services/TwitchApiService.php
@@ -28,7 +28,7 @@ class TwitchApiService
     /**
      * Per-type cache TTLs in seconds. Volatile reads (latest follower, subs,
      * goal progress) get short windows so cold consumers - notably Bot
-     * Expressions, which read the cache without the overlay's live EventSub
+     * Commands, which read the cache without the overlay's live EventSub
      * patching - see current data. Near-static reads (profile, follow list)
      * keep longer windows. Replaces the old blanket 365-day TTL that let a
      * single failed fetch poison a key for a year.

--- a/routes/console.php
+++ b/routes/console.php
@@ -271,7 +271,7 @@ Schedule::command('lists:sweep-expired')
     ->withoutOverlapping()
     ->name('lists:sweep-expired');
 
-// Self-destruct sweep for temporary Bot Commands. Deletes expressions
+// Self-destruct sweep for temporary Bot Commands. Deletes commands
 // whose destroy_at timer (set via `!ol cmd options <name> destroy <hours>`)
 // has elapsed, plus any aliases that forward to them. DB-backed so timers
 // survive restarts; idempotent.


### PR DESCRIPTION
Housekeeping after #232. A full-tree sweep turned up five stragglers the earlier passes missed. Comments and parameter names only - no behaviour, no wire contract, no schema.

## What was left

- **`TwitchApiService`** and **`routes/console.php`** still said "Bot Expressions" / "expressions". Both were split across a line break, which is exactly why a line-oriented pass missed them.
- **`TwitchEventSubController`** said "tts expression". That column is `tts_message` now.
- **`AlertMessageRenderer`** took `?string $expression` in `render()`, `renderMessage()` and `resolve()`. It renders `tts_message` and `chat_message`, so it takes `$message`.

## What was checked and deliberately left

`OverlayShareService:609` - "`dependencies`, which only restates what the expression itself shows". That is an Expression Control's config key describing its own formula, which is the one meaning of the word that survives.

Likewise untouched: Leaflet's `PointExpression` / `LatLngBoundsExpression` types, "CSS `url()` expressions", the "foreach expression" and "pipe expression" grammar terms in the DSL docs, and the deliberate `expressions` search keyword in the command palette.

## Checks

`pest` 1368 passed / 6 skipped / 0 failed.

## Status after this

Both repos verified clean. `expression` now means a jsep formula in an Expression Control, and nothing else, across the app and the bot. The four-step cross-repo sequence is documented in `CLAUDE.md` with this rename as the worked example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)