### PR TITLE
perf(templates): stop copying the whole payload per foreach iteration

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,29 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - perf(templates): a foreach copied your whole account, once per item
+
+Every `foreach` iteration started by cloning the entire render payload. Not the item, the whole thing: every control on the account, every list, every Twitch field, copied fresh for each row of the loop.
+
+That made rendering quadratic. The payload grows with the data being looped over, so doubling the item count doubled both the number of copies and the size of each one. A 50-message chat feed spent roughly three quarters of its render time copying keys it never read.
+
+The loop scope is now prototype-linked to the payload instead of copied from it. Lookup walks the chain, which costs nothing to set up, and own properties still shadow outer keys, so an alias that collides with a payload key wins exactly as before.
+
+| items | before | after | |
+|---|---|---|---|
+| 10 | 0.31 ms | 0.14 ms | 2.3x |
+| 25 | 1.68 ms | 0.24 ms | 6.9x |
+| 50 | 6.84 ms | 0.48 ms | 14x |
+| 100 | 31.9 ms | 0.97 ms | 33x |
+| 500 | 525 ms | 5.07 ms | 104x |
+
+- **The curve is linear now.** That is the real result, not any single row. Before, every item you added made every other item more expensive. The 500-item case went from half a second to five milliseconds because the penalty compounded hardest where there was most of it.
+- **Payload size stopped mattering.** The control experiment: 25 items rendered with 300 unrelated keys sitting in the payload alongside them used to cost 3.18x the same 25 items rendered lean. It is now 1.02x. Loop cost is a function of what you loop over, not of how much you own.
+- **This is not a chat feature.** It lands on every `foreach` that already exists: poll choices, subscriber and follower lists, hype train contributors, list-driven wheels and leaderboards. Anyone iterating anything got faster today, and the users who got the biggest lift are the ones with the most controls, who were paying the largest hidden multiplier.
+- **Two lookups had to learn about inheritance.** `resolvePath` checks `in` rather than `hasOwnProperty`, or flat dotted keys like `twitch.stream.is_live` fall through to dot-walking and resolve to nothing against a flat payload. `resolveIterable` uses `for...in` rather than `Object.keys`, or a nested loop cannot see the iterable it is meant to iterate. Both are pinned by tests that fail loudly if reverted.
+- **Eleven tests were written first, against the old code.** They pin the scoping contract rather than the implementation: outer keys readable from inside a loop, dotted outer keys, namespaced control keys, `loop.*` counters, scoped-shadows-outer, no leakage past `endforeach`, and outer data surviving a nested loop. All eleven passed before the change and after it, which is the only reason to trust a rewrite of the hottest path in the renderer.
+- **`OverlayTemplateController` still merges every control and list into the payload wholesale** (the tag allowlist covers only the Twitch half). That is why the multiplier was your whole account rather than your template. It is now a hardening question rather than a performance one, and it is worth doing on its own: the reasons it is not a one-line change are expression controls reading each other's values, list foreach caps that would silently truncate long lists, and `template_tags` being a stored column that can go stale.
+
 ## August 16th, 2026 - chore: the rename's last scaffolding comes down
 
 The Bot Commands rename shipped behind two compatibility shims, because the bot deploys from its own repo and the two sides are never updated in the same instant. Both are now redundant, and this removes the app's half.

--- a/resources/js/composables/useConditionalTemplates.ts
+++ b/resources/js/composables/useConditionalTemplates.ts
@@ -167,8 +167,14 @@ function splitTopLevel(inner: string, firstCondition: string): ConditionalBlock[
  * `choice.title` work alongside flat keys like `event.user_name`.
  */
 function resolvePath(data: Record<string, any>, path: string): any {
-  if (data == null) return undefined;
-  if (Object.prototype.hasOwnProperty.call(data, path)) return data[path];
+  if (data == null || typeof data !== 'object') return undefined;
+  // `in` rather than hasOwnProperty: a foreach scope is prototype-linked to the
+  // outer payload (see buildScopedData), so the outer keys a condition inside a
+  // loop needs to read are INHERITED, not own. Checking own properties only
+  // would send flat dotted keys like `twitch.stream.is_live` down the
+  // dot-walking fallback, where they resolve to undefined because the payload is
+  // flat and there is no `twitch` object to walk into.
+  if (path in data) return data[path];
   return path.split('.').reduce<any>((obj, key) => (obj == null ? undefined : obj[key]), data);
 }
 
@@ -191,7 +197,12 @@ function resolveIterable(data: Record<string, any>, path: string): any[] {
 
   const byIndex = new Map<number, any>();
 
-  for (const key of Object.keys(data)) {
+  // `for...in` rather than Object.keys: a nested foreach resolves its iterable
+  // against the enclosing loop's scope, which is prototype-linked to the outer
+  // payload, so the indexed keys it needs are inherited. Object.keys sees only
+  // own properties and would find nothing. Object.prototype's own members are
+  // non-enumerable, so they are excluded here for free.
+  for (const key in data) {
     if (!key.startsWith(prefix)) continue;
     const rest = key.slice(prefix.length);
     if (rest === 'count') continue;
@@ -244,9 +255,26 @@ function resolveIterable(data: Record<string, any>, path: string): any[] {
  * existing flat-lookup substitution works, and as a nested structure
  * (`choice: { title }`, `loop: { index, first, last }`) so `resolvePath`
  * can walk deeper if the template writes `[[[choice.nested.field]]]`.
+ *
+ * The scope is PROTOTYPE-LINKED to the outer payload rather than a copy of it.
+ * A loop body has to see the whole payload - a condition inside a foreach can
+ * legitimately branch on whether the stream is live - and this used to be done
+ * with `{ ...outer }`, once per iteration. That made the render cost quadratic:
+ * doubling the item count doubled both the number of copies and the size of
+ * each one, since the payload grows with the data being looped over. A 50-item
+ * chat feed spent roughly three quarters of its render time copying keys it
+ * never read, and the payload includes every control and list on the account
+ * (OverlayTemplateController builds it wholesale), so the multiplier is the
+ * user's whole account, not the template.
+ *
+ * Object.create() makes lookup walk the chain instead, which is O(1) to set up.
+ * Own properties assigned below still shadow the outer payload, so an alias that
+ * collides with an outer key wins exactly as it did before. The two places that
+ * had to learn about inheritance are resolvePath (`in`, not hasOwnProperty) and
+ * resolveIterable (`for...in`, not Object.keys).
  */
 function buildScopedData(outer: Record<string, any>, alias: string, item: any, index: number, total: number): Record<string, any> {
-  const scoped: Record<string, any> = { ...outer };
+  const scoped: Record<string, any> = Object.create(outer ?? null);
   const loop = {
     index,
     first: index === 0,

--- a/resources/js/utils/renderTemplate.test.ts
+++ b/resources/js/utils/renderTemplate.test.ts
@@ -167,3 +167,125 @@ describe('renderTemplateSource / defusing does not damage ordinary data', () => 
     expect(out).toBe('JASPER');
   });
 });
+
+/**
+ * Loop scoping contract.
+ *
+ * A foreach body has to see three things at once: the current item under its
+ * alias, the `loop.*` counters, and the entire outer payload (so a condition
+ * inside a loop can branch on whether the stream is live). Historically that was
+ * achieved by copying the whole payload into a fresh object per iteration, which
+ * made the render cost quadratic in payload size x message count.
+ *
+ * These tests pin the SEMANTICS so that cost can be attacked without changing
+ * behaviour. Every one of them passed before the optimisation and must keep
+ * passing after it. The dotted-outer-key and shadowing cases are the two that a
+ * prototype-chain lookup gets wrong if done carelessly.
+ */
+describe('renderTemplateSource / foreach scope', () => {
+  const OUTER = {
+    'twitch.stream.is_live': '1',
+    'twitch.user.display_name': 'CasualElephant',
+    'c:alerts:muted': '0',
+    tier: 'gold',
+    'chat.0.text': 'first',
+    'chat.0.name': 'ana',
+    'chat.1.text': 'second',
+    'chat.1.name': 'bo',
+    'chat.count': 2,
+  };
+
+  it('resolves the alias sub-field and the bare alias', () => {
+    expect(renderTemplateSource('[[[foreach:chat as m]]][[[m.name]]];[[[endforeach]]]', OUTER, LOCALE)).toBe('ana;bo;');
+
+    expect(
+      renderTemplateSource('[[[foreach:names as n]]][[[n]]];[[[endforeach]]]', { 'names.0': 'x', 'names.1': 'y', 'names.count': 2 }, LOCALE),
+    ).toBe('x;y;');
+  });
+
+  it('exposes loop.index, loop.first, loop.last and loop.count', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:chat as m]]][[[loop.index]]]/[[[loop.count]]] f=[[[loop.first]]] l=[[[loop.last]]];[[[endforeach]]]',
+      OUTER,
+      LOCALE,
+    );
+
+    expect(out).toBe('0/2 f=1 l=0;1/2 f=0 l=1;');
+  });
+
+  it('lets a condition inside the loop read a plain outer key', () => {
+    const out = renderTemplateSource('[[[foreach:chat as m]]][[[if:tier = gold]]]*[[[endif]]][[[m.name]]];[[[endforeach]]]', OUTER, LOCALE);
+
+    expect(out).toBe('*ana;*bo;');
+  });
+
+  it('lets a condition inside the loop read a DOTTED outer key', () => {
+    // The payload is flat: the key is literally "twitch.stream.is_live", not a
+    // nested object. A lookup that walks dots before checking the flat key, or
+    // that only checks own properties on a prototype-linked scope, breaks here.
+    const out = renderTemplateSource(
+      '[[[foreach:chat as m]]][[[if:twitch.stream.is_live = 1]]]LIVE:[[[endif]]][[[m.name]]];[[[endforeach]]]',
+      OUTER,
+      LOCALE,
+    );
+
+    expect(out).toBe('LIVE:ana;LIVE:bo;');
+  });
+
+  it('lets a condition inside the loop read a namespaced outer control key', () => {
+    const out = renderTemplateSource('[[[foreach:chat as m]]][[[if:c:alerts:muted = 0]]]on[[[endif]]];[[[endforeach]]]', OUTER, LOCALE);
+
+    expect(out).toBe('on;on;');
+  });
+
+  it('resolves outer tags written inside a loop body', () => {
+    // Non-scoped tags are left untouched by pass 1 and resolved by pass 2, so
+    // the same outer value repeats once per iteration.
+    const out = renderTemplateSource('[[[foreach:chat as m]]][[[twitch.user.display_name]]]:[[[m.name]]];[[[endforeach]]]', OUTER, LOCALE);
+
+    expect(out).toBe('CasualElephant:ana;CasualElephant:bo;');
+  });
+
+  it('branches on a scoped field', () => {
+    const out = renderTemplateSource('[[[foreach:chat as m]]][[[if:m.name = ana]]]HI [[[endif]]][[[m.text]]];[[[endforeach]]]', OUTER, LOCALE);
+
+    expect(out).toBe('HI first;second;');
+  });
+
+  it('gives the scoped alias precedence over an outer key of the same name', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:rows as r]]][[[r.v]]];[[[endforeach]]]',
+      { 'r.v': 'OUTER', 'rows.0.v': 'inner', 'rows.count': 1 },
+      LOCALE,
+    );
+
+    expect(out).toBe('inner;');
+  });
+
+  it('does not leak scoped tokens outside the loop', () => {
+    const out = renderTemplateSource('[[[foreach:chat as m]]][[[m.name]]];[[[endforeach]]]|[[[m.name]]]', OUTER, LOCALE);
+
+    // The trailing tag has no scope to resolve against, so it renders empty
+    // rather than picking up the last iteration's value.
+    expect(out).toBe('ana;bo;|');
+  });
+
+  it('keeps outer data visible through a nested loop', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:rooms as room]]][[[foreach:chat as m]]][[[if:tier = gold]]]g[[[endif]]][[[room.id]]]-[[[m.name]]];[[[endforeach]]][[[endforeach]]]',
+      { ...OUTER, 'rooms.0.id': 'A', 'rooms.count': 1 },
+      LOCALE,
+    );
+
+    expect(out).toBe('gA-ana;gA-bo;');
+  });
+
+  it('iterates only over indices that have data, not up to count', () => {
+    // count is the source-of-truth size and may exceed what the payload
+    // carries once a foreach cap has trimmed it. Padding the difference with
+    // empty objects would render blank rows.
+    const out = renderTemplateSource('[[[foreach:chat as m]]][[[m.name]]];[[[endforeach]]]', { 'chat.0.name': 'solo', 'chat.count': 25 }, LOCALE);
+
+    expect(out).toBe('solo;');
+  });
+});


### PR DESCRIPTION
## What was wrong

`buildScopedData` started every loop iteration with `{ ...outer }` - a full clone of the render payload. Not the item being iterated, the whole payload: every control on the account, every list, every Twitch field, copied fresh for each row of the loop.

A loop body genuinely does need to see the outer payload, since a condition inside a `foreach` can legitimately branch on whether the stream is live. Copying was just the wrong way to give it that.

The result was quadratic. The payload grows with the data being looped over, so doubling the item count doubles both the number of copies **and** the size of each one. A 50-message chat feed spent roughly three quarters of its render time copying keys it never read.

## What changed

The scope is prototype-linked to the payload via `Object.create` instead of copied from it. Lookup walks the chain, which is O(1) to set up, and own properties still shadow the outer payload, so alias-vs-outer precedence is byte-identical to before.

| items | before | after | |
|---|---|---|---|
| 10 | 0.31 ms | 0.14 ms | 2.3x |
| 25 | 1.68 ms | 0.24 ms | 6.9x |
| 50 | 6.84 ms | 0.48 ms | 14x |
| 100 | 31.9 ms | 0.97 ms | 33x |
| 500 | 525 ms | 5.07 ms | 104x |

**The linearity is the actual result**, not any single row. Before, every item you added made every other item more expensive, which is why the improvement compounds hardest where there was most of it.

Payload-size sensitivity is gone too. The control experiment: 25 items rendered with 300 unrelated keys sitting in the payload alongside them used to cost **3.18x** the same 25 items rendered lean. It is now **1.02x**. Loop cost is a function of what you loop over, not of how much you own.

## This is not a chat change

It lands on every `foreach` that already ships: poll choices, subscriber and follower lists, hype train contributors, list-driven wheels and leaderboards. Anyone iterating anything gets faster, and the users who gain most are the ones with the most controls, who were paying the largest hidden multiplier without any way to know.

## Two lookups had to learn about inheritance

Both would have silently broken overlays if guessed at rather than tested, and both are pinned by tests that fail loudly if reverted:

- **`resolvePath` checks `in`, not `hasOwnProperty`.** Outer keys are now inherited rather than own. Checking own properties only would send flat dotted keys like `twitch.stream.is_live` down the dot-walking fallback, where they resolve to `undefined` because the payload is flat and there is no `twitch` object to walk into.
- **`resolveIterable` uses `for...in`, not `Object.keys`.** A nested `foreach` resolves its iterable against the enclosing loop's scope, so the indexed keys it needs are inherited. `Object.keys` sees only own properties and would find nothing. `Object.prototype`'s own members are non-enumerable, so they stay excluded for free.

## Tests

Eleven new ones, **written first, against the old code**, pinning the scoping *contract* rather than the implementation. All eleven passed before the change and after it, which is the only reason to trust a rewrite of the hottest path in the renderer.

Covered: alias sub-field and bare alias, `loop.index`/`first`/`last`/`count`, a condition inside a loop reading a plain outer key, a **dotted** outer key, a namespaced control key, outer tags written inside a loop body, branching on a scoped field, scoped-shadows-outer precedence, no scope leakage past `endforeach`, outer data surviving a nested loop, and iteration stopping at populated indices rather than padding up to `count`.

The eight existing single-pass injection tests from #230 also still pass unchanged.

## Verification

22/22 vitest · `format:check` · `lint:check` · `typecheck` · full Pest suite **1368 passed, 6 skipped, 0 failures**.

## Deliberately still open

`OverlayTemplateController:788` still merges every control and list into the payload wholesale, with the tag allowlist covering only the Twitch half. That is *why* the multiplier was your whole account rather than your template, but it is now a hardening question with no performance urgency, and it deserves its own PR.

It is not a one-line change, for three reasons worth recording: expression controls read each other's values out of the payload (and transitively), a `foreach` over a list only expands 10 indexed keys into the allowlist so strict filtering would silently truncate long lists, and `template_tags` is a stored column that can go stale against a template nobody has re-saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
