### PR TITLE
perf(build): give Vue its own chunk so CodeMirror stops riding along

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,27 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - perf(build): every page was downloading a code editor it wasn't showing
+
+Vue had no explicit home in the chunking config, so Rolldown parked it inside the first manual chunk it could find, which happened to be `codemirror`. Every entry needs Vue. So every entry pulled a 678 kB code editor along with it: the overlay, which contains no editor anywhere, and the dashboard's first paint, where the editor lives on lazily-loaded pages that had not been visited yet.
+
+Vue now has its own chunk, and CodeMirror is left to the three components that actually import it.
+
+| critical path, gzipped | before | after | |
+|---|---|---|---|
+| overlay | 282.4 kB | 90.3 kB | -68% |
+| dashboard | 327.8 kB | 135.8 kB | -59% |
+| events feed | 339.6 kB | 147.4 kB | -57% |
+| map | 393.7 kB | 201.6 kB | -49% |
+
+Roughly 192 kB gzipped off the front of every page in the app, from one config change and no source changes at all.
+
+- **`manualChunks` could not do this, and failed silently.** It is a compatibility shim over Rolldown. Returning a chunk name for a vendor package works, which is why the codemirror, websocket and leaflet groups all landed and looked healthy. Returning one for Vue was ignored outright: no warning, no build error, no chunk. The config read as correct while doing nothing, and the only symptom was a large download. The fix is Rolldown's native `advancedChunks`, and all four groups moved over to it.
+- **Group order is load-bearing.** Groups are evaluated in order, so Vue is listed first and claims its modules before the codemirror pattern can absorb them. Reorder them and the bug comes straight back.
+- **Verify chunking with a build, never by reading the config.** That is the actual lesson here, and it is now a comment in `vite.config.mts`. This had been quietly true for months.
+- **Nothing regressed.** All five entries were measured before and after. The welcome page is unchanged because it never loaded Vue in the first place. CodeMirror is now imported by exactly three chunks: the template code editor, the builder's source sync, and the admin updates editor.
+- **The emitted chunk graph has no cycles**, checked across 203 chunks and 1123 import edges. Regrouping chunks is exactly the kind of change that can introduce a circular import and a runtime TDZ error that no test would catch, so it was worth confirming rather than assuming.
+
 ## August 16th, 2026 - perf(overlay): the emote library is no longer in everyone's critical path
 
 With `foreach` fixed, the next thing you could feel on an overlay load was the 7TV/BTTV/FFZ emote library. It was a static import, and `manualChunks` only splits codemirror, websocket and leaflet, so it rode along inside the overlay's entry bundle: downloaded, parsed and evaluated before anything painted, on every overlay, every load.

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -41,19 +41,35 @@ export default defineConfig(() => ({
         chunkSizeWarningLimit: 1000,
         rollupOptions: {
             output: {
-                // Rolldown (Vite 8) only accepts the function form of manualChunks.
-                // Match by node_modules path to preserve the previous object grouping.
-                manualChunks(id) {
-                    if (!id.includes('node_modules')) return;
-                    if (id.includes('/vue-codemirror/') || id.includes('/codemirror/') || id.includes('/@codemirror/')) {
-                        return 'codemirror';
-                    }
-                    if (id.includes('/pusher-js/') || id.includes('/laravel-echo/')) {
-                        return 'websocket';
-                    }
-                    if (id.includes('/leaflet/')) {
-                        return 'leaflet';
-                    }
+                // Rolldown's native chunking API, NOT rollup's `manualChunks`.
+                //
+                // `manualChunks` is a compatibility shim here and it silently
+                // could not do this job: returning a chunk name for a vendor
+                // package works (codemirror/websocket/leaflet all landed), but
+                // returning one for Vue was ignored outright, with no warning and
+                // no build error. Vue stayed welded into the codemirror chunk and
+                // the only symptom was a 678 kB download.
+                //
+                // Which mattered because Vue had no explicit home, so Rolldown
+                // parked it inside the first manual chunk it could - codemirror.
+                // Every entry needs Vue, so every entry pulled codemirror with it:
+                // the overlay (no editor anywhere in it) and the dashboard's first
+                // paint (the editor lives on lazily-loaded pages) both paid 237 kB
+                // gzipped for a code editor they were not showing.
+                //
+                // Vue is listed FIRST and that ordering is the fix. Groups are
+                // evaluated in order, so Vue claims its modules before the
+                // codemirror pattern can absorb them.
+                //
+                // If you add a group, verify with a build rather than by reading:
+                // `manualChunks` looked correct for months while doing nothing.
+                advancedChunks: {
+                    groups: [
+                        { name: 'vue', test: /node_modules[\\/](@vue|vue)[\\/]/ },
+                        { name: 'codemirror', test: /node_modules[\\/](vue-codemirror|codemirror|@codemirror)[\\/]/ },
+                        { name: 'websocket', test: /node_modules[\\/](pusher-js|laravel-echo)[\\/]/ },
+                        { name: 'leaflet', test: /node_modules[\\/]leaflet[\\/]/ },
+                    ],
                 },
             },
         },


### PR DESCRIPTION
## What was wrong

Vue had no explicit home in the chunking config, so Rolldown parked it inside the first manual chunk available: `codemirror`.

Every entry needs Vue. So **every entry downloaded a 678 kB code editor to get it** - the overlay, which contains no editor anywhere, and the dashboard's first paint, where the editor lives on lazily-loaded pages that have not been visited yet.

## The result

| critical path, gzipped | before | after | |
|---|---|---|---|
| overlay | 282.4 kB | **90.3 kB** | -68% |
| dashboard | 327.8 kB | **135.8 kB** | -59% |
| events feed | 339.6 kB | **147.4 kB** | -57% |
| map | 393.7 kB | **201.6 kB** | -49% |
| welcome | 0.77 kB | 0.77 kB | unchanged |

Roughly **192 kB gzipped off the front of every page in the app**, from one config change and no source changes at all. Welcome is unchanged because it never loaded Vue in the first place.

## `manualChunks` could not do this, and failed silently

This was the expensive part to find. Adding a Vue rule to `manualChunks` produced a **byte-identical** codemirror chunk. The rule matched - verified by logging the module ids Vite passes in - and Rolldown discarded it. No warning, no build error, no chunk.

`manualChunks` is a compatibility shim over Rolldown. Returning a chunk name for a vendor package works, which is why the codemirror, websocket and leaflet groups all landed and the config looked perfectly healthy for months. Returning one for Vue was ignored outright.

The fix is Rolldown's native `advancedChunks`, and all four groups moved onto it.

**Group order is load-bearing.** Groups evaluate in order, so `vue` is listed first and claims its modules before the codemirror pattern can absorb them. Reorder them and the bug returns.

The real lesson is now a comment in `vite.config.mts`: **verify chunking with a build, never by reading the config.**

## Verified rather than assumed

- **All five entries measured** before and after, by walking the manifest import graph and gzipping each chunk.
- **CodeMirror is now imported by exactly 3 chunks** - the template code editor, the builder's source sync, and the admin updates editor - and by no entry.
- **No cycles in the emitted chunk graph**: 203 chunks, 1123 import edges, zero strongly-connected components larger than one. Regrouping chunks is precisely the change that can introduce a circular import and a runtime TDZ error that no test would catch.
- **Browser run against the real built assets** (dev server stopped, so Laravel served the manifest):
  - `/` and `/templates` load `vue-*.js`, fetch **no codemirror chunk in 61 requests**, and log zero console errors.
  - `/templates/create` fetches `codemirror-*.js` with a 200 and logs zero console errors, so the editor still works.
  - The template *show* page turns out not to need CodeMirror either - its highlighted view is not the editor - so viewing a template got lighter as a side effect.

## Not covered

An **overlay** was not loaded in the browser, because that needs a live token URL. The overlay entry shares the same Vue chunk, its import graph was verified in the manifest, and the chunk graph is acyclic - but it was not observed directly, and it is the entry that matters most. Worth one manual load after merge.

## Gates

`typecheck` · `build` · `format:check` · `lint:check` · 22/22 vitest · Pest **1368 passed, 6 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
