### PR TITLE
feat(chat): four chat controls fed by an aggregated bot summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ alongside the foreach tag-injection fix (PR #230), which had no automated covera
 
 ### Control reset lifecycle (fixed Aug 2026)
 
-- **The go-live reset is scoped by KEY, never by source.** `StreamSessionService::resetControls()` selects on `PER_STREAM_CONTROL_KEYS`, the eight `*_this_stream` counters. Do not widen it back to `where('source', 'twitch')` with no key filter.
+- **The go-live reset is scoped by KEY, never by source.** `StreamSessionService::resetControls()` selects on `PER_STREAM_CONTROL_KEYS`, the ten `*_this_stream` counters. Do not widen it back to `where('source', 'twitch')` with no key filter.
 - A key belongs on that list only if its label promises per-stream scope. The reset is the *only* thing implementing that promise: `handleEvent()` increments purely additively (`$current + $step`) and nothing else ever zeroes a counter.
 - The three `latest_cheer*` presets deliberately do NOT reset. They are most-recent values, and all 25 equivalents across the five donation services persist across streams. They were swept into the reset for four months because they share `source='twitch'` with controls the filter predated - which broke the bits/donation parity they were added (`c6be780`) to provide.
 - `latest_cheerer_name` is a `text` control with no `config`, so the old reset wrote `(string) ($control->config['reset_value'] ?? 0)` = the literal string `"0"` into it. `"0"` is falsy in conditionals (`useConditionalTemplates.ts`) but a bare `[[[c:key]]]` renders it verbatim - `replaceTagsWithFormatting` blanks only on undefined/null/object/`''`, and `?? default` backstops absence only.
@@ -319,6 +319,25 @@ counts them ("five donation services", "five pipes") lives in `resources/views/w
 - **`EventsTable.vue` and `ControlsManager.vue` are deliberately NOT converted.** Each row is wrapped in a popover / collapsible respectively, so they are a different shape, not the same row with different content. They stay on `.collection-row` so they still move with the skin. Do not "finish the job" unprompted.
 - Empty states go through `EmptyState.vue` (via `emptyMessage`/`emptyDashed` props or the `empty` slot), not hand-rolled dashed divs.
 - External event labels derive from `SERVICE_LABELS` in `resources/js/utils/services.ts`. The old hardcoded per-service map covered Ko-fi and Streamlabs only and had rotted into "bmac: donation" for the three donation services added after it was written.
+
+## Twitch Chat Overlay (Implemented Aug 2026)
+
+- `[[[foreach:chat as msg]]]` renders live chat in any static overlay. **The overlay connects to Twitch DIRECTLY**, anonymous IRC-over-WebSocket (`justinfan`, no credentials). Nothing is relayed through Overlabels, and the overlay never phones home.
+- Files: `utils/ircParser.ts` (parsing), `utils/chatSlots.ts` (window -> `chat.*` slots), `composables/useTwitchChat.ts` (socket). The socket only opens when the template actually renders chat.
+- Per-message tags: `author`, `login`, `text`, `html`, `color`, `badges`, `at`, `id`, `mod`, `sub`, `vip`, `broadcaster`, `first`, `source_channel`, plus `chat.count`. Index 0 is OLDEST. `at` is Unix seconds.
+- `chat.N.html` is the ONLY foreach field rendered unescaped (`htmlSafeFields`, keyed by iterable). **Bracket defusing still applies inside it** - skipping that reopens the PR #230 injection hole through a side door.
+- Deletions are not optional: CLEARMSG removes one message, CLEARCHAT purges a user or clears the room. Purge by user id, falling back to login, and NEVER to "clear everything".
+
+### Chat controls (Aug 2026)
+
+- Four controls, all `source='twitch'`, `source_managed=true`: `chat_messages_this_stream`, `unique_chatters_this_stream`, `latest_chatter_name`, `latest_chat_message`. The first two ARE on `PER_STREAM_CONTROL_KEYS`; the `latest_*` pair deliberately is NOT (same rule as `latest_cheer*`).
+- **Fed by the BOT, never by the overlay.** `POST /internal/bot/chat-stats/{login}` takes one aggregated summary every 30-60s: `{message_count, chatters[], latest_chatter_name, latest_chat_message}`. Rejected: Laravel subscribing to `channel.chat.message` by webhook (one synchronous POST per message, and a slow webhook risks Twitch killing the user's OTHER subscriptions via `notification_failures_exceeded`).
+- `chatters` is the distinct logins seen in THAT WINDOW. Stream-scoped uniqueness is resolved server-side in `mergeChatters()` against a cached set (`chat:chatters:{user_id}`), because the bot is a thin relay and would lose the set on every restart.
+- `unique_chatters_this_stream` only ever moves UPWARD within a stream. A cache flush restarts the set from empty, and without the `max()` guard the counter would visibly count down on stream. `resetControls()` therefore has to `Cache::forget()` the set at go-live, or the counter stays pinned at last stream's total.
+- Counts are **native-only**: the bot excludes Shared Chat foreign messages so a collab cannot inflate the numbers. The feed shows more than the counter counts - that is intended.
+- The summary is ignored unless the channel is confidently live, and returns 200 with `applied:false` so the bot does not retry.
+- `latest_chat_message` is stored RAW, like `latest_cheer_message`. Do NOT "sanitize" it with `strip_tags()`: that eats from `<` to the next `>` or end of string, so "i <3 you" becomes "i ". Render-side encoding plus `defuseBrackets()` is what makes it safe.
+- Pinned by `tests/Feature/BotChatStatsTest.php` (18 tests); the go-live cache clear and the upward-only guard were both verified to fail when removed.
 
 ## Development Workflow
 

--- a/app/Http/Controllers/Api/Internal/BotChatStatsController.php
+++ b/app/Http/Controllers/Api/Internal/BotChatStatsController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Api\Internal;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Services\StreamSessionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BotChatStatsController extends Controller
+{
+    public function __construct(private readonly StreamSessionService $sessions) {}
+
+    /**
+     * Accept one aggregated chat summary for a channel and apply it to the
+     * four chat controls.
+     *
+     * The bot aggregates in memory and POSTs a summary every 30-60s; it does
+     * NOT call this per message. Rejected alternative: Laravel subscribing to
+     * channel.chat.message by webhook, which is one synchronous POST per
+     * message into a handler doing 6-10 DB ops on a shared 4 GB box, and where
+     * a slow webhook risks Twitch disabling the user's OTHER subscriptions via
+     * notification_failures_exceeded.
+     *
+     * `chatters` is the distinct logins seen in THIS window. Stream-scoped
+     * uniqueness is resolved server-side - the bot is a thin relay and has no
+     * notion of where a stream starts.
+     *
+     * `message_count` and `chatters` must be native-only: Shared Chat messages
+     * duplicated in from another channel are excluded by the bot so a collab
+     * does not inflate the streamer's numbers.
+     */
+    public function store(Request $request, string $login): JsonResponse
+    {
+        $data = $request->validate([
+            'message_count' => 'required|integer|min:0|max:1000000',
+            'chatters' => 'sometimes|array|max:10000',
+            'chatters.*' => 'string|max:64',
+            // Twitch caps a chat message at 500 characters.
+            'latest_chatter_name' => 'nullable|string|max:64',
+            'latest_chat_message' => 'nullable|string|max:500',
+        ]);
+
+        $user = $this->resolveUser($login);
+
+        if (! $user) {
+            return response()->json(['error' => 'channel not found'], 404);
+        }
+
+        $result = $this->sessions->applyChatSummary(
+            $user,
+            $data['message_count'],
+            $data['chatters'] ?? [],
+            $data['latest_chatter_name'] ?? null,
+            $data['latest_chat_message'] ?? null,
+        );
+
+        // 200 with applied=false when the channel is not confidently live. The
+        // bot must not retry - the summary is genuinely not wanted, and a 4xx
+        // here would look like a bug worth retrying.
+        return response()->json($result);
+    }
+
+    private function resolveUser(string $login): ?User
+    {
+        $login = strtolower($login);
+
+        return User::where('bot_enabled', true)
+            ->whereNotNull('twitch_data')
+            ->get()
+            ->first(fn (User $u) => strtolower($u->twitch_data['login'] ?? '') === $login);
+    }
+}

--- a/app/Services/StreamSessionService.php
+++ b/app/Services/StreamSessionService.php
@@ -7,6 +7,7 @@ use App\Models\OverlayControl;
 use App\Models\StreamSession;
 use App\Models\StreamState;
 use App\Models\User;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 class StreamSessionService
@@ -44,7 +45,23 @@ class StreamSessionService
         'redemptions_this_stream',
         'cheers_this_stream',
         'bits_this_stream',
+        'chat_messages_this_stream',
+        'unique_chatters_this_stream',
     ];
+
+    /**
+     * How long the per-stream unique-chatter set survives without a write.
+     * Longer than any plausible stream, because the authoritative clear is the
+     * go-live reset in resetControls(), not expiry.
+     */
+    private const int CHATTER_SET_TTL = 43200; // 12 hours
+
+    /**
+     * Ceiling on logins tracked for unique_chatters_this_stream. A real 86k-viewer
+     * stream produced ~134 messages/minute, so this is unreachable in practice; it
+     * exists so the cached set cannot grow without bound.
+     */
+    private const int MAX_TRACKED_CHATTERS = 50000;
 
     /**
      * Control presets users can add to their overlays.
@@ -61,6 +78,10 @@ class StreamSessionService
         ['key' => 'latest_cheerer_name', 'type' => 'text', 'label' => 'Latest Cheerer Name', 'value' => ''],
         ['key' => 'latest_cheer_amount', 'type' => 'number', 'label' => 'Latest Cheer Amount (bits)', 'value' => '0'],
         ['key' => 'latest_cheer_message', 'type' => 'text', 'label' => 'Latest Cheer Message', 'value' => ''],
+        ['key' => 'chat_messages_this_stream', 'type' => 'counter', 'label' => 'Chat Messages This Stream', 'value' => '0'],
+        ['key' => 'unique_chatters_this_stream', 'type' => 'counter', 'label' => 'Unique Chatters This Stream', 'value' => '0'],
+        ['key' => 'latest_chatter_name', 'type' => 'text', 'label' => 'Latest Chatter Name', 'value' => ''],
+        ['key' => 'latest_chat_message', 'type' => 'text', 'label' => 'Latest Chat Message', 'value' => ''],
     ];
 
     /**
@@ -152,6 +173,126 @@ class StreamSessionService
     }
 
     /**
+     * Apply one aggregated chat summary from the bot.
+     *
+     * The bot buffers chat in memory per channel and POSTs ONE summary every
+     * 30-60s rather than one request per message, so Laravel sees ~60-120
+     * requests per hour per channel instead of thousands.
+     *
+     * Counts are NATIVE-ONLY by contract: the bot excludes Shared Chat messages
+     * duplicated in from another channel, so a collab cannot inflate your
+     * numbers. The feed therefore shows more messages than the counter counts.
+     *
+     * The overlay's own IRC connection is display-only and never feeds these -
+     * overlays do not phone home.
+     *
+     * @param  list<string>  $chatters  Distinct logins seen in this window.
+     * @return array{applied: bool, unique_chatters: int|null}
+     */
+    public function applyChatSummary(
+        User $user,
+        int $messageCount,
+        array $chatters = [],
+        ?string $latestChatterName = null,
+        ?string $latestChatMessage = null,
+    ): array {
+        // "This stream" is meaningless while offline, and the latest_* pair
+        // matches the cheer handling above by only moving during a stream.
+        if (! StreamState::forUser($user)->isConfidentlyLive()) {
+            return ['applied' => false, 'unique_chatters' => null];
+        }
+
+        if ($messageCount > 0) {
+            $this->applyTwitchControl(
+                $user,
+                'chat_messages_this_stream',
+                fn (OverlayControl $control) => (string) ((float) ($control->value ?? 0) + $messageCount),
+            );
+        }
+
+        $uniqueCount = $this->mergeChatters($user, $chatters);
+
+        if ($uniqueCount !== null) {
+            $this->applyTwitchControl(
+                $user,
+                'unique_chatters_this_stream',
+                // Only ever moves upward. The chatter set lives in the cache, so
+                // a cache flush mid-stream restarts it from empty; without this
+                // guard the counter would visibly count DOWN on stream. It
+                // resumes climbing once the fresh set overtakes the stored peak.
+                fn (OverlayControl $control) => (string) max((float) ($control->value ?? 0), $uniqueCount),
+            );
+        }
+
+        // Stored raw, exactly like latest_cheer_message and the donation message
+        // controls. strip_tags() is deliberately NOT used: it eats from `<` to
+        // the next `>` or end of string, so "i <3 you" would be truncated to
+        // "i ". The render pass is what makes this safe - control values are
+        // substituted once and entity-encoded, and defuseBrackets() stops a
+        // chatter's literal [[[c:...]]] from being resolved.
+        if ($latestChatterName !== null && $latestChatterName !== '') {
+            $this->applyTwitchControl($user, 'latest_chatter_name', fn () => $latestChatterName);
+        }
+
+        if ($latestChatMessage !== null && $latestChatMessage !== '') {
+            $this->applyTwitchControl($user, 'latest_chat_message', fn () => $latestChatMessage);
+        }
+
+        return ['applied' => true, 'unique_chatters' => $uniqueCount];
+    }
+
+    /**
+     * Fold this window's logins into the per-stream unique-chatter set.
+     *
+     * Returns the new set size, or null when the window added nobody new - the
+     * caller skips the control write entirely in that case, so a quiet window
+     * costs zero writes and zero broadcasts.
+     *
+     * Uniqueness is decided HERE rather than in the bot: the bot is a thin relay
+     * and has no notion of where a stream starts, and it would lose the set on
+     * every restart.
+     *
+     * @param  list<string>  $chatters
+     */
+    private function mergeChatters(User $user, array $chatters): ?int
+    {
+        $incoming = collect($chatters)
+            ->map(fn ($login) => strtolower(trim((string) $login)))
+            ->filter()
+            ->unique();
+
+        $key = self::chatterSetCacheKey($user);
+        $known = collect(Cache::get($key, []));
+        $before = $known->count();
+
+        $merged = $known->merge($incoming)->unique()->values();
+
+        if ($merged->count() > self::MAX_TRACKED_CHATTERS) {
+            Log::warning("Unique-chatter set capped for user {$user->id}", [
+                'seen' => $merged->count(),
+                'cap' => self::MAX_TRACKED_CHATTERS,
+            ]);
+            $merged = $merged->take(self::MAX_TRACKED_CHATTERS)->values();
+        }
+
+        if ($merged->count() === $before) {
+            return null;
+        }
+
+        Cache::put($key, $merged->all(), self::CHATTER_SET_TTL);
+
+        return $merged->count();
+    }
+
+    /**
+     * Cache key holding the current stream's set of distinct chatter logins.
+     */
+    private static function chatterSetCacheKey(User $user): string
+    {
+        return "chat:chatters:{$user->id}";
+    }
+
+    /**
      * Update every twitch source_managed control matching this key, then broadcast each change.
      * The transformer receives the control and returns the new stringified value.
      */
@@ -187,6 +328,11 @@ class StreamSessionService
      */
     private function resetControls(User $user): void
     {
+        // unique_chatters_this_stream is backed by a cached set of logins, so
+        // zeroing the control alone would leave the counter pinned at last
+        // stream's total (applyChatSummary only ever moves it upward).
+        Cache::forget(self::chatterSetCacheKey($user));
+
         $controls = OverlayControl::where('user_id', $user->id)
             ->where('source', 'twitch')
             ->whereIn('key', self::PER_STREAM_CONTROL_KEYS)

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,19 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - feat(chat): four chat controls, counted server-side
+
+Chat has been renderable in an overlay since this morning, but only as a feed. These are the numbers: `chat_messages_this_stream`, `unique_chatters_this_stream`, `latest_chatter_name` and `latest_chat_message`, usable anywhere a control tag is, including alerts and bot replies.
+
+The overlay is not what counts them. It reads chat directly from Twitch for display and it never phones home, so the numbers come from the bot instead, which was already watching chat for command handling.
+
+- **One summary every 30-60 seconds, not one request per message.** The bot aggregates in memory per channel and POSTs a single summary, so Laravel sees roughly 60-120 requests an hour per channel instead of thousands. The alternative - subscribing to `channel.chat.message` by webhook - would have been one synchronous POST per message into a handler doing six to ten database writes, and a webhook that falls behind risks Twitch disabling that user's *other* subscriptions.
+- **The bot sends who talked; the server decides who is new.** The summary carries the distinct logins from that window only. Deduplicating across the whole stream happens here, because the bot is a thin relay with no notion of where a stream begins and would lose the set every time it restarts.
+- **The unique-chatter count never counts down.** It is backed by a cached set, and a cache flush mid-stream would otherwise restart it from zero and walk the number backwards live on stream. It holds its peak instead and resumes climbing. The flip side is that the go-live reset has to clear the set as well as the control, or the counter spends the next stream frozen at the last one's total. Both halves have a test that was checked to fail without them.
+- **Two of the four reset at go-live and two do not.** The counters promise "this stream" and are on the reset list. The `latest_*` pair are most-recent values, and every equivalent across the five donation services persists across streams - sweeping those into the reset is exactly the bug that took four months to notice last time.
+- **The counts are native-only.** Shared Chat messages duplicated in from a collab partner show up in the feed but are not counted, so a collab cannot inflate your numbers. The feed showing more than the counter counts is deliberate.
+- **`latest_chat_message` is stored exactly as typed.** Running `strip_tags()` over it looks like the careful thing to do right up until someone types "i <3 you" and the overlay renders "i ", because it eats everything from the `<` onward. Escaping belongs at render time, where it already is.
+
 ## August 16th, 2026 - perf(overlay): the emote library waits its turn
 
 The emote library was fetched by every overlay on every load, roughly 77 kB and seven requests to BTTV, 7TV, FFZ and our own proxy. It exists for exactly two alert fields and the chat feed, so most overlays were paying for nothing.

--- a/resources/js/components/controls/controlPresets.ts
+++ b/resources/js/components/controls/controlPresets.ts
@@ -69,6 +69,13 @@ export const TWITCH_PRESETS: ServicePreset[] = [
   { key: 'latest_cheerer_name', label: 'Latest Cheerer Name', type: 'text' },
   { key: 'latest_cheer_amount', label: 'Latest Cheer Amount (bits)', type: 'number' },
   { key: 'latest_cheer_message', label: 'Latest Cheer Message', type: 'text' },
+  // Fed by the bot's aggregated chat summary, not by the overlay's own IRC
+  // connection. Counts are native-only, so a Shared Chat collab shows more
+  // messages in the feed than these count.
+  { key: 'chat_messages_this_stream', label: 'Chat Messages This Stream', type: 'counter' },
+  { key: 'unique_chatters_this_stream', label: 'Unique Chatters This Stream', type: 'counter' },
+  { key: 'latest_chatter_name', label: 'Latest Chatter Name', type: 'text' },
+  { key: 'latest_chat_message', label: 'Latest Chat Message', type: 'text' },
 ];
 
 // System namespace, not an integration: alerts:muted mirrors the global

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\GpsSessionMapController;
 use App\Http\Controllers\Api\Internal\BotAccountageController;
 use App\Http\Controllers\Api\Internal\BotChannelController;
 use App\Http\Controllers\Api\Internal\BotChatAdminController;
+use App\Http\Controllers\Api\Internal\BotChatStatsController;
 use App\Http\Controllers\Api\Internal\BotCommandController;
 use App\Http\Controllers\Api\Internal\BotCommandMapController;
 use App\Http\Controllers\Api\Internal\BotControlController;
@@ -213,6 +214,8 @@ Route::prefix('/internal/bot')
                 ->where(['login' => '[a-z0-9_]+', 'key' => '[a-z][a-z0-9_]{0,49}']);
             Route::post('/controls/{login}/{key}', [BotControlController::class, 'update'])
                 ->where(['login' => '[a-z0-9_]+', 'key' => '[a-z][a-z0-9_]{0,49}']);
+            Route::post('/chat-stats/{login}', [BotChatStatsController::class, 'store'])
+                ->where('login', '[a-z0-9_]+');
             Route::get('/outbox', [BotOutboxController::class, 'index']);
             Route::post('/settings/{login}/controls-access', [BotSettingsController::class, 'setControlsAccess'])
                 ->where('login', '[a-z0-9_]+');

--- a/tests/Feature/BotChatStatsTest.php
+++ b/tests/Feature/BotChatStatsTest.php
@@ -1,0 +1,274 @@
+<?php
+
+use App\Events\ControlValueUpdated;
+use App\Models\OverlayControl;
+use App\Models\StreamState;
+use App\Models\User;
+use App\Services\StreamSessionService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Testing\TestResponse;
+
+uses(DatabaseTransactions::class);
+
+const CHAT_STATS_URL = '/api/internal/bot/chat-stats/streamer';
+
+beforeEach(function () {
+    config(['services.twitchbot.listener_secret' => 'test-bot-secret']);
+    Cache::flush();
+
+    $this->user = User::factory()->create([
+        'bot_enabled' => true,
+        'twitch_data' => ['login' => 'streamer'],
+    ]);
+});
+
+function goLive(User $user): void
+{
+    StreamState::updateOrCreate(
+        ['user_id' => $user->id],
+        ['state' => StreamState::STATE_LIVE, 'confidence' => 1.0],
+    );
+}
+
+function chatControl(User $user, string $key, string $type, string $value): OverlayControl
+{
+    return OverlayControl::create([
+        'user_id' => $user->id,
+        'overlay_template_id' => null,
+        'key' => $key,
+        'label' => $key,
+        'type' => $type,
+        'value' => $value,
+        'source' => 'twitch',
+        'source_managed' => true,
+    ]);
+}
+
+function postChatStats(array $payload): TestResponse
+{
+    return test()->postJson(CHAT_STATS_URL, $payload, ['X-Internal-Secret' => 'test-bot-secret']);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Auth and routing
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('chat-stats returns 403 without the internal secret', function () {
+    $this->postJson(CHAT_STATS_URL, ['message_count' => 1])
+        ->assertStatus(403);
+});
+
+test('chat-stats returns 404 for an unknown channel', function () {
+    $this->postJson(
+        '/api/internal/bot/chat-stats/nobody',
+        ['message_count' => 1],
+        ['X-Internal-Secret' => 'test-bot-secret'],
+    )->assertStatus(404);
+});
+
+test('chat-stats returns 404 for a channel with the bot disabled', function () {
+    // A channel with the bot off produces no data, which must not be mistaken
+    // for a quiet stream.
+    $this->user->update(['bot_enabled' => false]);
+
+    postChatStats(['message_count' => 5])->assertStatus(404);
+});
+
+test('chat-stats rejects a message that exceeds the Twitch limit', function () {
+    goLive($this->user);
+
+    postChatStats([
+        'message_count' => 1,
+        'latest_chat_message' => str_repeat('a', 501),
+    ])->assertStatus(422);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Live gating
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('a summary is ignored while the channel is not confidently live', function () {
+    $messages = chatControl($this->user, 'chat_messages_this_stream', 'counter', '0');
+
+    postChatStats(['message_count' => 40, 'chatters' => ['alice']])
+        ->assertOk()
+        ->assertJson(['applied' => false]);
+
+    expect($messages->fresh()->value)->toBe('0');
+});
+
+test('a summary below the confidence threshold is ignored', function () {
+    StreamState::updateOrCreate(
+        ['user_id' => $this->user->id],
+        ['state' => StreamState::STATE_LIVE, 'confidence' => 0.5],
+    );
+    $messages = chatControl($this->user, 'chat_messages_this_stream', 'counter', '0');
+
+    postChatStats(['message_count' => 40])->assertJson(['applied' => false]);
+
+    expect($messages->fresh()->value)->toBe('0');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Applying a summary
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('message counts accumulate additively across summaries', function () {
+    goLive($this->user);
+    $messages = chatControl($this->user, 'chat_messages_this_stream', 'counter', '0');
+
+    postChatStats(['message_count' => 40])->assertJson(['applied' => true]);
+    postChatStats(['message_count' => 12]);
+
+    expect($messages->fresh()->value)->toBe('52');
+});
+
+test('unique chatters dedupe across summaries, not just within one', function () {
+    goLive($this->user);
+    $unique = chatControl($this->user, 'unique_chatters_this_stream', 'counter', '0');
+
+    postChatStats(['message_count' => 3, 'chatters' => ['alice', 'bob']]);
+    // bob already counted; only carol is new.
+    postChatStats(['message_count' => 2, 'chatters' => ['bob', 'carol']]);
+
+    expect($unique->fresh()->value)->toBe('3');
+});
+
+test('chatter logins are compared case-insensitively', function () {
+    goLive($this->user);
+    $unique = chatControl($this->user, 'unique_chatters_this_stream', 'counter', '0');
+
+    postChatStats(['message_count' => 2, 'chatters' => ['Alice', 'alice', 'ALICE']]);
+
+    expect($unique->fresh()->value)->toBe('1');
+});
+
+test('the latest chatter and message are recorded verbatim', function () {
+    goLive($this->user);
+    $name = chatControl($this->user, 'latest_chatter_name', 'text', '');
+    $message = chatControl($this->user, 'latest_chat_message', 'text', '');
+
+    postChatStats([
+        'message_count' => 1,
+        'latest_chatter_name' => 'Alice',
+        'latest_chat_message' => 'i <3 you',
+    ]);
+
+    expect($name->fresh()->value)->toBe('Alice')
+        // Not strip_tags()'d: that eats from `<` to end of string, which would
+        // truncate this to "i ". Render-side encoding is what makes it safe.
+        ->and($message->fresh()->value)->toBe('i <3 you');
+});
+
+test('a window that adds no new chatter writes nothing and broadcasts nothing', function () {
+    goLive($this->user);
+    $unique = chatControl($this->user, 'unique_chatters_this_stream', 'counter', '0');
+
+    postChatStats(['message_count' => 1, 'chatters' => ['alice']]);
+
+    Event::fake([ControlValueUpdated::class]);
+    $before = $unique->fresh()->updated_at;
+
+    postChatStats(['message_count' => 0, 'chatters' => ['alice']]);
+
+    Event::assertNotDispatched(ControlValueUpdated::class);
+    expect($unique->fresh()->updated_at->eq($before))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Reset lifecycle - the documented trap
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('both chat counters are on the per-stream reset list', function () {
+    expect(StreamSessionService::PER_STREAM_CONTROL_KEYS)
+        ->toContain('chat_messages_this_stream')
+        ->toContain('unique_chatters_this_stream');
+});
+
+test('neither latest_* chat control is on the per-stream reset list', function () {
+    // These are most-recent values, matching latest_cheer* and all 25
+    // equivalents across the five donation services, which persist across
+    // streams. Adding them here is the documented regression.
+    expect(StreamSessionService::PER_STREAM_CONTROL_KEYS)
+        ->not->toContain('latest_chatter_name')
+        ->not->toContain('latest_chat_message');
+});
+
+test('going live zeroes the chat counters but leaves the latest_* pair alone', function () {
+    goLive($this->user);
+    $messages = chatControl($this->user, 'chat_messages_this_stream', 'counter', '900');
+    $unique = chatControl($this->user, 'unique_chatters_this_stream', 'counter', '42');
+    $name = chatControl($this->user, 'latest_chatter_name', 'text', 'alice');
+    $message = chatControl($this->user, 'latest_chat_message', 'text', 'hello');
+
+    app(StreamSessionService::class)->openSession($this->user);
+
+    expect($messages->fresh()->value)->toBe('0')
+        ->and($unique->fresh()->value)->toBe('0')
+        ->and($name->fresh()->value)->toBe('alice')
+        ->and($message->fresh()->value)->toBe('hello');
+});
+
+test('the unique-chatter set is cleared at go-live, so the counter can fall', function () {
+    // The counter only ever moves upward within a stream, so clearing the
+    // control without clearing the backing set would pin it at last stream's
+    // total for the whole of the next one.
+    goLive($this->user);
+    $unique = chatControl($this->user, 'unique_chatters_this_stream', 'counter', '0');
+
+    postChatStats(['message_count' => 3, 'chatters' => ['alice', 'bob', 'carol']]);
+    expect($unique->fresh()->value)->toBe('3');
+
+    app(StreamSessionService::class)->openSession($this->user);
+    goLive($this->user);
+
+    postChatStats(['message_count' => 1, 'chatters' => ['dave']]);
+
+    expect($unique->fresh()->value)->toBe('1');
+});
+
+test('the unique counter never moves downward within a stream', function () {
+    // A cache flush mid-stream restarts the set from empty. The counter must
+    // hold its peak rather than visibly counting down on stream.
+    goLive($this->user);
+    $unique = chatControl($this->user, 'unique_chatters_this_stream', 'counter', '0');
+
+    postChatStats(['message_count' => 3, 'chatters' => ['alice', 'bob', 'carol']]);
+    expect($unique->fresh()->value)->toBe('3');
+
+    Cache::flush();
+
+    postChatStats(['message_count' => 1, 'chatters' => ['dave']]);
+
+    expect($unique->fresh()->value)->toBe('3');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Scoping
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('a summary does not touch another user\'s controls', function () {
+    goLive($this->user);
+    $other = User::factory()->create([
+        'bot_enabled' => true,
+        'twitch_data' => ['login' => 'someone_else'],
+    ]);
+    goLive($other);
+    $otherMessages = chatControl($other, 'chat_messages_this_stream', 'counter', '7');
+
+    postChatStats(['message_count' => 40]);
+
+    expect($otherMessages->fresh()->value)->toBe('7');
+});
+
+test('a summary broadcasts each changed control to the user channel', function () {
+    goLive($this->user);
+    chatControl($this->user, 'chat_messages_this_stream', 'counter', '0');
+    Event::fake([ControlValueUpdated::class]);
+
+    postChatStats(['message_count' => 40]);
+
+    Event::assertDispatched(ControlValueUpdated::class);
+});


### PR DESCRIPTION
Adds the four chat controls from the chat handoff, plus the internal endpoint the bot will POST them to. This is the Laravel half of the work; the bot half is still open (see below).

## The controls

`chat_messages_this_stream`, `unique_chatters_this_stream`, `latest_chatter_name`, `latest_chat_message`. All `source='twitch'`, `source_managed=true`, available anywhere a control tag is.

The two counters join `PER_STREAM_CONTROL_KEYS`; the `latest_*` pair deliberately stay off it, matching `latest_cheer*` and every equivalent across the five donation services. Tests assert both directions, since sweeping most-recent values into the reset is the bug that took four months to notice last time.

## Why the bot counts, not the overlay

The overlay reads chat directly from Twitch for display and never phones home, so the numbers come from the bot, which already watches chat for command handling.

The bot aggregates in memory and POSTs **one summary every 30-60s** rather than one request per message, so Laravel sees ~60-120 requests an hour per channel instead of thousands. The alternative - subscribing to `channel.chat.message` by webhook - would be one synchronous POST per message into a handler doing 6-10 DB writes, and a webhook that falls behind risks Twitch disabling that user's *other* subscriptions via `notification_failures_exceeded`.

`POST /internal/bot/chat-stats/{login}`, in the existing `bot.internal` + `throttle:bot-internal` group:

```json
{ "message_count": 42, "chatters": ["alice", "bob"],
  "latest_chatter_name": "Bob", "latest_chat_message": "hello" }
```

Returns `{ applied, unique_chatters }`. `applied:false` (not confidently live) is a **200**, so the bot does not retry a summary that was genuinely unwanted.

## Two things worth reviewing closely

**Uniqueness is resolved server-side.** The bot sends only the distinct logins from its own window; `mergeChatters()` folds them into a cached set (`chat:chatters:{user_id}`). The bot is a thin relay with no notion of where a stream starts, and would lose the set on every restart.

That has a consequence: `unique_chatters_this_stream` only ever moves **upward** within a stream, because a cache flush would otherwise restart the set from empty and walk the number backwards live on stream. Which in turn makes clearing the set at go-live load-bearing - without it the counter spends the next stream pinned at the previous one's total. Both halves were verified to fail when removed.

**`latest_chat_message` is stored raw**, like `latest_cheer_message`. `strip_tags()` looks like the careful choice right up until someone types `i <3 you` and the overlay renders `i `, because it eats everything from the `<` onward. Escaping stays at render time, where `defuseBrackets()` already covers the injection case.

## Native-only

`message_count` and `chatters` exclude Shared Chat foreign messages, so a collab cannot inflate the numbers. The feed showing more than the counter counts is intended. Enforcement is on the bot side, at aggregation time.

## Tests

18 new in `tests/Feature/BotChatStatsTest.php`. Full suite `1394 passed, 6 skipped`; `pint --test`, `typecheck`, `lint:check`, `format:check` and `npm test` (70) all green.

## Still to do (not in this PR)

The bot's `chatStats.js` already counts everything but currently only logs - it needs to POST the summary and exclude foreign messages. Also open from the handoff: the filtering settings page and badge artwork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
