### PR TITLE
perf(overlay): code-split the emote library out of the entry bundle

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,27 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - perf(overlay): the emote library is no longer in everyone's critical path
+
+With `foreach` fixed, the next thing you could feel on an overlay load was the 7TV/BTTV/FFZ emote library. It was a static import, and `manualChunks` only splits codemirror, websocket and leaflet, so it rode along inside the overlay's entry bundle: downloaded, parsed and evaluated before anything painted, on every overlay, every load.
+
+Only two fields are ever emote-parsed, `event.message.text` and `event.user_input`, and both belong to alerts. So an overlay that no alert template even targets was paying the full price for a feature it could never use.
+
+It is a dynamic import now, which makes it its own chunk.
+
+| | before | after |
+|---|---|---|
+| overlay entry, raw | 382.6 kB | 35.6 kB |
+| overlay entry, gzipped | 84.8 kB | 12.2 kB |
+
+That is 72.6 kB gzipped off the critical path of every single overlay load, and the entry is 90% smaller. The library still downloads, as its own 72.8 kB gzipped chunk, but only once something actually asks for emotes.
+
+- **Nothing had to be restructured, because the layering was already right.** It is tempting to read "the static overlay carries 7TV so that alerts can use it" as a mistake. It is not one. Alerts render inside the static overlay's DOM, so that is the only JS context in existence, and emote sets are per-channel rather than per-alert, so fetching once at mount and reusing is exactly what stops a cheer from hitting 7TV every time. The eagerness was the bug, not the placement.
+- **Safe to make async because nothing was ever waiting on it.** `OverlayRenderer` calls `initialize()` fire-and-forget with a `.catch()`, and `parseEmotes()` already returned its input untouched while `isReady` was false. The download window just joins the fetch window that was always there.
+- **It fails better than it used to.** A chunk that does not load, from a network blip or a stale reference after a deploy, now leaves the parser null and renders emotes as plain text. The same failure used to take the entry bundle, and therefore the entire overlay, down with it.
+- **The type import is load-bearing.** `import type { EmoteParser }` is erased at compile time, so it keeps `InstanceType<typeof EmoteParser>` working without pulling the library back into the bundle. Changing it to a value import silently undoes this whole change, with no test failing to tell you.
+- **Still eager, still worth doing later:** `initialize()` runs on every mount regardless, firing roughly seven requests (BTTV, 7TV and FFZ global plus channel, and the Twitch proxy). The render response already preloads compiled CSS for every alert template that could fire on this overlay, which is a ready-made signal for whether any of this is needed at all.
+
 ## August 16th, 2026 - perf(templates): a foreach copied your whole account, once per item
 
 Every `foreach` iteration started by cloning the entire render payload. Not the item, the whole thing: every control on the account, every list, every Twitch field, copied fresh for each row of the loop.

--- a/resources/js/composables/useEmoteParser.ts
+++ b/resources/js/composables/useEmoteParser.ts
@@ -1,5 +1,8 @@
 import { encodeHtml } from '@/utils/tagParser';
-import { EmoteFetcher, EmoteParser } from '@mkody/twitch-emoticons';
+// TYPE-ONLY on purpose: this import is erased at compile time, so it creates no
+// runtime dependency and the library stays out of the overlay's entry bundle.
+// The value import lives inside initialize(), below. See the note there.
+import type { EmoteParser } from '@mkody/twitch-emoticons';
 import { ref } from 'vue';
 
 interface TwitchEmotePosition {
@@ -19,7 +22,35 @@ export function useEmoteParser() {
   // Twitch emotes fetched from backend proxy (credentials stay server-side)
   const twitchEmoteMap = new Map<string, string>(); // code → CDN URL
 
+  /**
+   * Load the emote library and warm its caches for one channel.
+   *
+   * The library is pulled in with a DYNAMIC import so it becomes its own chunk
+   * instead of riding in the overlay's entry bundle. Only two fields are ever
+   * emote-parsed (`event.message.text` and `event.user_input`, see
+   * HTML_SAFE_ALERT_FIELDS in OverlayRenderer), and both belong to alerts - yet
+   * every overlay was paying to download and evaluate the library before first
+   * paint, including overlays no alert template targets.
+   *
+   * This is safe to make async because nothing awaits initialize(): OverlayRenderer
+   * calls it fire-and-forget with a `.catch()`, and parseEmotes() already returns
+   * its input untouched while `isReady` is false. The download window simply joins
+   * the fetch window that was always there.
+   *
+   * It also degrades better than the static import did. A chunk that fails to load
+   * (network blip, or a stale chunk reference after a deploy) now rejects here,
+   * leaves `parser` null, and renders emotes as plain text. Previously the same
+   * failure took the whole entry bundle - and therefore the whole overlay - with it.
+   *
+   * NOTE: the emote parser belongs in the static overlay and should stay here.
+   * Alerts render inside the static overlay's DOM, so this is the only JS context
+   * that exists, and emote sets are per-channel rather than per-alert - fetching
+   * once at mount and reusing is what keeps a cheer from hitting 7TV every time.
+   * The eagerness was the bug, not the placement.
+   */
   async function initialize(channelId: number): Promise<void> {
+    const { EmoteFetcher, EmoteParser } = await import('@mkody/twitch-emoticons');
+
     const fetcher = new EmoteFetcher(); // No Twitch credentials — BTTV/FFZ/7TV only
     parser = new EmoteParser(fetcher, {
       template: '<img class="overlay-emote" alt="{name}" src="{link}" style="display:inline;vertical-align:middle;height:1.5em;">',


### PR DESCRIPTION
## What was wrong

`@mkody/twitch-emoticons` was a static import in `useEmoteParser.ts`, and `manualChunks` in `vite.config.mts` only splits codemirror, websocket and leaflet. So the emote library rode inside the overlay's **entry** bundle: downloaded, parsed and evaluated before anything painted, on every overlay, every load.

Only two fields are ever emote-parsed (`HTML_SAFE_ALERT_FIELDS`: `event.message.text` and `event.user_input`) and both belong to alerts. An overlay that no alert template even targets was paying the full price for a feature it could never use.

## The result

| | before | after |
|---|---|---|
| overlay entry, raw | 382.6 kB | **35.6 kB** |
| overlay entry, gzipped | 84.8 kB | **12.2 kB** |

**72.6 kB gzipped off the critical path of every overlay load**, with the entry 90% smaller. The library still downloads, as its own 72.8 kB gzipped chunk, but only when something actually asks for emotes.

Measured by stashing, rebuilding, and comparing the real manifest entry both ways rather than inferring from the diff.

## The layering was already correct

Worth stating, because "the static overlay carries 7TV so that alerts can use it" reads like a mistake and isn't one:

- Alerts render inside the static overlay's DOM, so this is the only JS context that exists. There is nowhere else to put the parser.
- Emote sets are per-**channel**, not per-alert. Fetching once at mount and reusing is what stops a cheer from hitting 7TV every time.

The eagerness was the bug, not the placement. Nothing was restructured.

## Why making it async is safe

Nothing ever awaited it. `OverlayRenderer.vue` calls `initialize()` fire-and-forget with a `.catch()`, and `parseEmotes()` already returned its input untouched while `isReady` was false. The download window simply joins the fetch window that was always there.

It also **degrades better than before**. A chunk that fails to load (network blip, or a stale chunk reference after a deploy) now leaves `parser` null and renders emotes as plain text. The same failure previously took the entry bundle, and therefore the entire overlay, down with it.

## One line is load-bearing

```ts
import type { EmoteParser } from '@mkody/twitch-emoticons';
```

Type-only, so it is erased at compile time and keeps `InstanceType<typeof EmoteParser>` working without pulling the library back into the bundle. Changing it to a value import silently reverts this entire PR, and **no test would fail to tell you**. Called out in both the code comment and the changelog for that reason.

## Verified rather than assumed

- **The library really left.** The entry now contains zero references to `7tv.io`, `betterttv.net` or `frankerfacez.com`; the new chunk contains all three. (A grep for `fetchSevenTVEmotes` still matches the entry, but that is our own `initialize()` calling the fetcher, which belongs there.)
- **Dynamic import resolves at runtime here.** It only works if the bundle loads as a module, and both `overlay/authenticate.blade.php` and `overlay/render.blade.php` use `@vite(...)`, which emits `type="module"`. The failure mode otherwise would have been emotes silently dying in OBS.

## Gates

`typecheck` · `build` · `format:check` · `lint:check` · 22/22 vitest · full Pest suite **1368 passed, 6 skipped, 0 failures**.

## Deliberately not in here

`initialize()` still runs on every mount regardless of whether any alert can fire on that overlay, firing roughly seven requests (BTTV, 7TV and FFZ global plus channel, and the Twitch proxy). The render response already preloads compiled CSS for every alert template that could fire on this overlay, which is a ready-made signal for whether any of it is needed. Separate job, recorded in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
