### PR TITLE
perf(overlay): defer the emote library, and gate it on actual usage

### DIFF
--- a/app/Http/Controllers/OverlayTemplateController.php
+++ b/app/Http/Controllers/OverlayTemplateController.php
@@ -806,9 +806,24 @@ class OverlayTemplateController extends Controller
             // off first-play latency vs. instantiating Audio() lazily on dispatch.
             $alertCssPreload = [];
             $alertSoundPreload = [];
+            // Whether the emote library is worth downloading for this overlay.
+            //
+            // The library exists for exactly two alert fields (event.message.text
+            // and event.user_input) plus the chat feed, but it was being fetched
+            // by every overlay on every load - roughly 77 kB for most of them.
+            //
+            // Gating on "is this overlay targeted by an alert" would be WRONG:
+            // an alert with no targeting fires on every static overlay, which is
+            // the deliberate backward-compatible default. So the question is not
+            // whether an alert can fire here (almost always yes) but whether any
+            // alert that can fire here actually renders an emote-parsed field.
+            //
+            // Computed in Postgres so the html blobs never leave the database.
+            $alertsNeedEmotes = false;
             if ($template->type === 'static') {
                 $alertTemplates = OverlayTemplate::query()
                     ->select(['id', 'slug', 'compiled_css', 'alert_sound_url'])
+                    ->selectRaw("(html LIKE '%event.message.text%' OR html LIKE '%event.user_input%') AS uses_emote_fields")
                     ->where('owner_id', $user->id)
                     ->where('type', 'alert')
                     ->with(['targetStaticOverlays:id'])
@@ -819,6 +834,9 @@ class OverlayTemplateController extends Controller
                     $firesHere = empty($targetIds) || in_array($template->id, $targetIds, true);
                     if (! $firesHere) {
                         continue;
+                    }
+                    if ($alertTemplate->uses_emote_fields) {
+                        $alertsNeedEmotes = true;
                     }
                     if (! empty($alertTemplate->compiled_css)) {
                         $alertCssPreload[$alertTemplate->slug] = $alertTemplate->compiled_css;
@@ -840,6 +858,11 @@ class OverlayTemplateController extends Controller
                 ],
                 'alert_css_preload' => $alertCssPreload,
                 'alert_sound_preload' => $alertSoundPreload,
+                // Tells the overlay whether to preload the emote library. Only a
+                // hint: the renderer also loads it lazily if an alert turns up
+                // needing it, so a template edited after this overlay mounted
+                // still gets emotes rather than silently rendering codes.
+                'alerts_need_emotes' => $alertsNeedEmotes,
                 'meta' => [
                     'name' => $template->name,
                     'slug' => $template->slug,

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,20 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - perf(overlay): the emote library waits its turn
+
+The emote library was fetched by every overlay on every load, roughly 77 kB and seven requests to BTTV, 7TV, FFZ and our own proxy. It exists for exactly two alert fields and the chat feed, so most overlays were paying for nothing.
+
+The obvious gate turned out to be the wrong question, which is worth recording because it is an easy mistake to repeat.
+
+**"Is this overlay targeted by an alert?" is not the test.** An alert with no targeting fires on EVERY static overlay - that is the deliberate backward-compatible default from March. So almost every overlay can host alerts, and gating on targeting would have quietly stopped emotes rendering in most people's sub alerts. The real question is whether any alert that can fire here actually renders `event.message.text` or `event.user_input`, which the server can answer exactly because it already assembles that candidate set for the CSS preload.
+
+- **The honest measurement: that gate helps rarely.** Checked against real data before shipping - every single account with alerts had at least one untargeted alert using a message field, so the gate alone would have changed nothing for any of them. It is kept because it is exact and free, and it does help an account with no emote-using alerts at all, but it is not where the win is.
+- **The win is deferral, not skipping.** Nothing needs this library at mount. An alert fires minutes or hours into a stream, and a chat message rendered plain for one flush is invisible because the slots rebuild the moment the library is ready. So the load is scheduled for idle time instead of racing the overlay's own first paint, with a 2 s ceiling so an overlay that never goes idle still gets it.
+- **Anything that needs it now still gets it now.** The alert path starts the load immediately rather than waiting for idle, and cancels a pending idle callback so the two cannot race.
+- **The preload flag is a hint, not a contract.** An alert template edited to use a message field after an overlay mounted is not in `alerts_need_emotes`, so the alert path loads the library itself. That costs one alert its emotes instead of every alert for the rest of the stream.
+- **Eight tests pin the gate**, and three of them were verified to fail against the naive targeting-based version - including the exact case that would have broken sub alerts for everyone.
+
 ## August 16th, 2026 - feat(chat): Twitch chat in an overlay
 
 ```

--- a/resources/js/components/OverlayRenderer.vue
+++ b/resources/js/components/OverlayRenderer.vue
@@ -140,6 +140,54 @@ const templateUsesChat = computed(() => {
  * accurate than code-matching: it cannot false-positive on a word that merely
  * contains an emote name.
  */
+/**
+ * Emote library loading, in two speeds.
+ *
+ * Nothing needs this library at mount. An alert fires minutes or hours into a
+ * stream, and a chat message rendered plain for one flush is invisible because
+ * the slots rebuild when the library becomes ready. So the mount path SCHEDULES
+ * the load for idle time rather than racing the overlay's own first paint,
+ * while anything that needs it right now starts it immediately.
+ *
+ * Both are idempotent, because the server-side preload hint is only a hint: an
+ * alert template edited to use `event.message.text` after this overlay mounted
+ * is not in `alerts_need_emotes`, and the alert path picks it up instead.
+ */
+let emoteLoadStarted = false;
+let emoteIdleHandle: number | null = null;
+
+function loadEmoteParser(): void {
+  if (emoteLoadStarted || !userId.value) return;
+  emoteLoadStarted = true;
+
+  if (emoteIdleHandle !== null) {
+    if (typeof cancelIdleCallback === 'function') cancelIdleCallback(emoteIdleHandle);
+    emoteIdleHandle = null;
+  }
+
+  emoteParser.initialize(Number(userId.value)).catch(() => {
+    console.warn('[OverlayRenderer] Emote parser failed to initialize');
+  });
+}
+
+function scheduleEmoteParser(): void {
+  if (emoteLoadStarted || emoteIdleHandle !== null) return;
+
+  // The timeout is a ceiling, not a target: it guarantees the load happens even
+  // on an overlay that never goes idle, which a busy animated one might not.
+  if (typeof requestIdleCallback === 'function') {
+    emoteIdleHandle = requestIdleCallback(
+      () => {
+        emoteIdleHandle = null;
+        loadEmoteParser();
+      },
+      { timeout: 2000 },
+    );
+  } else {
+    setTimeout(loadEmoteParser, 500);
+  }
+}
+
 function chatMessageHtml(m: ChatMessage): string {
   return emoteParser.parseEmotes(m.text, m.emotes.length ? JSON.stringify(m.emotes) : undefined);
 }
@@ -610,11 +658,14 @@ onMounted(async () => {
 
     userId.value = json.data?.user_twitch_id || json.data?.user_id || json.data?.channel_id || json.data?.twitch_id || null;
 
-    // Start loading emotes for this broadcaster's channel
-    if (userId.value) {
-      emoteParser.initialize(Number(userId.value)).catch(() => {
-        console.warn('[OverlayRenderer] Emote parser failed to initialize');
-      });
+    // Preload the emote library only when something on this overlay can
+    // actually use it: a chat feed, or an alert that renders an emote-parsed
+    // field and can fire here. `alerts_need_emotes` is computed server-side
+    // because only the server knows which alert templates target this overlay -
+    // and an untargeted alert fires on EVERY static overlay, so "is this overlay
+    // targeted" would have been the wrong question entirely.
+    if (userId.value && (templateUsesChat.value || json.alerts_need_emotes)) {
+      scheduleEmoteParser();
     }
 
     // Join Twitch chat, but ONLY when this template actually renders it.
@@ -977,6 +1028,11 @@ function handleAlertTriggered(event: any) {
 
   for (const { field, emotesField } of EMOTE_TEXT_FIELDS) {
     if (typeof processedData[field] === 'string' && processedData[field]) {
+      // Safety net for an alert template that started using an emote field
+      // after this overlay mounted, so the preload hint missed it. parseEmotes
+      // passes the text through untouched while the library is still loading,
+      // so this alert renders plain and every later one renders emotes.
+      loadEmoteParser();
       processedData[field] = emoteParser.parseEmotes(processedData[field], emotesField ? processedData[emotesField] : undefined);
     }
   }

--- a/tests/Feature/EmotePreloadGateTest.php
+++ b/tests/Feature/EmotePreloadGateTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Models\OverlayAccessToken;
+use App\Models\OverlayTemplate;
+use App\Models\User;
+use App\Services\TwitchApiService;
+use App\Services\TwitchTokenService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+uses(DatabaseTransactions::class);
+
+/*
+ * `alerts_need_emotes` decides whether an overlay downloads the 7TV/BTTV/FFZ
+ * emote library, which is ~77 kB and was previously fetched by every overlay on
+ * every load.
+ *
+ * The tempting gate - "is this overlay targeted by an alert?" - is WRONG, and
+ * that is what these tests exist to lock down. An alert with no targeting fires
+ * on EVERY static overlay by design, so almost every overlay can host alerts.
+ * The real question is whether any alert that can fire here actually renders an
+ * emote-parsed field (`event.message.text` or `event.user_input`).
+ *
+ * Getting this backwards is silent in both directions: too eager wastes the
+ * download forever, too strict renders emote codes as literal text in someone's
+ * sub alert on stream.
+ */
+
+function emoteGateUser(): User
+{
+    return User::factory()->create([
+        'twitch_id' => (string) fake()->unique()->randomNumber(9),
+        'access_token' => 'fake-twitch-token',
+    ]);
+}
+
+function emoteGateToken(User $user): string
+{
+    $plain = bin2hex(random_bytes(32));
+    OverlayAccessToken::create([
+        'user_id' => $user->id,
+        'token_hash' => hash('sha256', $plain),
+        'token_prefix' => substr($plain, 0, 8),
+        'name' => 'emote-gate-test',
+        'is_active' => true,
+    ]);
+
+    return $plain;
+}
+
+function emoteGateTemplate(User $user, string $type, string $html = '<div>x</div>'): OverlayTemplate
+{
+    return OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => $type,
+        'html' => $html,
+        'slug' => $type.'-'.fake()->unique()->lexify('????????'),
+        'metadata' => null,
+    ]);
+}
+
+function renderOverlay(string $slug, string $token)
+{
+    return test()->postJson('/api/overlay/render', ['slug' => $slug, 'token' => $token]);
+}
+
+beforeEach(function () {
+    $this->mock(TwitchTokenService::class, function ($mock) {
+        $mock->shouldReceive('ensureValidToken')->andReturnTrue();
+    });
+    $this->mock(TwitchApiService::class, function ($mock) {
+        $mock->shouldReceive('getExtendedUserData')->andReturn([]);
+        $mock->shouldReceive('enrichEventWithUserAvatars')->andReturnUsing(fn ($t, $e) => $e);
+    });
+});
+
+it('does not ask for emotes when the user has no alerts at all', function () {
+    $user = emoteGateUser();
+    $static = emoteGateTemplate($user, 'static');
+
+    renderOverlay($static->slug, emoteGateToken($user))
+        ->assertOk()
+        ->assertJsonPath('alerts_need_emotes', false);
+});
+
+it('does not ask for emotes when an alert renders no emote-parsed field', function () {
+    $user = emoteGateUser();
+    $static = emoteGateTemplate($user, 'static');
+    emoteGateTemplate($user, 'alert', '<div>[[[event.user_name]]] followed</div>');
+
+    renderOverlay($static->slug, emoteGateToken($user))
+        ->assertOk()
+        ->assertJsonPath('alerts_need_emotes', false);
+});
+
+it('asks for emotes when an UNTARGETED alert renders a message field', function () {
+    // The case the naive gate would miss. No targeting means it fires here.
+    $user = emoteGateUser();
+    $static = emoteGateTemplate($user, 'static');
+    emoteGateTemplate($user, 'alert', '<div>[[[event.message.text]]]</div>');
+
+    renderOverlay($static->slug, emoteGateToken($user))
+        ->assertOk()
+        ->assertJsonPath('alerts_need_emotes', true);
+});
+
+it('asks for emotes for a channel-points alert using user_input', function () {
+    $user = emoteGateUser();
+    $static = emoteGateTemplate($user, 'static');
+    emoteGateTemplate($user, 'alert', '<div>[[[event.user_input]]]</div>');
+
+    renderOverlay($static->slug, emoteGateToken($user))
+        ->assertOk()
+        ->assertJsonPath('alerts_need_emotes', true);
+});
+
+it('ignores an emote-using alert that is targeted at a DIFFERENT overlay', function () {
+    $user = emoteGateUser();
+    $static = emoteGateTemplate($user, 'static');
+    $other = emoteGateTemplate($user, 'static');
+
+    $alert = emoteGateTemplate($user, 'alert', '<div>[[[event.message.text]]]</div>');
+    $alert->targetStaticOverlays()->attach($other->id);
+
+    renderOverlay($static->slug, emoteGateToken($user))
+        ->assertOk()
+        ->assertJsonPath('alerts_need_emotes', false);
+});
+
+it('asks for emotes when the alert targets THIS overlay', function () {
+    $user = emoteGateUser();
+    $static = emoteGateTemplate($user, 'static');
+
+    $alert = emoteGateTemplate($user, 'alert', '<div>[[[event.message.text]]]</div>');
+    $alert->targetStaticOverlays()->attach($static->id);
+
+    renderOverlay($static->slug, emoteGateToken($user))
+        ->assertOk()
+        ->assertJsonPath('alerts_need_emotes', true);
+});
+
+it('ignores another user\'s emote-using alert', function () {
+    $user = emoteGateUser();
+    $static = emoteGateTemplate($user, 'static');
+
+    $stranger = emoteGateUser();
+    emoteGateTemplate($stranger, 'alert', '<div>[[[event.message.text]]]</div>');
+
+    renderOverlay($static->slug, emoteGateToken($user))
+        ->assertOk()
+        ->assertJsonPath('alerts_need_emotes', false);
+});
+
+it('needs only one emote-using alert among many that do not', function () {
+    $user = emoteGateUser();
+    $static = emoteGateTemplate($user, 'static');
+
+    emoteGateTemplate($user, 'alert', '<div>[[[event.user_name]]] followed</div>');
+    emoteGateTemplate($user, 'alert', '<div>[[[event.user_name]]] raided</div>');
+    emoteGateTemplate($user, 'alert', '<div>[[[event.message.text]]]</div>');
+
+    renderOverlay($static->slug, emoteGateToken($user))
+        ->assertOk()
+        ->assertJsonPath('alerts_need_emotes', true);
+});


### PR DESCRIPTION
## What was wrong

The emote library was fetched by every overlay on every load: roughly 77 kB plus seven requests to BTTV, 7TV, FFZ and our own proxy. It exists for exactly two alert fields (`event.message.text`, `event.user_input`) and the chat feed, so most overlays were paying for nothing.

## The obvious gate is the wrong question

Worth recording, because it is an easy mistake to repeat.

**"Is this overlay targeted by an alert?" is not the test.** An alert with no targeting fires on EVERY static overlay - the deliberate backward-compatible default from March. So almost every overlay can host alerts, and gating on targeting would have quietly stopped emotes rendering in most people's sub alerts.

The right question is whether any alert that *can* fire here actually renders an emote field. The server can answer that exactly, because it already assembles the candidate set for the CSS preload (`$firesHere = empty($targetIds) || in_array(...)`). Computed with a `selectRaw` so the HTML blobs never leave Postgres.

## Then I measured it, and it mostly does not help

```
alert templates: 57 | using emote fields: 14
owners with an emote alert: 6 of 6
```

**Every account with alerts has at least one untargeted alert using a message field.** The gate alone would have changed nothing for any of them.

It is kept because it is exact, free, and does help an account with no emote-using alerts at all. But it is not the win, and pretending otherwise would be shipping something that looks clever and does nothing.

## The win is deferral, not skipping

Nothing needs this library at mount. An alert fires minutes or hours into a stream, and a chat message rendered plain for one flush is invisible because the slots rebuild the moment the library becomes ready.

- **Scheduled for idle time** instead of racing the overlay's own first paint, with a 2 s ceiling via `requestIdleCallback`'s `timeout` so a busy animated overlay that never goes idle still gets it.
- **Anything that needs it now still gets it now.** The alert path starts the load immediately and cancels a pending idle callback, so the two cannot race.
- **`alerts_need_emotes` is a hint, not a contract.** An alert template edited to use a message field *after* an overlay mounted is not in it, so the alert path loads the library itself. That costs one alert its emotes instead of every alert for the rest of the stream.

Honest framing: the 77 kB still downloads for nearly everyone. It just stops competing with first paint. That is a smaller win than the earlier "44% of the overlay's JS" estimate suggested, and the changelog says so.

## Tests

Eight new, and **three were verified to fail against the naive targeting-based gate** - including the exact case that would have broken sub alerts for everyone:

- no alerts at all
- an alert that renders no emote field
- an **untargeted** alert that renders a message field (fails naive)
- a channel-points alert using `user_input` (fails naive)
- an emote alert targeted at a *different* overlay
- an emote alert targeted at *this* overlay
- another user's emote alert
- one emote-using alert among several that are not (fails naive)

## Gates

Pest **1376 passed, 6 skipped, 0 failures** · `typecheck` · `lint:check` · `format:check` · `pint` · `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
