### PR TITLE
feat(chat): let streamers decide what their chat overlay draws

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,15 @@ counts them ("five donation services", "five pipes") lives in `resources/views/w
 - `chat.N.html` is the ONLY foreach field rendered unescaped (`htmlSafeFields`, keyed by iterable). **Bracket defusing still applies inside it** - skipping that reopens the PR #230 injection hole through a side door.
 - Deletions are not optional: CLEARMSG removes one message, CLEARCHAT purges a user or clears the room. Purge by user id, falling back to login, and NEVER to "clear everything".
 
+### Chat display filters (Aug 2026)
+
+- Two per-user settings at `/settings/chat`: `hide_commands` (hide messages starting with `!`) and `hidden_logins`. Stored in the `preferences` jsonb column via `User::PREFERENCE_DEFAULTS['chat_filters']` - **no migration, no new table**. Both default to showing everything: deciding for the streamer which chatters are worth rendering was explicitly rejected.
+- **`chat_filters` is deliberately NOT in `User::$appends`**, unlike `locale` and `foreach_caps`. A list of logins the streamer has hidden is private, and appending it would leak it into every incidental User serialisation. Callers ask for it explicitly - the settings page and the render payload, nowhere else. Pinned by a test.
+- The filters MUST reach the client: the overlay reads chat directly from Twitch, so the server never sees a message and cannot filter one. That means the hidden list is visible to anyone holding the overlay token, which is already true of everything else in that payload.
+- **Filtering happens at INGEST** in `useTwitchChat.handleLine()`, not at render. A hidden message must not occupy one of the 50 window slots, or a chatter spamming commands pushes real messages off the overlay while showing nothing themselves.
+- `resources/js/utils/chatFilters.ts` is the pure part (`toChatFilters`, `shouldHideMessage`); it degrades to "show everything" on a malformed payload rather than throwing inside the socket handler. Filters apply to Shared Chat foreign messages too.
+- **This is NOT a moderation or safety feature and must never be described as one** - see the standing rule that Overlabels is not a safety tool. Deletions (CLEARMSG/CLEARCHAT) are a separate mechanism, are not optional, and are honoured regardless of these settings. The settings page says so in as many words.
+
 ### Chat controls (Aug 2026)
 
 - Four controls, all `source='twitch'`, `source_managed=true`: `chat_messages_this_stream`, `unique_chatters_this_stream`, `latest_chatter_name`, `latest_chat_message`. The first two ARE on `PER_STREAM_CONTROL_KEYS`; the `latest_*` pair deliberately is NOT (same rule as `latest_cheer*`).

--- a/app/Http/Controllers/OverlayTemplateController.php
+++ b/app/Http/Controllers/OverlayTemplateController.php
@@ -877,6 +877,13 @@ class OverlayTemplateController extends Controller
                 'random_controls' => $randomControls,
                 'stream_live' => StreamSessionService::isLive($user),
                 'locale' => $user->locale ?? 'en-US',
+                // Chat display filters. They have to reach the client because
+                // the overlay reads chat directly from Twitch - the server
+                // never sees a message, so it cannot filter one. Reaching the
+                // client means the hidden-logins list is visible to anyone
+                // holding this overlay's token, which is already true of
+                // everything else in this payload.
+                'chat_filters' => $user->chatFilters(),
             ]);
 
         } catch (Exception $e) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -130,9 +130,23 @@ class User extends Authenticatable
             'followers' => 5,
             'followed' => 5,
         ],
+        // Chat overlay display filters. Both default to showing everything:
+        // deciding for the streamer which of their chatters is worth rendering
+        // is not this app's call.
+        'chat_filters' => [
+            'hide_commands' => false,
+            'hidden_logins' => [],
+        ],
     ];
 
     public const int FOREACH_CAP_MAX = 50;
+
+    /**
+     * Ceiling on hidden chat logins. The list ships in every overlay render
+     * payload, so it is capped to keep that response small rather than because
+     * anyone plausibly needs more.
+     */
+    public const int MAX_HIDDEN_LOGINS = 200;
 
     /**
      * The attributes that should be hidden for serialization.
@@ -232,6 +246,36 @@ class User extends Authenticatable
         }
 
         return $merged;
+    }
+
+    /**
+     * Chat overlay display filters, merged with defaults and normalised.
+     *
+     * Deliberately NOT in $appends, unlike locale and foreach_caps. Those are
+     * harmless anywhere a User gets serialised; a list of logins the streamer
+     * has chosen to hide is not, and appending it would leak it into every
+     * incidental serialisation. Callers ask for it explicitly: the settings
+     * page and the overlay render payload, and nowhere else.
+     *
+     * @return array{hide_commands: bool, hidden_logins: list<string>}
+     */
+    public function chatFilters(): array
+    {
+        $defaults = self::PREFERENCE_DEFAULTS['chat_filters'];
+        $stored = (array) ($this->preference('chat_filters') ?? []);
+
+        $logins = collect($stored['hidden_logins'] ?? $defaults['hidden_logins'])
+            ->map(fn ($login) => strtolower(trim((string) $login)))
+            ->filter()
+            ->unique()
+            ->take(self::MAX_HIDDEN_LOGINS)
+            ->values()
+            ->all();
+
+        return [
+            'hide_commands' => (bool) ($stored['hide_commands'] ?? $defaults['hide_commands']),
+            'hidden_logins' => $logins,
+        ];
     }
 
     /**

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,19 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - feat(chat): decide what your chat overlay draws
+
+A new Chat page in settings, with two switches: hide messages starting with `!`, and a list of chatters whose messages your overlay skips.
+
+Both default to off, and that is the actual design decision. Deciding for you that bot commands are clutter, or that a particular chatter is not worth rendering, is not this app's call to make. So neither is a default; they are both a thing you turn on.
+
+- **This is not moderation, and the page says so out loud.** Hiding something here keeps it off your overlay. The message is still in chat, still in the VOD, and every viewer and moderator still sees it. Deletions are the separate mechanism that actually removes things, they are not optional, and your overlay honours them whatever these settings say.
+- **The filter runs at the door, not at the window.** A hidden message is dropped as it arrives rather than skipped when drawing. Otherwise a chatter spamming commands would quietly push fifty real messages off the overlay while showing nothing themselves.
+- **A hidden chatter is hidden wherever they type from**, including from another channel during a shared chat collab. Any other reading would be a surprise.
+- **The hidden list is not on the guest list for anything else.** It rides in the overlay payload because it has to - your overlay talks to Twitch directly, so the server never sees a message and cannot filter one for you. Everywhere else it is left out on purpose, including the ordinary serialisation that carries your locale and loop limits around the app. There is a test that fails if someone adds it.
+- **The textarea takes a mess.** Extra blank lines, stray commas, a leading `@`, the same name twice, mixed case: all fine. Throwing a validation error at someone pasting a list when the fix is obvious would just be rude.
+- No migration. It lives in the preferences column that already holds your locale and foreach caps.
+
 ## August 16th, 2026 - feat(chat): four chat controls, counted server-side
 
 Chat has been renderable in an overlay since this morning, but only as a feed. These are the numbers: `chat_messages_this_stream`, `unique_chatters_this_stream`, `latest_chatter_name` and `latest_chat_message`, usable anywhere a control tag is, including alerts and bot replies.

--- a/resources/js/components/OverlayRenderer.vue
+++ b/resources/js/components/OverlayRenderer.vue
@@ -41,6 +41,7 @@ import { useConditionalTemplates } from '@/composables/useConditionalTemplates';
 import { useOverlayHealth } from '@/composables/useOverlayHealth';
 import { useEmoteParser } from '@/composables/useEmoteParser';
 import { useTwitchChat } from '@/composables/useTwitchChat';
+import { toChatFilters } from '@/utils/chatFilters';
 import { withChatSlots } from '@/utils/chatSlots';
 import type { ChatMessage } from '@/utils/ircParser';
 import { useExpressionEngine } from '@/composables/useExpressionEngine';
@@ -673,6 +674,10 @@ onMounted(async () => {
     // should not hold a WebSocket open for hours in an OBS source.
     const chatChannel = String(json.data?.user_login ?? '');
     if (chatChannel && templateUsesChat.value) {
+      // Set before connecting, so the first messages through the socket are
+      // already filtered rather than flashing on screen and being excluded
+      // only from the second batch onward.
+      twitchChat.setFilters(toChatFilters(json.chat_filters));
       twitchChat.connect(chatChannel);
     }
 

--- a/resources/js/composables/useTwitchChat.ts
+++ b/resources/js/composables/useTwitchChat.ts
@@ -1,3 +1,4 @@
+import { type ChatFilters, EMPTY_CHAT_FILTERS, hasActiveFilters, shouldHideMessage } from '@/utils/chatFilters';
 import { type ChatMessage, type ModerationAction, parseIrcLine, toChatMessage, toModerationAction } from '@/utils/ircParser';
 import { ref } from 'vue';
 
@@ -49,6 +50,12 @@ export interface UseTwitchChatOptions {
 export function useTwitchChat(options: UseTwitchChatOptions = {}) {
   const windowSize = Math.max(1, options.windowSize ?? DEFAULT_WINDOW);
   const flushMs = Math.max(0, options.flushMs ?? DEFAULT_FLUSH_MS);
+
+  // Set once the render payload arrives. Until then nothing is filtered, which
+  // is the right way round: showing a message the streamer wanted hidden for
+  // the first instant is recoverable, and defaulting to hiding everything
+  // would render an empty overlay on any payload problem.
+  let filters: ChatFilters = EMPTY_CHAT_FILTERS;
 
   const messages = ref<ChatMessage[]>([]);
   const isConnected = ref(false);
@@ -131,6 +138,11 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
 
     const message = toChatMessage(line);
     if (message) {
+      // Filtered at INGEST, not at render. A hidden message must not occupy
+      // one of the 50 window slots, or a chatter spamming commands would push
+      // real messages off the overlay while showing nothing themselves.
+      if (hasActiveFilters(filters) && shouldHideMessage(message, filters)) return;
+
       queue.push({ kind: 'add', message });
       scheduleFlush();
       return;
@@ -218,5 +230,17 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
     isConnected.value = false;
   }
 
-  return { messages, isConnected, connect, disconnect };
+  /**
+   * Apply display filters. Safe to call before or after connect().
+   *
+   * Only affects messages arriving from now on - anything already in the
+   * window stays. Re-filtering the existing window would make a settings
+   * change retroactively blank out messages already on screen, which reads as
+   * a glitch rather than as the setting taking effect.
+   */
+  function setFilters(next: ChatFilters): void {
+    filters = next;
+  }
+
+  return { messages, isConnected, connect, disconnect, setFilters };
 }

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -16,6 +16,7 @@ const sidebarNavGroups: NavGroup[] = [
     label: null,
     items: [
       { title: 'Account', href: '/settings/account' },
+      { title: 'Chat', href: '/settings/chat' },
       { title: 'Integrations', href: '/settings/integrations' },
       { title: 'Usage', href: '/settings/usage' },
       { title: 'Controls', href: '/settings/controls' },

--- a/resources/js/pages/settings/Chat.vue
+++ b/resources/js/pages/settings/Chat.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Head, router } from '@inertiajs/vue3';
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import { Label } from '@/components/ui/label';
+import { type BreadcrumbItem } from '@/types';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/Layout.vue';
+
+interface ChatFilterProps {
+  hide_commands: boolean;
+  hidden_logins: string[];
+}
+
+const props = defineProps<{ chatFilters: ChatFilterProps }>();
+
+const MAX_HIDDEN_LOGINS = 200;
+
+const breadcrumbItems: BreadcrumbItem[] = [
+  { title: 'Dashboard', href: '/dashboard' },
+  { title: 'Chat settings', href: '/settings/chat' },
+];
+
+const hideCommands = ref(props.chatFilters.hide_commands);
+const hiddenLoginsText = ref(props.chatFilters.hidden_logins.join('\n'));
+
+const saving = ref(false);
+const confirmation = ref('');
+
+const loginCount = computed(
+  () =>
+    hiddenLoginsText.value
+      .split(/[\r\n,]+/)
+      .map((line) => line.trim())
+      .filter((line) => line !== '').length,
+);
+
+const overCap = computed(() => loginCount.value > MAX_HIDDEN_LOGINS);
+
+function save() {
+  saving.value = true;
+  confirmation.value = '';
+
+  router.patch(
+    route('settings.chat.update'),
+    {
+      hide_commands: hideCommands.value,
+      hidden_logins: hiddenLoginsText.value,
+    },
+    {
+      preserveScroll: true,
+      onSuccess: () => {
+        confirmation.value = 'Chat display settings updated. Reload your overlay in OBS to apply them.';
+        setTimeout(() => {
+          confirmation.value = '';
+        }, 6000);
+      },
+      onError: () => {
+        confirmation.value = 'Saving failed.';
+      },
+      onFinish: () => {
+        saving.value = false;
+      },
+    },
+  );
+}
+</script>
+
+<template>
+  <AppLayout :breadcrumbs="breadcrumbItems">
+    <Head title="Chat settings" />
+
+    <SettingsLayout>
+      <div class="space-y-6">
+        <HeadingSmall
+          title="Chat display"
+          description="What your chat overlay draws. These settings change your overlay only - chat itself is untouched."
+        />
+
+        <p class="text-sm text-foreground">
+          Your overlay reads chat straight from Twitch. Hiding something here keeps it off your overlay; the message is still in chat, still in the
+          VOD, and every viewer and moderator still sees it. To actually remove a message, use Twitch's own moderation - your overlay honours
+          deletions and timeouts automatically, and always will.
+        </p>
+
+        <div class="space-y-3">
+          <label class="flex cursor-pointer items-start gap-3">
+            <input v-model="hideCommands" type="checkbox" class="mt-1 size-4 cursor-pointer" />
+            <span class="text-sm">
+              <span class="font-medium">Hide messages starting with <code class="font-mono">!</code></span>
+              <span class="block text-muted-foreground">
+                Keeps bot commands off the overlay. Takes every message starting with an exclamation mark, so
+                <code class="font-mono">!!!</code> and <code class="font-mono">!what a play</code> go too.
+              </span>
+            </span>
+          </label>
+        </div>
+
+        <div class="space-y-3">
+          <Label for="hidden-logins">Hidden chatters</Label>
+          <p class="text-sm text-muted-foreground">
+            One Twitch username per line. Their messages are not drawn on your overlay, including during a shared chat collab. Up to
+            {{ MAX_HIDDEN_LOGINS }}.
+          </p>
+          <textarea
+            id="hidden-logins"
+            v-model="hiddenLoginsText"
+            rows="8"
+            class="input-border w-full font-mono text-sm"
+            placeholder="somebot&#10;anotherbot"
+          ></textarea>
+          <p v-if="overCap" class="text-sm text-destructive">{{ loginCount }} names listed. Only the first {{ MAX_HIDDEN_LOGINS }} will be saved.</p>
+          <p v-else-if="loginCount > 0" class="text-sm text-muted-foreground">{{ loginCount }} {{ loginCount === 1 ? 'name' : 'names' }} listed.</p>
+        </div>
+
+        <!-- Stacked, not side by side: the confirmation is long enough that as a
+             flex sibling it squeezed the button and wrapped its label onto two lines. -->
+        <div class="flex flex-col items-start gap-3">
+          <button
+            type="button"
+            :disabled="saving"
+            class="btn btn-primary cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+            @click="save"
+          >
+            {{ saving ? 'Saving...' : 'Save chat settings' }}
+          </button>
+          <p v-if="confirmation" class="text-sm text-muted-foreground">{{ confirmation }}</p>
+        </div>
+      </div>
+    </SettingsLayout>
+  </AppLayout>
+</template>

--- a/resources/js/utils/chatFilters.test.ts
+++ b/resources/js/utils/chatFilters.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { EMPTY_CHAT_FILTERS, hasActiveFilters, shouldHideMessage, toChatFilters } from './chatFilters';
+import type { ChatMessage } from './ircParser';
+
+function msg(over: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'm1',
+    userId: '1',
+    login: 'ana',
+    author: 'Ana',
+    text: 'hello',
+    color: '#ff0000',
+    badges: 'subscriber',
+    at: 1755273600,
+    isMod: false,
+    isSubscriber: true,
+    isVip: false,
+    isBroadcaster: false,
+    isFirstMessage: false,
+    sourceRoomId: '',
+    emotes: [],
+    ...over,
+  };
+}
+
+describe('toChatFilters', () => {
+  it('reads the payload shape the server sends', () => {
+    expect(toChatFilters({ hide_commands: true, hidden_logins: ['bot'] })).toEqual({
+      hideCommands: true,
+      hiddenLogins: ['bot'],
+    });
+  });
+
+  it('falls back to showing everything when the payload is missing or malformed', () => {
+    // Arrives over the wire from a possibly-older app, so it must degrade to
+    // "show everything" rather than throw inside the socket handler.
+    expect(toChatFilters(undefined)).toEqual(EMPTY_CHAT_FILTERS);
+    expect(toChatFilters(null)).toEqual(EMPTY_CHAT_FILTERS);
+    expect(toChatFilters('nonsense')).toEqual(EMPTY_CHAT_FILTERS);
+    expect(toChatFilters({})).toEqual(EMPTY_CHAT_FILTERS);
+  });
+
+  it('treats anything other than true as false', () => {
+    expect(toChatFilters({ hide_commands: 'yes' }).hideCommands).toBe(false);
+    expect(toChatFilters({ hide_commands: 1 }).hideCommands).toBe(false);
+  });
+
+  it('normalises logins and drops non-strings', () => {
+    const filters = toChatFilters({ hidden_logins: ['  BoT  ', 42, null, '', 'other'] });
+
+    expect(filters.hiddenLogins).toEqual(['bot', 'other']);
+  });
+
+  it('survives hidden_logins arriving as something other than an array', () => {
+    expect(toChatFilters({ hidden_logins: 'bot' }).hiddenLogins).toEqual([]);
+  });
+});
+
+describe('hasActiveFilters', () => {
+  it('is false for the default set', () => {
+    expect(hasActiveFilters(EMPTY_CHAT_FILTERS)).toBe(false);
+  });
+
+  it('is true when either filter is doing something', () => {
+    expect(hasActiveFilters({ hideCommands: true, hiddenLogins: [] })).toBe(true);
+    expect(hasActiveFilters({ hideCommands: false, hiddenLogins: ['bot'] })).toBe(true);
+  });
+});
+
+describe('shouldHideMessage', () => {
+  it('hides nothing by default', () => {
+    expect(shouldHideMessage(msg({ text: '!ping' }), EMPTY_CHAT_FILTERS)).toBe(false);
+  });
+
+  describe('hideCommands', () => {
+    const filters = { hideCommands: true, hiddenLogins: [] };
+
+    it('hides a message starting with !', () => {
+      expect(shouldHideMessage(msg({ text: '!ping' }), filters)).toBe(true);
+    });
+
+    it('ignores leading whitespace so a stray space does not defeat it', () => {
+      expect(shouldHideMessage(msg({ text: '   !ping' }), filters)).toBe(true);
+    });
+
+    it('keeps a message with ! anywhere but the start', () => {
+      expect(shouldHideMessage(msg({ text: 'what a play!' }), filters)).toBe(false);
+      expect(shouldHideMessage(msg({ text: 'nice !ping there' }), filters)).toBe(false);
+    });
+
+    it('hides !!! too, which the setting copy warns about', () => {
+      // Not a command, but "starts with !" is what the toggle promises and a
+      // cleverer rule would make the label a lie.
+      expect(shouldHideMessage(msg({ text: '!!!' }), filters)).toBe(true);
+    });
+
+    it('keeps an empty message', () => {
+      expect(shouldHideMessage(msg({ text: '' }), filters)).toBe(false);
+    });
+  });
+
+  describe('hiddenLogins', () => {
+    const filters = { hideCommands: false, hiddenLogins: ['spambot'] };
+
+    it('hides a listed login', () => {
+      expect(shouldHideMessage(msg({ login: 'spambot' }), filters)).toBe(true);
+    });
+
+    it('matches regardless of case', () => {
+      expect(shouldHideMessage(msg({ login: 'SpamBot' }), filters)).toBe(true);
+    });
+
+    it('leaves everyone else alone', () => {
+      expect(shouldHideMessage(msg({ login: 'ana' }), filters)).toBe(false);
+    });
+
+    it('does not hide a message with no login', () => {
+      expect(shouldHideMessage(msg({ login: '' }), filters)).toBe(false);
+    });
+
+    it('does not match on a partial login', () => {
+      expect(shouldHideMessage(msg({ login: 'spambot2' }), filters)).toBe(false);
+      expect(shouldHideMessage(msg({ login: 'spam' }), filters)).toBe(false);
+    });
+
+    it('hides a listed login typing from another channel during shared chat', () => {
+      // A hidden user is hidden wherever they type from - the only reading
+      // that is not surprising.
+      expect(shouldHideMessage(msg({ login: 'spambot', sourceRoomId: '999' }), filters)).toBe(true);
+    });
+  });
+
+  it('hides when either rule matches', () => {
+    const filters = { hideCommands: true, hiddenLogins: ['spambot'] };
+
+    expect(shouldHideMessage(msg({ login: 'ana', text: '!ping' }), filters)).toBe(true);
+    expect(shouldHideMessage(msg({ login: 'spambot', text: 'hello' }), filters)).toBe(true);
+    expect(shouldHideMessage(msg({ login: 'ana', text: 'hello' }), filters)).toBe(false);
+  });
+});

--- a/resources/js/utils/chatFilters.ts
+++ b/resources/js/utils/chatFilters.ts
@@ -1,0 +1,87 @@
+import type { ChatMessage } from '@/utils/ircParser';
+
+/**
+ * Display filters for the chat overlay.
+ *
+ * These decide what the overlay DRAWS and nothing else. The overlay reads chat
+ * straight from Twitch over an anonymous connection, so there is nothing here
+ * that touches Twitch, the chatter, or anyone else's view of the channel. A
+ * hidden message is hidden on this overlay; it is still in chat, still in the
+ * VOD, and still visible to every viewer and moderator.
+ *
+ * Moderation is a separate mechanism and is not optional: CLEARMSG and
+ * CLEARCHAT are honoured in `useTwitchChat` regardless of anything here.
+ */
+export interface ChatFilters {
+  /** Hide messages that start with `!`. */
+  hideCommands: boolean;
+  /** Lowercased logins whose messages are not drawn. */
+  hiddenLogins: string[];
+}
+
+export const EMPTY_CHAT_FILTERS: ChatFilters = {
+  hideCommands: false,
+  hiddenLogins: [],
+};
+
+/**
+ * Normalise whatever the render payload supplied into a usable filter set.
+ *
+ * Defensive because this arrives over the wire: a stale overlay, a partial
+ * payload or an older app version must degrade to "show everything" rather
+ * than throw inside the socket handler and take the feed down with it.
+ */
+export function toChatFilters(raw: unknown): ChatFilters {
+  if (!raw || typeof raw !== 'object') return EMPTY_CHAT_FILTERS;
+
+  const source = raw as { hide_commands?: unknown; hidden_logins?: unknown };
+
+  const hiddenLogins = Array.isArray(source.hidden_logins)
+    ? source.hidden_logins
+        .filter((login): login is string => typeof login === 'string')
+        .map((login) => login.trim().toLowerCase())
+        .filter((login) => login !== '')
+    : [];
+
+  return {
+    hideCommands: source.hide_commands === true,
+    hiddenLogins,
+  };
+}
+
+/** Is this filter set doing anything at all? Lets callers skip the work. */
+export function hasActiveFilters(filters: ChatFilters): boolean {
+  return filters.hideCommands || filters.hiddenLogins.length > 0;
+}
+
+/**
+ * Should this message be kept out of the overlay?
+ *
+ * Applies to Shared Chat messages exactly as it does to native ones. A login
+ * the streamer has hidden is hidden wherever they typed it from, which is the
+ * only reading that is not surprising.
+ */
+export function shouldHideMessage(message: ChatMessage, filters: ChatFilters): boolean {
+  if (filters.hideCommands && isCommand(message.text)) return true;
+
+  if (filters.hiddenLogins.length > 0) {
+    const login = (message.login ?? '').toLowerCase();
+    if (login !== '' && filters.hiddenLogins.includes(login)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * A message "starting with !", taken literally, which is what the setting
+ * promises.
+ *
+ * Leading whitespace is ignored so a stray space does not defeat it. This does
+ * catch a chatter typing "!!!" or "!what a play" - they are not commands, but
+ * narrowing it to `!` followed by a word character would still catch the
+ * second one, and inventing a cleverer rule would make the toggle's label a
+ * lie. Anyone who wants those shown leaves the toggle off.
+ */
+function isCommand(text: string): boolean {
+  return text.trimStart().startsWith('!');
+}

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -35,6 +35,40 @@ Route::middleware('auth.redirect')->group(function () {
     Route::get('/settings/controls', [ControlUsageController::class, 'index'])
         ->name('settings.controls');
 
+    Route::get('/settings/chat', function (Request $request) {
+        return inertia('settings/Chat', [
+            'chatFilters' => $request->user()->chatFilters(),
+        ]);
+    })->name('settings.chat');
+
+    // Display filters for the chat overlay. These only decide what the overlay
+    // draws - the overlay reads chat straight from Twitch, so nothing here
+    // touches Twitch, the chatter, or anyone else's view of the channel.
+    Route::patch('/settings/chat', function (Request $request) {
+        $validated = $request->validate([
+            'hide_commands' => 'required|boolean',
+            'hidden_logins' => 'nullable|string|max:10000',
+        ]);
+
+        // Accepted as free text (one login per line) rather than a structured
+        // list, because the UI is a textarea and a streamer pasting a messy
+        // list should not get a validation error thrown back at them.
+        $logins = collect(preg_split('/[\r\n,]+/', $validated['hidden_logins'] ?? ''))
+            ->map(fn (string $login) => strtolower(trim(ltrim($login, '@'))))
+            ->filter(fn (string $login) => $login !== '' && preg_match('/^[a-z0-9_]{1,25}$/', $login) === 1)
+            ->unique()
+            ->take(User::MAX_HIDDEN_LOGINS)
+            ->values()
+            ->all();
+
+        $user = $request->user();
+        $user->setPreference('chat_filters.hide_commands', $validated['hide_commands']);
+        $user->setPreference('chat_filters.hidden_logins', $logins);
+        $user->save();
+
+        return back();
+    })->name('settings.chat.update');
+
     Route::patch('/settings/locale', function (Request $request) {
         $request->validate(['locale' => 'required|string|max:10']);
         $request->user()->setPreference('locale', $request->input('locale'))->save();

--- a/tests/Feature/ChatFilterSettingsTest.php
+++ b/tests/Feature/ChatFilterSettingsTest.php
@@ -1,0 +1,214 @@
+<?php
+
+use App\Models\OverlayAccessToken;
+use App\Models\OverlayTemplate;
+use App\Models\User;
+use App\Services\TwitchApiService;
+use App\Services\TwitchTokenService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create([
+        'twitch_id' => (string) fake()->unique()->randomNumber(9),
+        'access_token' => 'fake-twitch-token',
+    ]);
+
+    $this->mock(TwitchTokenService::class, function ($mock) {
+        $mock->shouldReceive('ensureValidToken')->andReturnTrue();
+    });
+    $this->mock(TwitchApiService::class, function ($mock) {
+        $mock->shouldReceive('getExtendedUserData')->andReturn([]);
+        $mock->shouldReceive('enrichEventWithUserAvatars')->andReturnUsing(fn ($t, $e) => $e);
+    });
+});
+
+function saveChatFilters(User $user, array $payload): TestResponse
+{
+    return test()->actingAs($user)->patch('/settings/chat', $payload);
+}
+
+/**
+ * Render a static overlay for this user and return the payload response. The
+ * filters have to reach the client because the overlay reads chat directly
+ * from Twitch - the server never sees a message, so it cannot filter one.
+ */
+function renderChatOverlay(User $user): TestResponse
+{
+    $plain = bin2hex(random_bytes(32));
+    OverlayAccessToken::create([
+        'user_id' => $user->id,
+        'token_hash' => hash('sha256', $plain),
+        'token_prefix' => substr($plain, 0, 8),
+        'name' => 'chat-filter-test',
+        'is_active' => true,
+    ]);
+
+    $template = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id,
+        'fork_of_id' => null,
+        'type' => 'static',
+        'html' => '<div>[[[foreach:chat as msg]]][[[msg.text]]][[[endforeach]]]</div>',
+        'slug' => 'chat-'.fake()->unique()->lexify('????????'),
+        'metadata' => null,
+    ]);
+
+    return test()->postJson('/api/overlay/render', ['slug' => $template->slug, 'token' => $plain]);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Access
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('requires authentication', function () {
+    $this->get('/settings/chat')->assertRedirect();
+    $this->patch('/settings/chat', ['hide_commands' => true])->assertRedirect();
+});
+
+it('renders the settings page with the current filters', function () {
+    $this->user->setPreference('chat_filters.hide_commands', true);
+    $this->user->setPreference('chat_filters.hidden_logins', ['spambot']);
+    $this->user->save();
+
+    $this->actingAs($this->user)
+        ->get('/settings/chat')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('settings/Chat')
+            ->where('chatFilters.hide_commands', true)
+            ->where('chatFilters.hidden_logins', ['spambot'])
+        );
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Defaults
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('shows everything by default', function () {
+    // Deciding for the streamer which of their chatters is worth rendering is
+    // not this app's call - both filters start off.
+    expect($this->user->chatFilters())->toBe([
+        'hide_commands' => false,
+        'hidden_logins' => [],
+    ]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Saving
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('saves the command toggle', function () {
+    saveChatFilters($this->user, ['hide_commands' => true, 'hidden_logins' => ''])
+        ->assertRedirect();
+
+    expect($this->user->fresh()->chatFilters()['hide_commands'])->toBeTrue();
+});
+
+it('parses one login per line', function () {
+    saveChatFilters($this->user, [
+        'hide_commands' => false,
+        'hidden_logins' => "spambot\nanotherbot",
+    ]);
+
+    expect($this->user->fresh()->chatFilters()['hidden_logins'])->toBe(['spambot', 'anotherbot']);
+});
+
+it('accepts a messy pasted list without erroring', function () {
+    // A textarea invites mess. Rejecting it with a validation error would be
+    // hostile when the fix is obvious.
+    saveChatFilters($this->user, [
+        'hide_commands' => false,
+        'hidden_logins' => "  SpamBot  \n\n@AnotherBot\r\nspambot\n,,\n",
+    ]);
+
+    expect($this->user->fresh()->chatFilters()['hidden_logins'])
+        ->toBe(['spambot', 'anotherbot']);
+});
+
+it('drops entries that cannot be a Twitch login', function () {
+    saveChatFilters($this->user, [
+        'hide_commands' => false,
+        'hidden_logins' => "good_name\nhas spaces\nway_too_long_to_be_a_twitch_login_at_all\nbad!char\nok2",
+    ]);
+
+    expect($this->user->fresh()->chatFilters()['hidden_logins'])->toBe(['good_name', 'ok2']);
+});
+
+it('caps the list', function () {
+    $logins = collect(range(1, User::MAX_HIDDEN_LOGINS + 50))
+        ->map(fn (int $n) => "user$n")
+        ->implode("\n");
+
+    saveChatFilters($this->user, ['hide_commands' => false, 'hidden_logins' => $logins]);
+
+    expect($this->user->fresh()->chatFilters()['hidden_logins'])
+        ->toHaveCount(User::MAX_HIDDEN_LOGINS);
+});
+
+it('clears the list when the textarea is emptied', function () {
+    $this->user->setPreference('chat_filters.hidden_logins', ['spambot']);
+    $this->user->save();
+
+    saveChatFilters($this->user, ['hide_commands' => false, 'hidden_logins' => '']);
+
+    expect($this->user->fresh()->chatFilters()['hidden_logins'])->toBe([]);
+});
+
+it('rejects a missing toggle', function () {
+    saveChatFilters($this->user, ['hidden_logins' => 'spambot'])
+        ->assertSessionHasErrors('hide_commands');
+});
+
+it('leaves other preferences alone', function () {
+    // chat_filters is one key in a shared jsonb column. Writing it must not
+    // stomp the neighbours.
+    $this->user->setPreference('locale', 'nl-NL');
+    $this->user->save();
+
+    saveChatFilters($this->user, ['hide_commands' => true, 'hidden_logins' => 'spambot']);
+
+    expect($this->user->fresh()->locale)->toBe('nl-NL');
+});
+
+it('does not leak the hidden list through incidental serialisation', function () {
+    // Deliberately NOT in $appends, unlike locale and foreach_caps. A list of
+    // logins the streamer has hidden is theirs, and appending it would put it
+    // into every serialisation of a User anywhere in the app.
+    $this->user->setPreference('chat_filters.hidden_logins', ['spambot']);
+    $this->user->save();
+
+    expect($this->user->fresh()->toArray())->not->toHaveKey('chat_filters');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Reaching the overlay
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('ships the filters in the overlay render payload', function () {
+    saveChatFilters($this->user, ['hide_commands' => true, 'hidden_logins' => "spambot\nanotherbot"]);
+
+    renderChatOverlay($this->user->fresh())
+        ->assertOk()
+        ->assertJsonPath('chat_filters.hide_commands', true)
+        ->assertJsonPath('chat_filters.hidden_logins', ['spambot', 'anotherbot']);
+});
+
+it('ships the permissive defaults when nothing was ever saved', function () {
+    renderChatOverlay($this->user)
+        ->assertOk()
+        ->assertJsonPath('chat_filters.hide_commands', false)
+        ->assertJsonPath('chat_filters.hidden_logins', []);
+});
+
+it('scopes filters to the user who saved them', function () {
+    $other = User::factory()->create();
+
+    saveChatFilters($this->user, ['hide_commands' => true, 'hidden_logins' => 'spambot']);
+
+    expect($other->fresh()->chatFilters())->toBe([
+        'hide_commands' => false,
+        'hidden_logins' => [],
+    ]);
+});


### PR DESCRIPTION
Section 5.2 of the chat handoff. Adds a Chat page under settings with two display filters: hide messages starting with `!`, and a list of chatters whose messages the overlay skips.

**Both default to off**, and that is the design decision rather than an oversight. Deciding for the streamer that bot commands are clutter, or that a given chatter is not worth rendering, is not this app's call. They are switches, not defaults.

**No migration.** It lives in the `preferences` jsonb column that already holds locale and foreach caps, via `User::PREFERENCE_DEFAULTS['chat_filters']`.

## This is not moderation, and the page says so

Hiding something here keeps it off the overlay. The message is still in chat, still in the VOD, and every viewer and moderator still sees it. `CLEARMSG`/`CLEARCHAT` are the separate mechanism that actually removes things, they are not optional, and the overlay honours them regardless of anything set here. The page states that in as many words, per the standing rule that Overlabels is not a safety tool.

## Three things worth reviewing

**`chat_filters` is deliberately NOT in `User::$appends`.** `locale` and `foreach_caps` are harmless anywhere a User gets serialised; a list of logins someone has chosen to hide is not, and appending it would put it into every incidental serialisation in the app. Callers ask for it explicitly - the settings page and the render payload, nowhere else. There is a test that fails if someone adds it.

**Filtering happens at INGEST**, in `useTwitchChat.handleLine()`, not at render. A hidden message must never occupy one of the 50 window slots - otherwise a chatter spamming commands quietly pushes fifty real messages off the overlay while showing nothing themselves.

**The hidden list is visible to anyone holding the overlay token.** Unavoidable: the overlay reads chat directly from Twitch, so the server never sees a message and cannot filter one - the list has to reach the client. Same exposure as everything else already in that payload, but it is new information about the streamer, so it is called out rather than buried.

## Details

- `resources/js/utils/chatFilters.ts` is the pure half. It degrades to "show everything" on a malformed or missing payload rather than throwing inside the socket handler and taking the feed down.
- Filters apply to Shared Chat foreign messages too. A hidden chatter is hidden wherever they type from, which is the only non-surprising reading.
- The textarea accepts a mess - blank lines, stray commas, a leading `@`, repeats, mixed case. Rejecting a pasted list with a validation error when the fix is obvious would be hostile. Invalid entries are dropped, and the list is capped at 200.

## Tests

20 frontend on the pure filter, 15 backend covering the settings route and the render payload. Full suites: **1409 backend**, **90 frontend**, plus `pint --test`, `typecheck`, `lint:check`, `format:check`.

The two subtle ones were verified to fail when broken: adding `chat_filters` to `$appends` (with its accessor, so it fails cleanly rather than throwing) trips the leak test, and dropping `chat_filters` from the render payload trips the payload test.

Also checked `config/ziggy.php` - no negation touches `settings.chat.*`, so `route('settings.chat.update')` resolves. That is the trap green PHP tests cannot catch.

## Not covered

Nobody has looked at the page in a browser. Everything is static-checked and the markup follows `Account.vue` closely, but layout and dark mode are things only eyes catch. Worth a glance before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
