### PR TITLE
feat(chat): Twitch chat in an overlay, with emotes

### DIFF
--- a/app/Http/Controllers/OverlayTemplateController.php
+++ b/app/Http/Controllers/OverlayTemplateController.php
@@ -787,6 +787,13 @@ class OverlayTemplateController extends Controller
             // Build final data: Twitch data + controls + lists + Twitch ID
             $finalData = array_merge($mapped, $controlData, $listData, [
                 'user_twitch_id' => $user->twitch_id,
+                // The chat overlay joins Twitch IRC directly, and IRC addresses
+                // channels by login (`JOIN #name`), not by the numeric id every
+                // other integration uses. Shipped unconditionally next to the id
+                // because it is one short public string, and deriving it in the
+                // browser would mean an authenticated Helix call from an overlay
+                // that deliberately holds no credentials.
+                'user_login' => strtolower((string) ($user->twitch_data['login'] ?? '')),
             ]);
 
             // Preload compiled_css for every alert template owned by this user that

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -25,7 +25,19 @@ The overlay connects to Twitch **directly**, over anonymous IRC-over-WebSocket. 
 - **Validated against live traffic, not just fixtures.** Pointed at an 86,000-viewer chat: 73 lines, 73 parsed, 56 messages, and 5 real moderation actions caught. The window correctly stayed at 50 through four timeouts, which is the proof that a targeted purge is not being mistaken for a room clear.
 - **Chat text is escaped like any other value**, including the `[[[` defusing added yesterday, so a chatter typing a tag gets a tag rendered as text rather than resolved.
 
-**Not in this slice, deliberately:** emotes and badge artwork. Both need message text to arrive as trusted HTML, which means a documented hole through the exact escaping that was hardened yesterday to stop chat-driven tag injection. That deserves its own pass with its own tests rather than riding along here. Badges are available now as names (`[[[msg.badges]]]` gives `broadcaster subscriber`) which is what you want for CSS anyway. The four chat controls and the filtering settings page are also still to come.
+### Emotes
+
+`[[[msg.html]]]` renders the message with Twitch, 7TV, BTTV and FFZ emotes as images. `[[[msg.text]]]` stays available as plain escaped text, so a template picks.
+
+This required a deliberate hole in the escaping, and it is worth knowing exactly how narrow it is.
+
+- **It reuses the alert emote pipeline** rather than growing a second one, so an emote works in chat the moment it works in an alert. Twitch emote positions come from the IRC `emotes` tag, which is more accurate than matching by name: it cannot false-positive on a word that merely contains an emote's name.
+- **The exemption is keyed by iterable, not by field name.** `{ chat: ['html'] }` means `msg.html` inside a chat loop and nothing else. A different loop with a field called `html` is still escaped, and there is a test for exactly that.
+- **Bracket defusing still applies inside the html field**, and this is the part that keeps yesterday's fix intact. `encodeHtml` never touched `[`, so skipping only the entity-encoding would let a chatter typing `[[[c:kofi:total_received]]]` land literally in the output and be resolved by the substitution pass - the injection hole from #230, reopened through a side door. Emote markup contains no square brackets, so defusing costs it nothing.
+- **The safety guarantee lives with the producer.** The emote parser escapes every piece of chatter text before adding any markup, so the only tags in that slot are `<img>` elements this app generated. The type is named `EmoteRenderer` rather than `string` to make that contract something you have to opt into.
+- **A caller with no emote pipeline emits no html slot at all**, rather than one that merely claims to be safe.
+
+**Still to come:** badge artwork (badges are names today, which is what CSS wants anyway), the four chat controls, and the filtering settings page.
 
 ## August 16th, 2026 - perf(build): every page was downloading a code editor it wasn't showing
 

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,31 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - feat(chat): Twitch chat in an overlay
+
+```
+[[[foreach:chat as msg]]]
+  <div class="msg [[[msg.badges]]]">
+    <span style="color: [[[msg.color]]]">[[[msg.author]]]</span>
+    <span>[[[msg.text]]]</span>
+  </div>
+[[[endforeach]]]
+```
+
+That is the whole feature. Drop it in any static overlay and chat appears.
+
+The overlay connects to Twitch **directly**, over anonymous IRC-over-WebSocket. Nothing is relayed through Overlabels: no ingestion cost, no metering, no added latency, and chat that keeps working while Overlabels is down. Chat is public and an anonymous `justinfan` login needs no credentials, so no secret ever reaches an OBS browser source.
+
+- **No DSL change was needed.** `resolveIterable` already synthesizes an array from flat dotted keys with no registration anywhere, so putting `chat.0.author` and `chat.count` into the data map is enough for `foreach` to work. The feature is a data source, not new syntax.
+- **Deleted messages disappear, and that is the part that actually matters.** CLEARMSG removes one message, CLEARCHAT purges a user or clears the room. A slur a moderator removed staying on the overlay would be burned into the stream, the VOD, and every clip of it. Timeouts purge by user id, falling back to login when the id tag is absent - never to "clear everything", because failing open wipes the overlay on every timeout and failing closed leaves the banned chatter on screen.
+- **Shared Chat is handled.** A message duplicated in from a collab partner exposes `[[[msg.source_channel]]]`, empty for a native message, so a template can mark it rather than passing a partner's audience off as its own. Their badges come from the channel they typed in, matching Twitch's own UI.
+- **The window is 50 messages, applied at most five times a second.** The batching is not a throughput fix - the renderer does a 50-message feed in under half a millisecond now. It is an animation fix: the overlay re-renders by replacing innerHTML, which kills any CSS transition mid-flight, so message-enter animations need the breathing room. 200 ms of latency on chat is invisible.
+- **The socket only opens if the template renders chat.** Same discipline as the emote library: an overlay that never shows a message should not hold a WebSocket open for an entire stream.
+- **Validated against live traffic, not just fixtures.** Pointed at an 86,000-viewer chat: 73 lines, 73 parsed, 56 messages, and 5 real moderation actions caught. The window correctly stayed at 50 through four timeouts, which is the proof that a targeted purge is not being mistaken for a room clear.
+- **Chat text is escaped like any other value**, including the `[[[` defusing added yesterday, so a chatter typing a tag gets a tag rendered as text rather than resolved.
+
+**Not in this slice, deliberately:** emotes and badge artwork. Both need message text to arrive as trusted HTML, which means a documented hole through the exact escaping that was hardened yesterday to stop chat-driven tag injection. That deserves its own pass with its own tests rather than riding along here. Badges are available now as names (`[[[msg.badges]]]` gives `broadcaster subscriber`) which is what you want for CSS anyway. The four chat controls and the filtering settings page are also still to come.
+
 ## August 16th, 2026 - perf(build): every page was downloading a code editor it wasn't showing
 
 Vue had no explicit home in the chunking config, so Rolldown parked it inside the first manual chunk it could find, which happened to be `codemirror`. Every entry needs Vue. So every entry pulled a 678 kB code editor along with it: the overlay, which contains no editor anywhere, and the dashboard's first paint, where the editor lives on lazily-loaded pages that had not been visited yet.

--- a/resources/js/components/OverlayRenderer.vue
+++ b/resources/js/components/OverlayRenderer.vue
@@ -42,6 +42,7 @@ import { useOverlayHealth } from '@/composables/useOverlayHealth';
 import { useEmoteParser } from '@/composables/useEmoteParser';
 import { useTwitchChat } from '@/composables/useTwitchChat';
 import { withChatSlots } from '@/utils/chatSlots';
+import type { ChatMessage } from '@/utils/ircParser';
 import { useExpressionEngine } from '@/composables/useExpressionEngine';
 import { useCssCustomProperties } from '@/composables/useCssCustomProperties';
 import { EVENT_RULES } from '@/composables/useTwitchEventRules';
@@ -128,6 +129,22 @@ const templateUsesChat = computed(() => {
 });
 
 /**
+ * Render one chat message to safe HTML for the `chat.N.html` slot.
+ *
+ * Reuses the alert emote pipeline rather than growing a second one, so Twitch,
+ * 7TV, BTTV and FFZ emotes all work in chat the moment they work in an alert.
+ * `parseEmotes` entity-escapes the chatter's text BEFORE inserting any `<img>`,
+ * which is the guarantee that makes the unescaped slot safe to render.
+ *
+ * Twitch emote positions ride along from the IRC `emotes` tag, which is more
+ * accurate than code-matching: it cannot false-positive on a word that merely
+ * contains an emote name.
+ */
+function chatMessageHtml(m: ChatMessage): string {
+  return emoteParser.parseEmotes(m.text, m.emotes.length ? JSON.stringify(m.emotes) : undefined);
+}
+
+/**
  * Project the chat window into `chat.*` data slots whenever it changes.
  *
  * The composable already buffers, so this fires at most a few times a second
@@ -135,10 +152,22 @@ const templateUsesChat = computed(() => {
  * instead of patching it, so a shrinking window cannot leave a deleted message
  * behind to reappear later.
  */
-watch(twitchChat.messages, (list) => {
+function refreshChatSlots(list: readonly ChatMessage[]): void {
   if (!data.value || typeof data.value !== 'object') return;
-  data.value = withChatSlots(data.value, list);
-});
+  data.value = withChatSlots(data.value, list, chatMessageHtml);
+}
+
+watch(twitchChat.messages, refreshChatSlots);
+
+// The emote library loads asynchronously, so the first messages of a stream can
+// arrive before it is ready and would otherwise keep their plain-text rendering
+// for as long as they stay in the window. Rebuild once when it becomes ready.
+watch(
+  () => emoteParser.isReady.value,
+  (ready) => {
+    if (ready) refreshChatSlots(twitchChat.messages.value);
+  },
+);
 
 // Phase 1 surgical-patching state. When fastPath is true, the user's CSS was
 // rewritten at mount to reference CSS custom properties (`var(--ol-...)`) for
@@ -247,12 +276,27 @@ const currentAlert = ref<AlertData | null>(null);
 const alertTimeout = ref<number | null>(null);
 const userId = ref<string | null>(null);
 
+/**
+ * The ONLY foreach fields rendered without entity-encoding, keyed by iterable.
+ *
+ * `chat.N.html` is produced by chatMessageHtml() above, which runs the chatter's
+ * text through the emote parser's escape-then-markup path, so the only tags in
+ * it are `<img>` elements this app generated. Bracket defusing still applies, so
+ * a chatter typing a `[[[tag]]]` cannot reach the substitution pass.
+ *
+ * Keep this list tiny and keep every entry's producer honest. Adding a field
+ * here without an escaping guarantee on the other end is an XSS hole, and it is
+ * the kind that no test notices because the markup only appears when a real
+ * stranger sends it.
+ */
+const HTML_SAFE_FOREACH_FIELDS = { chat: ['html'] } as const;
+
 function parseSource(source: string | null | undefined, encode: boolean = true): string {
   if (!source) return '';
   let result = source;
 
   if (data.value && typeof data.value === 'object') {
-    result = processTemplate(result, data.value, { locale: userLocale.value, encode });
+    result = processTemplate(result, data.value, { locale: userLocale.value, encode, htmlSafeFields: HTML_SAFE_FOREACH_FIELDS });
     result = replaceTagsWithFormatting(result, data.value, userLocale.value, encode);
   }
 

--- a/resources/js/components/OverlayRenderer.vue
+++ b/resources/js/components/OverlayRenderer.vue
@@ -40,6 +40,8 @@ import { useGiftBombDetector } from '@/composables/useGiftBombDetector';
 import { useConditionalTemplates } from '@/composables/useConditionalTemplates';
 import { useOverlayHealth } from '@/composables/useOverlayHealth';
 import { useEmoteParser } from '@/composables/useEmoteParser';
+import { useTwitchChat } from '@/composables/useTwitchChat';
+import { withChatSlots } from '@/utils/chatSlots';
 import { useExpressionEngine } from '@/composables/useExpressionEngine';
 import { useCssCustomProperties } from '@/composables/useCssCustomProperties';
 import { EVENT_RULES } from '@/composables/useTwitchEventRules';
@@ -110,6 +112,33 @@ const health = useOverlayHealth();
 const emoteParser = useEmoteParser();
 const expressionEngine = useExpressionEngine(data);
 const cssApplier = useCssCustomProperties();
+const twitchChat = useTwitchChat();
+
+/**
+ * Does this template render chat at all?
+ *
+ * Gating the connection on the template source, rather than joining for every
+ * overlay, keeps a WebSocket from sitting open for an entire stream in an OBS
+ * source that never displays a message. Matches how the emote library is now
+ * loaded only when something asks for it.
+ */
+const templateUsesChat = computed(() => {
+  const source = `${rawHtml.value ?? ''}\n${css.value ?? ''}`;
+  return /\[\[\[foreach:\s*chat\s+as\s/.test(source) || /\[\[\[chat\.count\b/.test(source);
+});
+
+/**
+ * Project the chat window into `chat.*` data slots whenever it changes.
+ *
+ * The composable already buffers, so this fires at most a few times a second
+ * rather than once per message. `withChatSlots` replaces the whole `chat.*` set
+ * instead of patching it, so a shrinking window cannot leave a deleted message
+ * behind to reappear later.
+ */
+watch(twitchChat.messages, (list) => {
+  if (!data.value || typeof data.value !== 'object') return;
+  data.value = withChatSlots(data.value, list);
+});
 
 // Phase 1 surgical-patching state. When fastPath is true, the user's CSS was
 // rewritten at mount to reference CSS custom properties (`var(--ol-...)`) for
@@ -544,6 +573,14 @@ onMounted(async () => {
       });
     }
 
+    // Join Twitch chat, but ONLY when this template actually renders it.
+    // Same discipline as the emote library: an overlay that never shows chat
+    // should not hold a WebSocket open for hours in an OBS source.
+    const chatChannel = String(json.data?.user_login ?? '');
+    if (chatChannel && templateUsesChat.value) {
+      twitchChat.connect(chatChannel);
+    }
+
     // Initialise user locale for pipe formatters
     userLocale.value = json.locale ?? 'en-US';
 
@@ -634,6 +671,10 @@ onUnmounted(() => {
   health.destroy();
   expressionEngine.destroy();
   cssApplier.teardown();
+  // Closes the socket, cancels the reconnect backoff and drops any queued
+  // flush. Without this an OBS source that reloads leaks a connection per
+  // reload, and the backoff timer keeps reopening one after the component dies.
+  twitchChat.disconnect();
   for (const key of Object.keys(timerIntervals)) {
     stopTimerTick(key);
   }

--- a/resources/js/composables/useConditionalTemplates.ts
+++ b/resources/js/composables/useConditionalTemplates.ts
@@ -23,6 +23,21 @@ interface ParsedCondition {
 interface ProcessOptions {
   locale?: string;
   encode?: boolean;
+  /**
+   * Fields whose value is ALREADY SAFE HTML, keyed by iterable name.
+   *
+   * `{ chat: ['html'] }` means that inside `[[[foreach:chat as msg]]]`, and
+   * nowhere else, `[[[msg.html]]]` is emitted without entity-encoding so the
+   * `<img>` tags an emote parser produced survive.
+   *
+   * Keyed by ITERABLE, not by field name alone, so the exemption cannot leak to
+   * another loop that happens to have a field called `html`. The producer of
+   * such a field owes the same guarantee `useEmoteParser` makes: every piece of
+   * user text is escaped before any markup is added.
+   *
+   * Bracket defusing still applies - see the note in substituteScopedTokens.
+   */
+  htmlSafeFields?: Record<string, readonly string[]>;
 }
 
 // ---------------------------------------------------------------------------
@@ -335,7 +350,14 @@ function defuseBrackets(value: string): string {
  * caller's outer substitution pass. HTML-encodes by default; honours pipe
  * formatters via the existing utility.
  */
-function substituteScopedTokens(template: string, alias: string, scoped: Record<string, any>, locale: string, encode: boolean): string {
+function substituteScopedTokens(
+  template: string,
+  alias: string,
+  scoped: Record<string, any>,
+  locale: string,
+  encode: boolean,
+  htmlSafeFields: readonly string[] = [],
+): string {
   TAG_REGEX.lastIndex = 0;
   return template.replace(TAG_REGEX, (match, key: string, pipe: string | undefined, def: string | undefined) => {
     // [[[raw]]] inside a foreach dumps the current iteration item as
@@ -352,6 +374,8 @@ function substituteScopedTokens(template: string, alias: string, scoped: Record<
       return defuseBrackets(json);
     }
 
+    const isHtmlSafe = (k: string) => htmlSafeFields.some((field) => k === `${alias}.${field}`);
+
     const isScoped = key === alias || key.startsWith(`${alias}.`) || key === 'loop' || key.startsWith('loop.');
     // Non-scoped tags (incl. any `?? default`) are left intact for the outer
     // substitution pass, which resolves their values and defaults.
@@ -367,6 +391,18 @@ function substituteScopedTokens(template: string, alias: string, scoped: Record<
     }
 
     const formatted = pipe ? applyFormatter(strVal, pipe, locale) : strVal;
+
+    // A declared html-safe field skips entity-encoding so markup its producer
+    // generated (emote <img> tags) survives to the DOM.
+    //
+    // It does NOT skip defuseBrackets, and that is the whole reason this is
+    // safe. encodeHtml never touched `[`, so without defusing, a chatter typing
+    // `[[[c:kofi:total_received]]]` would land literally in the output and be
+    // resolved by the outer substitution pass - the exact tag-injection hole
+    // closed in #230, reopened through a side door. Emote markup contains no
+    // square brackets, so defusing costs it nothing.
+    if (isHtmlSafe(key)) return defuseBrackets(formatted);
+
     return defuseBrackets(encode ? encodeHtml(formatted) : formatted);
   });
 }
@@ -498,6 +534,10 @@ export function useConditionalTemplates() {
         const inner = out.substring(t.index + t.length, endTag.index);
         const items = resolveIterable(data, t.iterable);
 
+        // Looked up by ITERABLE name, so `chat`'s html exemption cannot leak
+        // into some other loop that also has a field called `html`.
+        const htmlSafeFields = options.htmlSafeFields?.[t.iterable] ?? [];
+
         let rendered = '';
         for (let i = 0; i < items.length; i++) {
           const scoped = buildScopedData(data, t.alias, items[i], i, items.length);
@@ -507,7 +547,7 @@ export function useConditionalTemplates() {
           // Resolve scoped tokens now — they can't survive into the
           // outer substitution pass because the alias won't be bound
           // there.
-          iterationOut = substituteScopedTokens(iterationOut, t.alias, scoped, locale, encode);
+          iterationOut = substituteScopedTokens(iterationOut, t.alias, scoped, locale, encode, htmlSafeFields);
           rendered += iterationOut;
         }
 

--- a/resources/js/composables/useTwitchChat.ts
+++ b/resources/js/composables/useTwitchChat.ts
@@ -1,0 +1,222 @@
+import { type ChatMessage, type ModerationAction, parseIrcLine, toChatMessage, toModerationAction } from '@/utils/ircParser';
+import { ref } from 'vue';
+
+/**
+ * Read a channel's Twitch chat directly from Twitch, anonymously.
+ *
+ * The overlay connects to Twitch itself rather than having chat relayed through
+ * Overlabels. Chat is public, an anonymous `justinfan` login needs no
+ * credentials, and this keeps a firehose off the server entirely: no ingestion
+ * cost, no metering, no added latency, and chat that keeps working even while
+ * Overlabels is down.
+ *
+ * This does not violate "overlays never phone home" - that rule is about not
+ * sending overlay data back out. This is read-only, one way, to a third party
+ * the overlay is already about.
+ *
+ * The window is small and fixed. Twitch's own chat panel shows roughly 20 lines
+ * at 1080p and 30 at 1440p, so 50 is comfortably more than anyone can see, and
+ * beyond it we are paying to render messages that are scrolled out of existence.
+ */
+
+const TWITCH_IRC_URL = 'wss://irc-ws.chat.twitch.tv:443';
+
+/** Newest-N kept. Deliberately not configurable upward without measuring. */
+const DEFAULT_WINDOW = 50;
+
+/**
+ * How long changes are allowed to queue before being applied.
+ *
+ * Not a throughput fix - the renderer handles a 50-message feed in well under a
+ * millisecond. It is an ANIMATION fix: the overlay re-renders by replacing its
+ * innerHTML, which destroys any CSS transition mid-flight. Applying at most five
+ * times a second keeps message-enter animations able to finish. 200 ms of
+ * latency on a chat overlay is invisible to a viewer.
+ */
+const DEFAULT_FLUSH_MS = 200;
+
+/** Reconnect backoff. OBS sources run for hours; the socket will drop. */
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+
+type QueuedChange = { kind: 'add'; message: ChatMessage } | { kind: 'moderate'; action: ModerationAction };
+
+export interface UseTwitchChatOptions {
+  windowSize?: number;
+  flushMs?: number;
+}
+
+export function useTwitchChat(options: UseTwitchChatOptions = {}) {
+  const windowSize = Math.max(1, options.windowSize ?? DEFAULT_WINDOW);
+  const flushMs = Math.max(0, options.flushMs ?? DEFAULT_FLUSH_MS);
+
+  const messages = ref<ChatMessage[]>([]);
+  const isConnected = ref(false);
+
+  let socket: WebSocket | null = null;
+  let channel = '';
+  let closedByUs = false;
+  let reconnectAttempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // One ordered queue for additions AND deletions, rather than applying
+  // moderation immediately. If a message and the CLEARMSG deleting it land in
+  // the same window, order is the only thing that gets the result right.
+  let queue: QueuedChange[] = [];
+
+  function applyModeration(list: ChatMessage[], action: ModerationAction): ChatMessage[] {
+    switch (action.type) {
+      case 'delete_message':
+        return list.filter((m) => m.id !== action.messageId);
+      case 'purge_user':
+        return list.filter((m) => m.userId !== action.userId);
+      case 'purge_login':
+        return list.filter((m) => m.login !== action.login);
+      case 'clear_all':
+        return [];
+    }
+  }
+
+  function flush(): void {
+    flushTimer = null;
+    if (queue.length === 0) return;
+
+    const pending = queue;
+    queue = [];
+
+    let next = messages.value.slice();
+    for (const change of pending) {
+      if (change.kind === 'add') {
+        next.push(change.message);
+      } else {
+        next = applyModeration(next, change.action);
+      }
+    }
+
+    // Trim from the front: oldest messages leave first, and index 0 stays
+    // the oldest visible one so a template renders top-to-bottom.
+    if (next.length > windowSize) {
+      next = next.slice(next.length - windowSize);
+    }
+
+    messages.value = next;
+  }
+
+  function scheduleFlush(): void {
+    if (flushTimer !== null) return;
+    flushTimer = setTimeout(flush, flushMs);
+  }
+
+  function send(raw: string): void {
+    if (socket && socket.readyState === WebSocket.OPEN) socket.send(raw);
+  }
+
+  function handleLine(raw: string): void {
+    const line = parseIrcLine(raw);
+    if (!line) return;
+
+    // Twitch pings on a timer and drops connections that do not answer.
+    if (line.command === 'PING') {
+      send(`PONG :${line.trailing ?? 'tmi.twitch.tv'}`);
+      return;
+    }
+
+    // Twitch asks clients to reconnect before it cycles a server. Honouring
+    // it is the difference between a seamless handover and a dead overlay.
+    if (line.command === 'RECONNECT') {
+      reconnect();
+      return;
+    }
+
+    const message = toChatMessage(line);
+    if (message) {
+      queue.push({ kind: 'add', message });
+      scheduleFlush();
+      return;
+    }
+
+    const action = toModerationAction(line);
+    if (action) {
+      queue.push({ kind: 'moderate', action });
+      scheduleFlush();
+    }
+  }
+
+  function openSocket(): void {
+    closedByUs = false;
+    socket = new WebSocket(TWITCH_IRC_URL);
+
+    socket.onopen = () => {
+      reconnectAttempt = 0;
+      isConnected.value = true;
+      // Anonymous read-only login. Any `justinfan` nick is accepted with
+      // no password, which is exactly why no credential ever has to reach
+      // an OBS browser source.
+      send('CAP REQ :twitch.tv/tags twitch.tv/commands');
+      send(`NICK justinfan${Math.floor(Math.random() * 80_000) + 1_000}`);
+      send(`JOIN #${channel}`);
+    };
+
+    socket.onmessage = (event: MessageEvent) => {
+      // A frame can carry several lines.
+      for (const raw of String(event.data).split('\r\n')) {
+        if (raw) handleLine(raw);
+      }
+    };
+
+    socket.onerror = () => {
+      // onclose always follows, which is where reconnection is handled.
+      isConnected.value = false;
+    };
+
+    socket.onclose = () => {
+      isConnected.value = false;
+      socket = null;
+      if (closedByUs) return;
+
+      const delay = Math.min(RECONNECT_BASE_MS * 2 ** reconnectAttempt, RECONNECT_MAX_MS);
+      reconnectAttempt++;
+      reconnectTimer = setTimeout(openSocket, delay);
+    };
+  }
+
+  function reconnect(): void {
+    if (socket) {
+      closedByUs = true;
+      socket.close();
+      socket = null;
+    }
+    closedByUs = false;
+    openSocket();
+  }
+
+  /** Join a channel by its lowercase login. Safe to call once per overlay. */
+  function connect(channelLogin: string): void {
+    const login = (channelLogin ?? '').trim().toLowerCase();
+    if (!login || socket) return;
+
+    channel = login;
+    openSocket();
+  }
+
+  function disconnect(): void {
+    closedByUs = true;
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    queue = [];
+    if (socket) {
+      socket.close();
+      socket = null;
+    }
+    isConnected.value = false;
+  }
+
+  return { messages, isConnected, connect, disconnect };
+}

--- a/resources/js/utils/chatSlots.test.ts
+++ b/resources/js/utils/chatSlots.test.ts
@@ -18,6 +18,7 @@ function msg(over: Partial<ChatMessage> = {}): ChatMessage {
     isBroadcaster: false,
     isFirstMessage: false,
     sourceRoomId: '',
+    emotes: [],
     ...over,
   };
 }
@@ -94,5 +95,28 @@ describe('withChatSlots', () => {
     expect(original['chat.0.id']).toBe('stale');
     expect(out['chat.0.id']).toBe('fresh');
     expect(out['keep']).toBe('yes');
+  });
+});
+
+describe('chatSlots / the html slot', () => {
+  it('is absent unless a renderer is supplied', () => {
+    // That slot is rendered WITHOUT escaping, so a caller with no emote
+    // pipeline must never produce one that merely claims to be safe HTML.
+    expect(chatSlots([msg()])['chat.0.html']).toBeUndefined();
+  });
+
+  it('is produced by the supplied renderer', () => {
+    const slots = chatSlots([msg({ text: 'Kappa' })], (m) => `<img alt="${m.text}">`);
+
+    expect(slots['chat.0.html']).toBe('<img alt="Kappa">');
+    // The plain text slot stays alongside it, so a template can choose.
+    expect(slots['chat.0.text']).toBe('Kappa');
+  });
+
+  it('is cleared along with the rest of the window', () => {
+    const withOne = withChatSlots({}, [msg()], () => '<img>');
+    const afterClear = withChatSlots(withOne, []);
+
+    expect(afterClear['chat.0.html']).toBeUndefined();
   });
 });

--- a/resources/js/utils/chatSlots.test.ts
+++ b/resources/js/utils/chatSlots.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { chatSlots, withChatSlots } from './chatSlots';
+import type { ChatMessage } from './ircParser';
+
+function msg(over: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'm1',
+    userId: '1',
+    login: 'ana',
+    author: 'Ana',
+    text: 'hello',
+    color: '#ff0000',
+    badges: 'subscriber',
+    at: 1755273600,
+    isMod: false,
+    isSubscriber: true,
+    isVip: false,
+    isBroadcaster: false,
+    isFirstMessage: false,
+    sourceRoomId: '',
+    ...over,
+  };
+}
+
+describe('chatSlots', () => {
+  it('emits the flat dotted keys resolveIterable synthesizes an array from', () => {
+    const slots = chatSlots([msg({ id: 'a' }), msg({ id: 'b', author: 'Bo', login: 'bo' })]);
+
+    expect(slots['chat.count']).toBe('2');
+    expect(slots['chat.0.id']).toBe('a');
+    expect(slots['chat.1.author']).toBe('Bo');
+    expect(slots['chat.1.login']).toBe('bo');
+  });
+
+  it('renders booleans as 1 and empty, never the word false', () => {
+    // A bare [[[msg.mod]]] must print nothing for a non-mod. The string
+    // 'false' would be truthy when printed and is only handled as falsy by
+    // the conditional branch, so it would leak the word into the overlay.
+    const slots = chatSlots([msg({ isMod: true, isVip: false })]);
+
+    expect(slots['chat.0.mod']).toBe('1');
+    expect(slots['chat.0.vip']).toBe('');
+  });
+
+  it('keeps timestamps in Unix seconds', () => {
+    expect(chatSlots([msg()])['chat.0.at']).toBe('1755273600');
+  });
+
+  it('orders index 0 as the oldest message', () => {
+    const slots = chatSlots([msg({ id: 'older' }), msg({ id: 'newer' })]);
+
+    expect(slots['chat.0.id']).toBe('older');
+    expect(slots['chat.1.id']).toBe('newer');
+  });
+
+  it('leaves source_channel empty for a native message', () => {
+    expect(chatSlots([msg()])['chat.0.source_channel']).toBe('');
+    expect(chatSlots([msg({ sourceRoomId: '999' })])['chat.0.source_channel']).toBe('999');
+  });
+
+  it('reports an empty window without emitting any rows', () => {
+    const slots = chatSlots([]);
+
+    expect(slots['chat.count']).toBe('0');
+    expect(Object.keys(slots)).toEqual(['chat.count']);
+  });
+});
+
+describe('withChatSlots', () => {
+  it('leaves unrelated data untouched', () => {
+    const out = withChatSlots({ 'c:kofi:total_received': '42', 'twitch.user.display_name': 'Ana' }, [msg()]);
+
+    expect(out['c:kofi:total_received']).toBe('42');
+    expect(out['twitch.user.display_name']).toBe('Ana');
+    expect(out['chat.0.author']).toBe('Ana');
+  });
+
+  it('drops stale rows when the window shrinks', () => {
+    // The resurrection bug this prevents: after a moderator clears chat,
+    // a leftover chat.7.* would be invisible while count is small and would
+    // reappear the moment the window grew back past it.
+    const withThree = withChatSlots({}, [msg({ id: 'a' }), msg({ id: 'b' }), msg({ id: 'c' })]);
+    const afterClear = withChatSlots(withThree, []);
+
+    expect(afterClear['chat.count']).toBe('0');
+    expect(afterClear['chat.2.id']).toBeUndefined();
+    expect(Object.keys(afterClear).some((k) => k.startsWith('chat.') && k !== 'chat.count')).toBe(false);
+  });
+
+  it('does not mutate the object it was given', () => {
+    const original: Record<string, unknown> = { 'chat.count': '5', 'chat.0.id': 'stale', keep: 'yes' };
+    const out = withChatSlots(original, [msg({ id: 'fresh' })]);
+
+    expect(original['chat.0.id']).toBe('stale');
+    expect(out['chat.0.id']).toBe('fresh');
+    expect(out['keep']).toBe('yes');
+  });
+});

--- a/resources/js/utils/chatSlots.ts
+++ b/resources/js/utils/chatSlots.ts
@@ -15,6 +15,18 @@ import type { ChatMessage } from './ircParser';
 export const CHAT_SLOT_PREFIX = 'chat.';
 
 /**
+ * Turns a message into SAFE HTML for `chat.N.html`.
+ *
+ * The contract is the one `useEmoteParser` already keeps for alerts: every
+ * piece of chatter-supplied text is entity-escaped BEFORE any markup is added,
+ * so the only tags in the result are `<img>` elements this app generated. That
+ * slot is rendered without escaping, so a producer that breaks this contract is
+ * writing an XSS hole - which is why the type exists rather than the renderer
+ * just accepting any string.
+ */
+export type EmoteRenderer = (message: ChatMessage) => string;
+
+/**
  * Booleans render as `1` / empty string rather than `true` / `false`.
  *
  * `useConditionalTemplates` treats `'0'` and `''` as falsy but the STRING
@@ -33,13 +45,16 @@ function flag(value: boolean): string {
  * Index 0 is the OLDEST visible message, so a template iterating in order
  * renders top-to-bottom the way Twitch chat reads.
  */
-export function chatSlots(messages: readonly ChatMessage[]): Record<string, string> {
+export function chatSlots(messages: readonly ChatMessage[], toHtml?: EmoteRenderer): Record<string, string> {
   const slots: Record<string, string> = {
     'chat.count': String(messages.length),
   };
 
   messages.forEach((m, i) => {
     const k = `${CHAT_SLOT_PREFIX}${i}.`;
+    // Only emitted when a renderer is supplied, so a caller with no emote
+    // pipeline never produces a slot that claims to be safe HTML.
+    if (toHtml) slots[`${k}html`] = toHtml(m);
     slots[`${k}id`] = m.id;
     slots[`${k}author`] = m.author;
     slots[`${k}login`] = m.login;
@@ -71,7 +86,7 @@ export function chatSlots(messages: readonly ChatMessage[]): Record<string, stri
  * while `chat.count` is small, and would reappear the moment the window grew
  * back past it - a deleted message resurrected by an unrelated new one.
  */
-export function withChatSlots(data: Record<string, unknown>, messages: readonly ChatMessage[]): Record<string, unknown> {
+export function withChatSlots(data: Record<string, unknown>, messages: readonly ChatMessage[], toHtml?: EmoteRenderer): Record<string, unknown> {
   const next: Record<string, unknown> = {};
 
   for (const key in data) {
@@ -79,5 +94,5 @@ export function withChatSlots(data: Record<string, unknown>, messages: readonly 
     next[key] = data[key];
   }
 
-  return Object.assign(next, chatSlots(messages));
+  return Object.assign(next, chatSlots(messages, toHtml));
 }

--- a/resources/js/utils/chatSlots.ts
+++ b/resources/js/utils/chatSlots.ts
@@ -1,0 +1,83 @@
+import type { ChatMessage } from './ircParser';
+
+/**
+ * Project a chat window into the flat dotted data slots the renderer iterates.
+ *
+ * `resolveIterable` synthesizes an array from keys like `chat.0.author` plus
+ * `chat.count`, with no registration anywhere, which is why a chat feed needs no
+ * DSL change at all: put these keys in the data map and
+ * `[[[foreach:chat as msg]]]` already works.
+ *
+ * Pure on purpose - the composable owns the socket, this owns the shape.
+ */
+
+/** Prefix every key shares. The caller strips these before merging a new set. */
+export const CHAT_SLOT_PREFIX = 'chat.';
+
+/**
+ * Booleans render as `1` / empty string rather than `true` / `false`.
+ *
+ * `useConditionalTemplates` treats `'0'` and `''` as falsy but the STRING
+ * `'false'` is a special case that only its boolean branch knows about, and a
+ * bare `[[[msg.mod]]]` would print the word "false" into the overlay. Empty is
+ * both falsy in a condition and invisible when printed, which is what the
+ * null-over-placeholder rule wants.
+ */
+function flag(value: boolean): string {
+  return value ? '1' : '';
+}
+
+/**
+ * Build the complete `chat.*` slot set for the current window.
+ *
+ * Index 0 is the OLDEST visible message, so a template iterating in order
+ * renders top-to-bottom the way Twitch chat reads.
+ */
+export function chatSlots(messages: readonly ChatMessage[]): Record<string, string> {
+  const slots: Record<string, string> = {
+    'chat.count': String(messages.length),
+  };
+
+  messages.forEach((m, i) => {
+    const k = `${CHAT_SLOT_PREFIX}${i}.`;
+    slots[`${k}id`] = m.id;
+    slots[`${k}author`] = m.author;
+    slots[`${k}login`] = m.login;
+    slots[`${k}text`] = m.text;
+    slots[`${k}color`] = m.color;
+    slots[`${k}badges`] = m.badges;
+    slots[`${k}at`] = String(m.at);
+    slots[`${k}mod`] = flag(m.isMod);
+    slots[`${k}sub`] = flag(m.isSubscriber);
+    slots[`${k}vip`] = flag(m.isVip);
+    slots[`${k}broadcaster`] = flag(m.isBroadcaster);
+    slots[`${k}first`] = flag(m.isFirstMessage);
+    // Empty for a native message. Non-empty means the message was
+    // duplicated in from another channel during a Shared Chat session, so a
+    // template can mark it rather than passing a partner's audience off as
+    // its own.
+    slots[`${k}source_channel`] = m.sourceRoomId;
+  });
+
+  return slots;
+}
+
+/**
+ * Merge a fresh slot set into a data object, dropping every previous `chat.*`
+ * key first.
+ *
+ * Replacing rather than patching is what keeps a shrinking window honest. After
+ * a moderator clears chat, leaving `chat.7.author` behind would be invisible
+ * while `chat.count` is small, and would reappear the moment the window grew
+ * back past it - a deleted message resurrected by an unrelated new one.
+ */
+export function withChatSlots(data: Record<string, unknown>, messages: readonly ChatMessage[]): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+
+  for (const key in data) {
+    if (key === 'chat.count' || key.startsWith(CHAT_SLOT_PREFIX)) continue;
+    next[key] = data[key];
+  }
+
+  return Object.assign(next, chatSlots(messages));
+}

--- a/resources/js/utils/ircParser.test.ts
+++ b/resources/js/utils/ircParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseIrcLine, parseTags, toChatMessage, toModerationAction } from './ircParser';
+import { parseEmoteTag, parseIrcLine, parseTags, toChatMessage, toModerationAction } from './ircParser';
 
 /**
  * The wire format is a stranger's keyboard.
@@ -182,5 +182,49 @@ describe('toModerationAction', () => {
 
   it('is not triggered by an ordinary message', () => {
     expect(toModerationAction(parseIrcLine(PRIVMSG)!)).toBeNull();
+  });
+});
+
+describe('parseEmoteTag', () => {
+  it('parses a single emote occurrence', () => {
+    expect(parseEmoteTag('25:0-4')).toEqual([{ id: '25', begin: 0, end: 4 }]);
+  });
+
+  it('parses repeats of the same emote', () => {
+    expect(parseEmoteTag('25:0-4,6-10')).toEqual([
+      { id: '25', begin: 0, end: 4 },
+      { id: '25', begin: 6, end: 10 },
+    ]);
+  });
+
+  it('parses several different emotes', () => {
+    expect(parseEmoteTag('25:0-4/1902:6-10')).toEqual([
+      { id: '25', begin: 0, end: 4 },
+      { id: '1902', begin: 6, end: 10 },
+    ]);
+  });
+
+  it('returns nothing for a message with no emotes', () => {
+    expect(parseEmoteTag('')).toEqual([]);
+  });
+
+  it('skips malformed segments instead of throwing', () => {
+    // Runs inside a socket handler on attacker-influenced input, so a
+    // surprise here must never be able to take the overlay down.
+    expect(parseEmoteTag('garbage')).toEqual([]);
+    expect(parseEmoteTag('25:notarange/1902:6-10')).toEqual([{ id: '1902', begin: 6, end: 10 }]);
+    expect(parseEmoteTag(':0-4')).toEqual([]);
+    expect(parseEmoteTag('25:5-1')).toEqual([]);
+    expect(parseEmoteTag('25:-3--1')).toEqual([]);
+  });
+
+  it('rides along on a parsed message', () => {
+    const line = parseIrcLine('@emotes=25:0-4;id=1 :a!a@a PRIVMSG #c :Kappa hello')!;
+
+    expect(toChatMessage(line)!.emotes).toEqual([{ id: '25', begin: 0, end: 4 }]);
+  });
+
+  it('leaves emotes empty when the tag is absent', () => {
+    expect(toChatMessage(parseIrcLine(':a!a@a PRIVMSG #c :plain')!)!.emotes).toEqual([]);
   });
 });

--- a/resources/js/utils/ircParser.test.ts
+++ b/resources/js/utils/ircParser.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { parseIrcLine, parseTags, toChatMessage, toModerationAction } from './ircParser';
+
+/**
+ * The wire format is a stranger's keyboard.
+ *
+ * Every value here arrives from an anonymous Twitch IRC connection and is
+ * attacker-influenced: display names, message text, colours, even the tag
+ * structure. These tests pin the parsing rules that keep that survivable, and in
+ * particular the moderation ones - a deleted message that stays on the overlay
+ * is burned into the stream, the VOD and every clip of it.
+ */
+
+/** A realistic tags-enabled PRIVMSG, of the shape Twitch actually sends. */
+const PRIVMSG =
+  '@badge-info=subscriber/13;badges=broadcaster/1,subscriber/12;color=#1E90FF;display-name=CasualElephant;' +
+  'first-msg=0;id=abc-123;mod=0;room-id=555;subscriber=1;tmi-sent-ts=1755273600000;user-id=777 ' +
+  ':casualelephant!casualelephant@casualelephant.tmi.twitch.tv PRIVMSG #casualelephant :hello chat Kappa';
+
+describe('parseTags', () => {
+  it('parses key/value pairs', () => {
+    expect(parseTags('a=1;b=2')).toEqual({ a: '1', b: '2' });
+  });
+
+  it('treats a valueless tag as present-but-empty', () => {
+    expect(parseTags('color=;mod=1')).toEqual({ color: '', mod: '1' });
+    expect(parseTags('flag;mod=1')).toEqual({ flag: '', mod: '1' });
+  });
+
+  it('unescapes the IRCv3 escape sequences', () => {
+    // A display name with a space and a semicolon would otherwise split the
+    // tag list into bogus extra tags.
+    expect(parseTags(String.raw`system-msg=hi\sthere\:friend;x=a\\b`)).toEqual({
+      'system-msg': 'hi there;friend',
+      x: 'a\\b',
+    });
+  });
+
+  it('drops a trailing lone backslash rather than throwing', () => {
+    expect(parseTags('a=oops\\')).toEqual({ a: 'oops' });
+  });
+});
+
+describe('parseIrcLine', () => {
+  it('splits tags, prefix, command, params and trailing', () => {
+    const line = parseIrcLine(PRIVMSG)!;
+
+    expect(line.command).toBe('PRIVMSG');
+    expect(line.params).toEqual(['#casualelephant']);
+    expect(line.trailing).toBe('hello chat Kappa');
+    expect(line.tags['display-name']).toBe('CasualElephant');
+  });
+
+  it('keeps spaces and colons inside the trailing parameter', () => {
+    const line = parseIrcLine(':a!a@a PRIVMSG #c :look: a b  c')!;
+
+    expect(line.trailing).toBe('look: a b  c');
+  });
+
+  it('handles a line with no tags and no prefix', () => {
+    const line = parseIrcLine('PING :tmi.twitch.tv')!;
+
+    expect(line.command).toBe('PING');
+    expect(line.trailing).toBe('tmi.twitch.tv');
+  });
+
+  it('returns null for blank input', () => {
+    expect(parseIrcLine('')).toBeNull();
+    expect(parseIrcLine('   ')).toBeNull();
+  });
+
+  it('parses an unknown command rather than throwing', () => {
+    // A future Twitch addition should be an ignorable line, not an
+    // exception inside a socket handler.
+    expect(parseIrcLine(':tmi.twitch.tv SOMETHINGNEW #c :x')?.command).toBe('SOMETHINGNEW');
+  });
+});
+
+describe('toChatMessage', () => {
+  it('normalises a PRIVMSG', () => {
+    const msg = toChatMessage(parseIrcLine(PRIVMSG)!)!;
+
+    expect(msg.id).toBe('abc-123');
+    expect(msg.userId).toBe('777');
+    expect(msg.login).toBe('casualelephant');
+    expect(msg.author).toBe('CasualElephant');
+    expect(msg.text).toBe('hello chat Kappa');
+    expect(msg.color).toBe('#1E90FF');
+    expect(msg.badges).toBe('broadcaster subscriber');
+  });
+
+  it('converts tmi-sent-ts from milliseconds to seconds', () => {
+    // Every timestamp in the project is Unix SECONDS; the wire is ms.
+    expect(toChatMessage(parseIrcLine(PRIVMSG)!)!.at).toBe(1755273600);
+  });
+
+  it('falls back to the login when no display name is set', () => {
+    const line = parseIrcLine('@display-name=;id=1 :bob!bob@bob PRIVMSG #c :hi')!;
+
+    expect(toChatMessage(line)!.author).toBe('bob');
+  });
+
+  it('treats the broadcaster as a moderator even though mod=0', () => {
+    const msg = toChatMessage(parseIrcLine(PRIVMSG)!)!;
+
+    expect(msg.isBroadcaster).toBe(true);
+    expect(msg.isMod).toBe(true);
+  });
+
+  it('counts a founder as a subscriber', () => {
+    const line = parseIrcLine('@badges=founder/0;id=1 :a!a@a PRIVMSG #c :hi')!;
+
+    expect(toChatMessage(line)!.isSubscriber).toBe(true);
+  });
+
+  it('does not treat a non-PRIVMSG as a chat message', () => {
+    expect(toChatMessage(parseIrcLine('PING :tmi.twitch.tv')!)).toBeNull();
+  });
+
+  it('preserves message text verbatim, leaving escaping to the renderer', () => {
+    const line = parseIrcLine(':a!a@a PRIVMSG #c :<img src=x> and [[[c:kofi:total_received]]]')!;
+
+    // The parser must not sanitise: the renderer escapes and defuses tag
+    // brackets at substitution time, and doing it twice would corrupt text.
+    expect(toChatMessage(line)!.text).toBe('<img src=x> and [[[c:kofi:total_received]]]');
+  });
+});
+
+describe('toChatMessage / Shared Chat', () => {
+  it('marks a message duplicated in from another channel', () => {
+    const line = parseIrcLine('@id=1;room-id=555;source-room-id=999;source-badges=moderator/1 :a!a@a PRIVMSG #c :hi')!;
+    const msg = toChatMessage(line)!;
+
+    expect(msg.sourceRoomId).toBe('999');
+    // Their standing in the channel they typed in, which is what Twitch's
+    // own UI shows - a partner's moderator reads as a moderator.
+    expect(msg.badges).toBe('moderator');
+    expect(msg.isMod).toBe(true);
+  });
+
+  it('treats a native message as native even when source-room-id is echoed back', () => {
+    // Twitch sets source-room-id equal to room-id on the originating
+    // channel's own copy. That is not a foreign message.
+    const line = parseIrcLine('@id=1;room-id=555;source-room-id=555;badges=vip/1 :a!a@a PRIVMSG #c :hi')!;
+    const msg = toChatMessage(line)!;
+
+    expect(msg.sourceRoomId).toBe('');
+    expect(msg.badges).toBe('vip');
+  });
+});
+
+describe('toModerationAction', () => {
+  it('deletes a single message on CLEARMSG', () => {
+    const line = parseIrcLine('@login=bob;target-msg-id=abc-123 :tmi.twitch.tv CLEARMSG #c :some text')!;
+
+    expect(toModerationAction(line)).toEqual({ type: 'delete_message', messageId: 'abc-123' });
+  });
+
+  it('purges by user id on a timeout or ban', () => {
+    const line = parseIrcLine('@ban-duration=600;target-user-id=777 :tmi.twitch.tv CLEARCHAT #c :bob')!;
+
+    expect(toModerationAction(line)).toEqual({ type: 'purge_user', userId: '777' });
+  });
+
+  it('falls back to the login when the target id tag is missing', () => {
+    // Failing open here would wipe the whole overlay on every timeout;
+    // failing closed would leave a banned chatter's messages on stream.
+    const line = parseIrcLine(':tmi.twitch.tv CLEARCHAT #c :bob')!;
+
+    expect(toModerationAction(line)).toEqual({ type: 'purge_login', login: 'bob' });
+  });
+
+  it('clears everything only when no target is named', () => {
+    const line = parseIrcLine(':tmi.twitch.tv CLEARCHAT #c')!;
+
+    expect(toModerationAction(line)).toEqual({ type: 'clear_all' });
+  });
+
+  it('ignores a CLEARMSG with no target id', () => {
+    expect(toModerationAction(parseIrcLine(':tmi.twitch.tv CLEARMSG #c :x')!)).toBeNull();
+  });
+
+  it('is not triggered by an ordinary message', () => {
+    expect(toModerationAction(parseIrcLine(PRIVMSG)!)).toBeNull();
+  });
+});

--- a/resources/js/utils/ircParser.ts
+++ b/resources/js/utils/ircParser.ts
@@ -1,0 +1,266 @@
+/**
+ * Twitch IRC v3 line parser.
+ *
+ * Pure functions, no WebSocket and no Vue, so the whole protocol surface is
+ * testable without a network. `useTwitchChat` owns the socket and calls in here.
+ *
+ * The overlay reads chat DIRECTLY from Twitch over anonymous IRC-over-WebSocket
+ * rather than having it relayed through Overlabels. That decision is in the
+ * chat design notes; the short version is that chat is public, an anonymous
+ * `justinfan` connection needs no credentials, and routing a firehose through
+ * the server would cost real money to add latency.
+ *
+ * Everything here treats the wire as hostile. A chat line is a stranger's
+ * keyboard: values are never trusted, never re-parsed, and the caller is
+ * expected to escape before rendering.
+ */
+
+/** A parsed IRC line, before any Twitch-specific interpretation. */
+export interface IrcLine {
+  tags: Record<string, string>;
+  /** Everything between `:` and the first space, e.g. `foo!foo@foo.tmi.twitch.tv`. */
+  prefix: string | null;
+  /** `PRIVMSG`, `CLEARCHAT`, `PING`, `001`, ... */
+  command: string;
+  /** Middle params, not including the trailing one. */
+  params: string[];
+  /** The final `:`-prefixed parameter, which is where message text lives. */
+  trailing: string | null;
+}
+
+/** One chat message, normalised for the renderer's data slots. */
+export interface ChatMessage {
+  /** Twitch's message id. Stable, and what CLEARMSG deletes by. */
+  id: string;
+  /** Sender's numeric Twitch user id. What CLEARCHAT targets. */
+  userId: string;
+  /** Lowercase login. */
+  login: string;
+  /** Display name, which may differ in case or be a full localised name. */
+  author: string;
+  /** The raw message text. NOT escaped - the caller escapes at render. */
+  text: string;
+  /** Chosen name colour as `#rrggbb`, or empty when the chatter never set one. */
+  color: string;
+  /** Space-separated badge set names, e.g. `broadcaster moderator subscriber`. */
+  badges: string;
+  /** Unix SECONDS, honouring the project-wide timestamp contract. */
+  at: number;
+  isMod: boolean;
+  isSubscriber: boolean;
+  isVip: boolean;
+  isBroadcaster: boolean;
+  /** Twitch's own "first time chatting in this channel" flag. */
+  isFirstMessage: boolean;
+  /**
+   * Empty for a native message. During a Shared Chat session, a message
+   * duplicated in from another channel carries that channel's room id here, so
+   * a template can mark it as foreign. `source-room-id` differing from
+   * `room-id` is Twitch's own discriminator.
+   */
+  sourceRoomId: string;
+}
+
+/**
+ * Unescape an IRCv3 tag value.
+ *
+ * Tag values encode the characters that would otherwise break the tag list.
+ * Getting this wrong is not cosmetic: a display name containing an escaped
+ * semicolon would otherwise split into two bogus tags.
+ */
+function unescapeTagValue(value: string): string {
+  let out = '';
+  for (let i = 0; i < value.length; i++) {
+    if (value[i] !== '\\') {
+      out += value[i];
+      continue;
+    }
+    const next = value[++i];
+    if (next === 's') out += ' ';
+    else if (next === ':') out += ';';
+    else if (next === 'r') out += '\r';
+    else if (next === 'n') out += '\n';
+    else if (next === '\\') out += '\\';
+    else if (next === undefined)
+      break; // trailing lone backslash: drop it
+    else out += next;
+  }
+  return out;
+}
+
+/** Parse the `@a=1;b=2` tag block into a plain object. */
+export function parseTags(raw: string): Record<string, string> {
+  const tags: Record<string, string> = {};
+  if (!raw) return tags;
+
+  for (const pair of raw.split(';')) {
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    // A valueless tag (`@foo`) is legal and means "present, empty".
+    const key = eq === -1 ? pair : pair.slice(0, eq);
+    const value = eq === -1 ? '' : pair.slice(eq + 1);
+    if (key) tags[key] = unescapeTagValue(value);
+  }
+
+  return tags;
+}
+
+/**
+ * Parse one raw IRC line. Returns null for an empty line.
+ *
+ * Deliberately tolerant: an unrecognised command still parses, so a future
+ * Twitch addition shows up as an ignorable line rather than an exception inside
+ * a socket handler.
+ */
+export function parseIrcLine(line: string): IrcLine | null {
+  let rest = line.trim();
+  if (!rest) return null;
+
+  let tags: Record<string, string> = {};
+  if (rest.startsWith('@')) {
+    const sp = rest.indexOf(' ');
+    if (sp === -1) return null;
+    tags = parseTags(rest.slice(1, sp));
+    rest = rest.slice(sp + 1);
+  }
+
+  let prefix: string | null = null;
+  if (rest.startsWith(':')) {
+    const sp = rest.indexOf(' ');
+    if (sp === -1) return null;
+    prefix = rest.slice(1, sp);
+    rest = rest.slice(sp + 1);
+  }
+
+  // The trailing parameter starts at the first " :" and runs to end of line;
+  // it is the only param allowed to contain spaces.
+  let trailing: string | null = null;
+  const trailingIdx = rest.indexOf(' :');
+  if (rest.startsWith(':')) {
+    trailing = rest.slice(1);
+    rest = '';
+  } else if (trailingIdx !== -1) {
+    trailing = rest.slice(trailingIdx + 2);
+    rest = rest.slice(0, trailingIdx);
+  }
+
+  const parts = rest.split(' ').filter(Boolean);
+  const command = (parts.shift() ?? '').toUpperCase();
+  if (!command) return null;
+
+  return { tags, prefix, command, params: parts, trailing };
+}
+
+/** Pull the login out of a `nick!user@host` prefix. */
+function loginFromPrefix(prefix: string | null): string {
+  if (!prefix) return '';
+  const bang = prefix.indexOf('!');
+  return (bang === -1 ? prefix : prefix.slice(0, bang)).toLowerCase();
+}
+
+/**
+ * Badge set names only, dropping the version.
+ *
+ * `badges=broadcaster/1,subscriber/12` becomes `broadcaster subscriber`, which
+ * is what a template wants for styling (`.badge-subscriber`). The versions
+ * matter only for rendering Twitch's badge artwork, which is a separate concern.
+ */
+function badgeNames(raw: string): string {
+  if (!raw) return '';
+  return raw
+    .split(',')
+    .map((b) => b.split('/')[0])
+    .filter(Boolean)
+    .join(' ');
+}
+
+/**
+ * Turn a PRIVMSG line into a ChatMessage, or null if it is not one.
+ *
+ * `tmi-sent-ts` is milliseconds on the wire and is converted to SECONDS here, to
+ * match the project's timestamp contract. Falls back to local time only when the
+ * tag is absent, which should not happen on a tags-enabled connection.
+ */
+export function toChatMessage(line: IrcLine): ChatMessage | null {
+  if (line.command !== 'PRIVMSG') return null;
+
+  const t = line.tags;
+  const login = loginFromPrefix(line.prefix);
+  const badgesRaw = t['badges'] ?? '';
+
+  // During Shared Chat, a message from another channel carries that channel's
+  // badges under `source-badges`. Twitch's own UI shows the chatter as they
+  // appear where they typed, which is the honest answer to "who is this".
+  const sourceRoomId = t['source-room-id'] && t['source-room-id'] !== t['room-id'] ? t['source-room-id'] : '';
+  const effectiveBadges = sourceRoomId && t['source-badges'] ? t['source-badges'] : badgesRaw;
+
+  const tsMs = Number(t['tmi-sent-ts']);
+  const at = Number.isFinite(tsMs) && tsMs > 0 ? Math.floor(tsMs / 1000) : Math.floor(Date.now() / 1000);
+
+  const badges = badgeNames(effectiveBadges);
+  const badgeSet = new Set(badges.split(' '));
+
+  return {
+    id: t['id'] ?? '',
+    userId: t['user-id'] ?? '',
+    login,
+    author: t['display-name'] || login,
+    text: line.trailing ?? '',
+    color: t['color'] ?? '',
+    badges,
+    at,
+    // Derived from the badges we are actually rendering, not just the `mod`
+    // tag, so the flag and the badge can never disagree. Two cases need it:
+    // the broadcaster is implicitly a moderator but has `mod=0`, and a
+    // Shared Chat message carries its moderator standing only in
+    // `source-badges`, with no `mod` tag for this room at all.
+    isMod: t['mod'] === '1' || badgeSet.has('moderator') || badgeSet.has('broadcaster'),
+    isSubscriber: t['subscriber'] === '1' || badgeSet.has('subscriber') || badgeSet.has('founder'),
+    isVip: badgeSet.has('vip'),
+    isBroadcaster: badgeSet.has('broadcaster'),
+    isFirstMessage: t['first-msg'] === '1',
+    sourceRoomId,
+  };
+}
+
+/** What a moderation line asks the client to remove. */
+export type ModerationAction =
+  | { type: 'delete_message'; messageId: string }
+  | { type: 'purge_user'; userId: string }
+  | { type: 'purge_login'; login: string }
+  | { type: 'clear_all' };
+
+/**
+ * Interpret CLEARMSG / CLEARCHAT.
+ *
+ * This is the one part of the chat feature that genuinely matters rather than
+ * merely being nice: a message a moderator deleted must leave the overlay
+ * immediately, or a slur that was removed from chat stays burned into the
+ * stream and into every VOD and clip of it.
+ *
+ * CLEARCHAT carries a target login as its trailing parameter when a single user
+ * is banned or timed out, and no trailing parameter when the whole chat is
+ * cleared. `target-user-id` is preferred over the login because it survives a
+ * rename between the message arriving and the ban landing.
+ */
+export function toModerationAction(line: IrcLine): ModerationAction | null {
+  if (line.command === 'CLEARMSG') {
+    const messageId = line.tags['target-msg-id'] ?? '';
+    return messageId ? { type: 'delete_message', messageId } : null;
+  }
+
+  if (line.command === 'CLEARCHAT') {
+    const userId = line.tags['target-user-id'] ?? '';
+    if (userId) return { type: 'purge_user', userId };
+    // Fall back to the login when the id tag is missing. Never treat a
+    // named target as "clear everything": failing open here would wipe the
+    // overlay on every timeout, and failing closed would leave a banned
+    // chatter's messages on stream. Both are wrong, so handle the login.
+    const login = (line.trailing ?? '').trim().toLowerCase();
+    if (login) return { type: 'purge_login', login };
+
+    return { type: 'clear_all' };
+  }
+
+  return null;
+}

--- a/resources/js/utils/ircParser.ts
+++ b/resources/js/utils/ircParser.ts
@@ -59,6 +59,62 @@ export interface ChatMessage {
    * `room-id` is Twitch's own discriminator.
    */
   sourceRoomId: string;
+  /**
+   * Twitch emote positions, as character ranges into `text`.
+   *
+   * Shaped to match what `useEmoteParser` already consumes for alert payloads,
+   * so chat reuses the alert emote pipeline rather than growing a second one.
+   * Third-party emotes (7TV, BTTV, FFZ) are not in here - they carry no
+   * positions on the wire and are matched by token further down.
+   */
+  emotes: TwitchEmotePosition[];
+}
+
+/** A Twitch emote occurrence: an inclusive character range into the message. */
+export interface TwitchEmotePosition {
+  begin: number;
+  end: number;
+  id: string;
+}
+
+/**
+ * Parse the IRC `emotes` tag into positions.
+ *
+ * Wire format is `id:start-end,start-end/id:start-end`, where the ranges are
+ * inclusive and count CODE POINTS rather than UTF-16 units - a message with an
+ * astral-plane emoji before an emote shifts the indices. That mismatch is
+ * handled where the ranges are applied, not here; this stays a literal reading
+ * of the tag.
+ *
+ * Malformed segments are skipped rather than throwing. This runs inside a socket
+ * handler on attacker-influenced input, so a surprise here must never be able to
+ * take the overlay down.
+ */
+export function parseEmoteTag(raw: string): TwitchEmotePosition[] {
+  if (!raw) return [];
+
+  const positions: TwitchEmotePosition[] = [];
+
+  for (const group of raw.split('/')) {
+    const colon = group.indexOf(':');
+    if (colon === -1) continue;
+
+    const id = group.slice(0, colon);
+    if (!id) continue;
+
+    for (const range of group.slice(colon + 1).split(',')) {
+      const dash = range.indexOf('-');
+      if (dash === -1) continue;
+
+      const begin = Number(range.slice(0, dash));
+      const end = Number(range.slice(dash + 1));
+      if (!Number.isInteger(begin) || !Number.isInteger(end) || begin < 0 || end < begin) continue;
+
+      positions.push({ begin, end, id });
+    }
+  }
+
+  return positions;
 }
 
 /**
@@ -220,6 +276,7 @@ export function toChatMessage(line: IrcLine): ChatMessage | null {
     isBroadcaster: badgeSet.has('broadcaster'),
     isFirstMessage: t['first-msg'] === '1',
     sourceRoomId,
+    emotes: parseEmoteTag(t['emotes'] ?? ''),
   };
 }
 

--- a/resources/js/utils/renderTemplate.test.ts
+++ b/resources/js/utils/renderTemplate.test.ts
@@ -289,3 +289,86 @@ describe('renderTemplateSource / foreach scope', () => {
     expect(out).toBe('solo;');
   });
 });
+
+/**
+ * The html-safe escape hatch.
+ *
+ * `chat.N.html` is the one foreach field rendered WITHOUT entity-encoding, so
+ * that emote `<img>` tags survive. That is a deliberate hole in the escaping
+ * hardened above, and these tests are what keep it a hole rather than a wound.
+ *
+ * Two properties must both hold: markup that the emote parser produced gets
+ * through, and a chatter still cannot reach the tag substitution pass. The
+ * second is the one that would silently regress.
+ */
+describe('renderTemplateSource / html-safe foreach fields', () => {
+  const SAFE = { chat: ['html'] };
+
+  it('emits a declared html field without entity-encoding', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.html]]][[[endforeach]]]',
+      { 'chat.0.html': 'hi <img class="overlay-emote" alt="Kappa" src="https://cdn/x.png">', 'chat.count': 1 },
+      LOCALE,
+      true,
+      SAFE,
+    );
+
+    expect(out).toContain('<img class="overlay-emote"');
+    expect(out).not.toContain('&lt;img');
+  });
+
+  it('still defuses tag brackets inside an html field', () => {
+    // encodeHtml never touched `[`, so without defusing here a chatter typing
+    // a tag would land literally in the output and be resolved by pass 2 -
+    // the injection hole closed in #230, reopened through a side door.
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.html]]][[[endforeach]]]',
+      { 'chat.0.html': `[[[${SECRET_TAG}]]]`, 'chat.count': 1, [SECRET_TAG]: SECRET_VALUE },
+      LOCALE,
+      true,
+      SAFE,
+    );
+
+    expect(out).not.toContain(SECRET_VALUE);
+    expect(out).toContain('&#91;&#91;&#91;');
+  });
+
+  it('does not exempt any other field of the same loop', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.text]]][[[endforeach]]]',
+      { 'chat.0.text': '<img src=x onerror=xss>', 'chat.count': 1 },
+      LOCALE,
+      true,
+      SAFE,
+    );
+
+    expect(out).toContain('&lt;img');
+    expect(out).not.toContain('<img');
+  });
+
+  it('does not exempt a field called html on a DIFFERENT iterable', () => {
+    // The exemption is keyed by iterable precisely so it cannot leak to some
+    // other loop that happens to have a field with the same name.
+    const out = renderTemplateSource(
+      '[[[foreach:c:list:notes as n]]][[[n.html]]][[[endforeach]]]',
+      { 'c:list:notes.0.html': '<img src=x onerror=xss>', 'c:list:notes.count': 1 },
+      LOCALE,
+      true,
+      SAFE,
+    );
+
+    expect(out).toContain('&lt;img');
+    expect(out).not.toContain('<img');
+  });
+
+  it('encodes everything when no exemption is passed at all', () => {
+    const out = renderTemplateSource(
+      '[[[foreach:chat as msg]]][[[msg.html]]][[[endforeach]]]',
+      { 'chat.0.html': '<img src=x>', 'chat.count': 1 },
+      LOCALE,
+    );
+
+    expect(out).toContain('&lt;img');
+    expect(out).not.toContain('<img');
+  });
+});

--- a/resources/js/utils/renderTemplate.ts
+++ b/resources/js/utils/renderTemplate.ts
@@ -26,10 +26,11 @@ export function renderTemplateSource(
   data: Record<string, unknown>,
   locale: string,
   encode: boolean = true,
+  htmlSafeFields?: Record<string, readonly string[]>,
 ): string {
   if (!source) return '';
 
-  const withBlocks = processTemplate(source, data, { locale, encode });
+  const withBlocks = processTemplate(source, data, { locale, encode, htmlSafeFields });
 
   return replaceTagsWithFormatting(withBlocks, data, locale, encode);
 }


### PR DESCRIPTION
## The feature

```html
[[[foreach:chat as msg]]]
  <div class="msg [[[msg.badges]]]">
    <span style="color: [[[msg.color]]]">[[[msg.author]]]</span>
    <span>[[[msg.html]]]</span>
  </div>
[[[endforeach]]]
```

Drop that in any static overlay and Twitch chat appears, with Twitch, 7TV, BTTV and FFZ emotes.

The overlay connects to Twitch **directly**, over anonymous IRC-over-WebSocket. Nothing is relayed through Overlabels: no ingestion cost, no metering, no added latency, and chat that keeps working while Overlabels is down. Chat is public and a `justinfan` login needs no credentials, so no secret ever reaches an OBS browser source.

**No DSL change was needed.** `resolveIterable` already synthesizes an array from flat dotted keys with no registration anywhere, so writing `chat.0.author` and `chat.count` into the data map is enough for `foreach` to work. This is a data source, not new syntax.

Per message: `author`, `login`, `text`, `html`, `color`, `badges`, `at`, `id`, `mod`, `sub`, `vip`, `broadcaster`, `first`, `source_channel`.

## Shape

| file | role |
|---|---|
| `ircParser.ts` | pure IRCv3 parsing: tags, PRIVMSG, CLEARMSG, CLEARCHAT, emote positions |
| `chatSlots.ts` | pure projection into `chat.*` data slots |
| `useTwitchChat.ts` | the socket, buffering, window, reconnect |
| `OverlayRenderer.vue` | wires them, and connects only when the template renders chat |

## Deletions are the part that actually matters

CLEARMSG removes one message, CLEARCHAT purges a user or clears the room. A moderator-deleted slur left on the overlay is burned into the stream, the VOD and every clip of it.

Timeouts purge by user id, falling back to login when the id tag is absent, and **never** to "clear everything". Failing open there wipes the overlay on every timeout; failing closed leaves the banned chatter on screen. Both are wrong, so the login case is handled explicitly.

## The emote escape hatch, and why it is narrow

Emotes need markup to survive the entity-encoding. Rather than a general escape hatch:

- **Keyed by iterable, not field name.** `{ chat: ['html'] }` exempts `msg.html` inside a chat loop and nothing else. A different loop with a field called `html` is still escaped, and a test pins that.
- **Bracket defusing still applies inside the exempt field.** This keeps #230 fixed. `encodeHtml` never touched `[`, so skipping only the encoding would let a chatter typing `[[[c:kofi:total_received]]]` land literally in the output and be resolved by the substitution pass - the same injection hole, reopened through a side door. Emote markup has no square brackets, so defusing is free.
- **The guarantee lives with the producer.** `useEmoteParser` escapes every piece of chatter text before adding markup, so the only tags in that slot are `<img>` elements this app generated. The renderer type is named `EmoteRenderer` rather than `string` so the contract has to be opted into, and `chatSlots` emits no html slot at all when no renderer is supplied.

Twitch emote positions come from the IRC `emotes` tag rather than name-matching, so an emote name inside a longer word cannot false-positive. Third-party emotes still match by token through the same alert pipeline, so an emote works in chat the moment it works in an alert.

## Other decisions worth knowing

- **Shared Chat is handled.** A duplicated-in message exposes `[[[msg.source_channel]]]`, empty when native, and renders the chatter's badges from the channel they typed in - matching Twitch's own UI, where a partner's moderator reads as a moderator.
- **50-message window, flushed at most 5x/sec.** The batching is an *animation* fix, not a throughput one: a full `v-html` swap kills in-flight CSS transitions. The renderer does a 50-message feed in under half a millisecond, so throughput was never the issue.
- **The socket only opens if the template renders chat.** Same discipline as the emote library - an overlay that never shows a message should not hold a WebSocket open for a whole stream.
- **`user_login` added to the render payload.** IRC addresses channels by login, not the numeric id everything else uses, and deriving it in the browser would need an authenticated Helix call from a deliberately credential-free overlay.

## Verified

**Against live traffic, not just fixtures.** Pointed at an 86,000-viewer chat: 73 lines, 73 parsed, 56 messages, and **5 real moderation actions caught**. The window correctly held at 50 through four timeouts, which is the proof that a targeted purge is not being mistaken for a room clear. It also handled a real Shared Chat message and a hyphenated event badge without complaint.

**End to end in a real overlay**, rendering real emotes from a real channel.

**70 tests** (35 new), `typecheck`, `build`, `format:check`, `lint:check`, Pest **1368 passed, 6 skipped, 0 failures**.

One test caught a real bug during development: `isMod` only checked the `mod` tag and the broadcaster badge, so a Shared Chat moderator rendered *with* a moderator badge while `[[[if:msg.mod]]]` said no. It now derives from the badges being rendered, so the two cannot disagree.

## Still to come

Badge artwork (badges are names today, which is what CSS wants anyway), the four chat controls, and the filtering settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
