### PR TITLE
feat(chat): render Twitch badge artwork in the chat overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,16 @@ counts them ("five donation services", "five pipes") lives in `resources/views/w
 - `chat.N.html` is the ONLY foreach field rendered unescaped (`htmlSafeFields`, keyed by iterable). **Bracket defusing still applies inside it** - skipping that reopens the PR #230 injection hole through a side door.
 - Deletions are not optional: CLEARMSG removes one message, CLEARCHAT purges a user or clears the room. Purge by user id, falling back to login, and NEVER to "clear everything".
 
+### Chat badge artwork (Aug 2026)
+
+- `[[[msg.badge_images]]]` renders Twitch badge `<img>` tags. `[[[msg.badges]]]` still emits bare set names for CSS classes and MUST NOT change - templates in the wild use it.
+- `GET /api/overlay/badges/{channelId}` mirrors the emote endpoint exactly: app token server-side, 24 h cache, `throttle:60,1`, no auth (badge art is public). Returns `{ global: {...}, channel: {...} }`, each keyed `set/version` to match the IRC tag (`moderator/1,subscriber/12`).
+- **`global` and `channel` are returned separately on purpose, do not merge them.** A Shared Chat message carries a collab partner's badge VERSIONS, but their channel-specific art (subscriber, bits, founder) lives in a manifest we never fetched. Resolving those against our channel map renders OUR subscriber emblem for someone who subscribes elsewhere - it states something false about a viewer, which is worse than rendering nothing. `badgeImages()` picks `global` whenever `sourceRoomId` is set. `channel` already has global folded in, so a native message needs one lookup.
+- Uses `image_url_2x` (36px). Twitch's own chat renders badges at 18px, so 2x survives OBS scaling without paying 4x the bytes.
+- `ircParser.ts` has BOTH `badgeNames()` (names, for `msg.badges`) and `badgeVersions()` (`['moderator/1']`, for art). They answer different questions - do not collapse them.
+- **`badge_images` is the SECOND entry in `HTML_SAFE_FOREACH_FIELDS`**, so it renders unescaped. It is safe only because `badgeRenderer.ts` echoes nothing from chat: `src` comes from the server-fetched manifest and is pinned to `static-cdn.jtvnw.net`, alt/title are escaped anyway, and an unknown badge key produces NO element rather than being interpolated. All three are test-pinned and were verified to fail when removed.
+- The manifest fetch is gated on `templateUsesBadgeArt` - most chat templates only want the CSS class names, and must not pay for art they never draw.
+
 ### Chat display filters (Aug 2026)
 
 - Two per-user settings at `/settings/chat`: `hide_commands` (hide messages starting with `!`) and `hidden_logins`. Stored in the `preferences` jsonb column via `User::PREFERENCE_DEFAULTS['chat_filters']` - **no migration, no new table**. Both default to showing everything: deciding for the streamer which chatters are worth rendering was explicitly rejected.

--- a/app/Services/TwitchApiService.php
+++ b/app/Services/TwitchApiService.php
@@ -751,4 +751,80 @@ class TwitchApiService
 
         return $emotes;
     }
+
+    /**
+     * Chat badge art, keyed the way the IRC `badges` tag addresses it.
+     *
+     * The tag looks like `moderator/1,subscriber/12`, so the map is keyed
+     * "set/version" and the overlay can look a badge up without knowing
+     * anything about Twitch's response shape.
+     *
+     * Two separate keys are returned rather than one merged map, because a
+     * Shared Chat message from a collab partner carries THEIR badge versions,
+     * and their channel-specific art (subscriber, bits, founder) lives in a
+     * manifest we have not fetched. Resolving those against this channel's map
+     * would render the wrong emblem - showing a partner's subscriber as one of
+     * ours. `global` is safe for anyone in any channel; `channel` is only
+     * correct for native messages.
+     *
+     * Channel entries override global for the same set/version: subscriber and
+     * bits badges exist in both, and the channel's own art is the correct one.
+     *
+     * @return array{global: array<string, array{url: string, title: string}>, channel: array<string, array{url: string, title: string}>}
+     */
+    public function getChannelBadges(string $appToken, string $broadcasterId): array
+    {
+        $global = $this->badgeMapFrom(
+            $this->makeApiRequest($appToken, 'chat/badges/global', [], 'get global Twitch badges')
+        );
+
+        $channel = $this->badgeMapFrom(
+            $this->makeApiRequest($appToken, 'chat/badges', ['broadcaster_id' => $broadcasterId], 'get channel Twitch badges')
+        );
+
+        return [
+            'global' => $global,
+            // Merged so a native message needs one lookup, and so a channel
+            // that overrides only some versions still resolves the rest.
+            'channel' => array_merge($global, $channel),
+        ];
+    }
+
+    /**
+     * Flatten Twitch's set/versions response into a "set/version" => art map.
+     *
+     * Uses image_url_2x (36px). Twitch's own web chat renders badges at 18px,
+     * so 2x stays crisp on a 1080p or 1440p overlay and when OBS scales the
+     * source, without paying 4x the bytes for something drawn ~18px tall.
+     *
+     * @return array<string, array{url: string, title: string}>
+     */
+    private function badgeMapFrom(?array $response): array
+    {
+        $map = [];
+
+        foreach ($response['data'] ?? [] as $set) {
+            $setId = $set['set_id'] ?? null;
+            if (! $setId) {
+                continue;
+            }
+
+            foreach ($set['versions'] ?? [] as $version) {
+                $versionId = $version['id'] ?? null;
+                $url = $version['image_url_2x'] ?? $version['image_url_1x'] ?? null;
+                if (! $versionId || ! $url) {
+                    continue;
+                }
+
+                $map["$setId/$versionId"] = [
+                    'url' => $url,
+                    // Twitch's own accessible label, e.g. "Moderator" or
+                    // "Subscriber (12 months)". Used as the img alt text.
+                    'title' => (string) ($version['title'] ?? $setId),
+                ];
+            }
+        }
+
+        return $map;
+    }
 }

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,24 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - feat(chat): badges, as actual badges
+
+```
+[[[foreach:chat as msg]]]
+  <span class="badges">[[[msg.badge_images]]]</span>
+  <b>[[[msg.author]]]</b>: [[[msg.html]]]
+[[[endforeach]]]
+```
+
+Chat badges have been available as names since the feed shipped this morning - `broadcaster subscriber`, which is what CSS wants and is genuinely useful. Now the artwork is available too, the same emblems Twitch's own chat draws.
+
+- **The names did not change.** `[[[msg.badges]]]` still gives you `broadcaster subscriber` for styling. The art is a second, separate tag, because a template that wants a coloured border per badge should not be forced to load images to get it.
+- **The version matters, and it was being thrown away.** A 3-month and a 12-month subscriber badge are different pictures from the same set, so the parser now keeps `subscriber/12` alongside the bare name rather than discarding the number.
+- **A collab partner's subscriber badge is not our subscriber badge.** During a shared chat session, a message duplicated in from another channel carries that channel's badge versions, and the art for their channel-specific badges lives somewhere we never fetched. Rendering our own emblem for it would be worse than rendering nothing: it would state something false about a viewer. So foreign messages get the badges that are true everywhere on Twitch - moderator, VIP, staff, broadcaster - and their channel-specific ones simply do not draw.
+- **The art comes from our server, never from chat.** This is the second field ever allowed to render as unescaped HTML, next to the emote-parsed message body, so it earns that the hard way: every image URL comes from the manifest our own server fetched from Twitch and is pinned to Twitch's CDN, the alt text is escaped anyway, and a badge name we do not recognise produces no element at all rather than being pasted into the output. Three tests cover those, and each was checked to fail with the guard removed.
+- **Only templates that draw badges pay for them.** Most chat templates want the class names and nothing else; those never fetch the manifest. Same discipline as the emote library earlier today.
+- 36px art. Twitch draws badges at 18px, so it stays crisp when OBS scales your source without costing four times the bytes for something the size of a full stop.
+
 ## August 16th, 2026 - feat(chat): decide what your chat overlay draws
 
 A new Chat page in settings, with two switches: hide messages starting with `!`, and a list of chatters whose messages your overlay skips.

--- a/resources/js/components/OverlayRenderer.vue
+++ b/resources/js/components/OverlayRenderer.vue
@@ -41,6 +41,7 @@ import { useConditionalTemplates } from '@/composables/useConditionalTemplates';
 import { useOverlayHealth } from '@/composables/useOverlayHealth';
 import { useEmoteParser } from '@/composables/useEmoteParser';
 import { useTwitchChat } from '@/composables/useTwitchChat';
+import { type BadgeManifest, EMPTY_BADGE_MANIFEST, badgeImages, toBadgeManifest } from '@/utils/badgeRenderer';
 import { toChatFilters } from '@/utils/chatFilters';
 import { withChatSlots } from '@/utils/chatSlots';
 import type { ChatMessage } from '@/utils/ircParser';
@@ -130,6 +131,21 @@ const templateUsesChat = computed(() => {
 });
 
 /**
+ * Does this template render badge ARTWORK?
+ *
+ * Separate from templateUsesChat because most chat templates want
+ * `[[[msg.badges]]]` for CSS classes and nothing more. Those must not pay for
+ * a badge manifest they never draw - the same discipline as the emote library.
+ *
+ * Matches the field name rather than the loop alias, since the alias is
+ * whatever the author called it (`msg`, `m`, `line`).
+ */
+const templateUsesBadgeArt = computed(() => {
+  const source = `${rawHtml.value ?? ''}\n${css.value ?? ''}`;
+  return /\[\[\[[\w]+\.badge_images\b/.test(source);
+});
+
+/**
  * Render one chat message to safe HTML for the `chat.N.html` slot.
  *
  * Reuses the alert emote pipeline rather than growing a second one, so Twitch,
@@ -194,6 +210,33 @@ function chatMessageHtml(m: ChatMessage): string {
 }
 
 /**
+ * Badge artwork, fetched once per overlay from our own server.
+ *
+ * Credentials stay server-side and the response is cached 24 h there, so this
+ * is one small request per overlay load. Only fired when the template actually
+ * renders badge images.
+ */
+const badgeManifest = ref<BadgeManifest>(EMPTY_BADGE_MANIFEST);
+
+async function loadBadgeManifest(channelId: string): Promise<void> {
+  try {
+    const response = await fetch(`/api/overlay/badges/${channelId}`);
+    if (!response.ok) return;
+    badgeManifest.value = toBadgeManifest(await response.json());
+  } catch {
+    // No badge art is a fine outcome. The names are still in `msg.badges`,
+    // and an overlay that throws here would lose the whole chat feed over
+    // decoration.
+    console.warn('[OverlayRenderer] Badge manifest failed to load');
+  }
+}
+
+/** Render one message's badges for the `chat.N.badge_images` slot. */
+function chatBadgeHtml(m: ChatMessage): string {
+  return badgeImages(m, badgeManifest.value);
+}
+
+/**
  * Project the chat window into `chat.*` data slots whenever it changes.
  *
  * The composable already buffers, so this fires at most a few times a second
@@ -203,10 +246,21 @@ function chatMessageHtml(m: ChatMessage): string {
  */
 function refreshChatSlots(list: readonly ChatMessage[]): void {
   if (!data.value || typeof data.value !== 'object') return;
-  data.value = withChatSlots(data.value, list, chatMessageHtml);
+  data.value = withChatSlots(data.value, list, chatMessageHtml, templateUsesBadgeArt.value ? chatBadgeHtml : undefined);
 }
 
 watch(twitchChat.messages, refreshChatSlots);
+
+// The badge manifest is fetched asynchronously, so the first messages of a
+// stream can arrive before it lands. Rebuild once it does, exactly as the
+// emote library does below, so those messages gain their badges instead of
+// staying bare until they scroll out of the window.
+watch(
+  () => badgeManifest.value,
+  () => {
+    if (templateUsesBadgeArt.value) refreshChatSlots(twitchChat.messages.value);
+  },
+);
 
 // The emote library loads asynchronously, so the first messages of a stream can
 // arrive before it is ready and would otherwise keep their plain-text rendering
@@ -333,12 +387,18 @@ const userId = ref<string | null>(null);
  * it are `<img>` elements this app generated. Bracket defusing still applies, so
  * a chatter typing a `[[[tag]]]` cannot reach the substitution pass.
  *
+ * `chat.N.badge_images` is produced by badgeImages() in badgeRenderer.ts. It
+ * echoes NOTHING from chat: every `src` comes from the badge manifest our own
+ * server fetched from Twitch and is additionally pinned to Twitch's CDN, the
+ * alt text is escaped anyway, and an unknown badge key produces no element at
+ * all rather than being interpolated into the output.
+ *
  * Keep this list tiny and keep every entry's producer honest. Adding a field
  * here without an escaping guarantee on the other end is an XSS hole, and it is
  * the kind that no test notices because the markup only appears when a real
  * stranger sends it.
  */
-const HTML_SAFE_FOREACH_FIELDS = { chat: ['html'] } as const;
+const HTML_SAFE_FOREACH_FIELDS = { chat: ['html', 'badge_images'] } as const;
 
 function parseSource(source: string | null | undefined, encode: boolean = true): string {
   if (!source) return '';
@@ -679,6 +739,11 @@ onMounted(async () => {
       // only from the second batch onward.
       twitchChat.setFilters(toChatFilters(json.chat_filters));
       twitchChat.connect(chatChannel);
+
+      // Badge art is keyed by the numeric broadcaster id, not the login.
+      if (templateUsesBadgeArt.value && userId.value) {
+        void loadBadgeManifest(String(userId.value));
+      }
     }
 
     // Initialise user locale for pipe formatters

--- a/resources/js/utils/badgeRenderer.test.ts
+++ b/resources/js/utils/badgeRenderer.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { EMPTY_BADGE_MANIFEST, badgeImages, hasBadgeArt, toBadgeManifest, type BadgeManifest } from './badgeRenderer';
+import type { ChatMessage } from './ircParser';
+
+const CDN = 'https://static-cdn.jtvnw.net/badges/v1';
+
+function msg(over: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'm1',
+    userId: '1',
+    login: 'ana',
+    author: 'Ana',
+    text: 'hello',
+    color: '#ff0000',
+    badges: 'moderator',
+    at: 1755273600,
+    isMod: true,
+    isSubscriber: false,
+    isVip: false,
+    isBroadcaster: false,
+    isFirstMessage: false,
+    sourceRoomId: '',
+    badgeVersions: ['moderator/1'],
+    emotes: [],
+    ...over,
+  };
+}
+
+function manifest(over: Partial<BadgeManifest> = {}): BadgeManifest {
+  return {
+    global: { 'moderator/1': { url: `${CDN}/mod.png`, title: 'Moderator' } },
+    channel: {
+      'moderator/1': { url: `${CDN}/mod.png`, title: 'Moderator' },
+      'subscriber/12': { url: `${CDN}/ours-12.png`, title: 'Subscriber (12 months)' },
+    },
+    ...over,
+  };
+}
+
+describe('toBadgeManifest', () => {
+  it('reads the shape the endpoint returns', () => {
+    const parsed = toBadgeManifest({
+      global: { 'moderator/1': { url: `${CDN}/mod.png`, title: 'Moderator' } },
+      channel: { 'subscriber/1': { url: `${CDN}/sub.png`, title: 'Subscriber' } },
+    });
+
+    expect(parsed.global['moderator/1'].url).toBe(`${CDN}/mod.png`);
+    expect(parsed.channel['subscriber/1'].title).toBe('Subscriber');
+  });
+
+  it('degrades to no art rather than throwing on a bad payload', () => {
+    // A failed fetch or an older server must not take the chat feed down.
+    expect(toBadgeManifest(undefined)).toEqual(EMPTY_BADGE_MANIFEST);
+    expect(toBadgeManifest(null)).toEqual(EMPTY_BADGE_MANIFEST);
+    expect(toBadgeManifest('nope')).toEqual(EMPTY_BADGE_MANIFEST);
+    expect(toBadgeManifest({})).toEqual(EMPTY_BADGE_MANIFEST);
+    expect(toBadgeManifest({ global: 'nope', channel: 5 })).toEqual(EMPTY_BADGE_MANIFEST);
+  });
+
+  it('drops entries with no usable url', () => {
+    const parsed = toBadgeManifest({
+      global: {
+        'good/1': { url: `${CDN}/a.png`, title: 'A' },
+        'nourl/1': { title: 'B' },
+        'empty/1': { url: '', title: 'C' },
+        'notobject/1': 'nope',
+      },
+    });
+
+    expect(Object.keys(parsed.global)).toEqual(['good/1']);
+  });
+
+  it('falls back to the set name when a title is missing', () => {
+    const parsed = toBadgeManifest({ global: { 'moderator/1': { url: `${CDN}/m.png` } } });
+
+    expect(parsed.global['moderator/1'].title).toBe('moderator');
+  });
+});
+
+describe('hasBadgeArt', () => {
+  it('distinguishes an empty manifest from a loaded one', () => {
+    expect(hasBadgeArt(EMPTY_BADGE_MANIFEST)).toBe(false);
+    expect(hasBadgeArt(manifest())).toBe(true);
+  });
+});
+
+describe('badgeImages', () => {
+  it('renders an img per badge, in wire order', () => {
+    const html = badgeImages(msg({ badgeVersions: ['moderator/1', 'subscriber/12'] }), manifest());
+
+    expect(html).toBe(
+      `<img class="ol-badge" src="${CDN}/mod.png" alt="Moderator" title="Moderator">` +
+        `<img class="ol-badge" src="${CDN}/ours-12.png" alt="Subscriber (12 months)" title="Subscriber (12 months)">`,
+    );
+  });
+
+  it('renders nothing when the message has no badges', () => {
+    expect(badgeImages(msg({ badgeVersions: [] }), manifest())).toBe('');
+  });
+
+  it('renders nothing before the manifest loads', () => {
+    expect(badgeImages(msg(), EMPTY_BADGE_MANIFEST)).toBe('');
+  });
+
+  it('skips a badge the manifest does not know', () => {
+    // An unknown key must produce NO element rather than being interpolated
+    // into the output - that is what stops a crafted badge name reaching the
+    // html-safe slot.
+    const html = badgeImages(msg({ badgeVersions: ['moderator/1', 'invented/99'] }), manifest());
+
+    expect(html).toBe(`<img class="ol-badge" src="${CDN}/mod.png" alt="Moderator" title="Moderator">`);
+  });
+
+  it('respects the version, not just the set', () => {
+    // A 3-month and a 12-month subscriber badge are different images.
+    expect(badgeImages(msg({ badgeVersions: ['subscriber/3'] }), manifest())).toBe('');
+    expect(badgeImages(msg({ badgeVersions: ['subscriber/12'] }), manifest())).not.toBe('');
+  });
+
+  describe('Shared Chat', () => {
+    it('resolves a foreign message against global art only', () => {
+      // A partner's subscriber badge art lives in THEIR manifest, which this
+      // overlay never fetched. Falling back to ours would render our emblem
+      // for someone who subscribes elsewhere - stating something false about
+      // a viewer, which is worse than rendering nothing.
+      const foreign = msg({ sourceRoomId: '999', badgeVersions: ['moderator/1', 'subscriber/12'] });
+
+      const html = badgeImages(foreign, manifest());
+
+      expect(html).toBe(`<img class="ol-badge" src="${CDN}/mod.png" alt="Moderator" title="Moderator">`);
+      expect(html).not.toContain('ours-12');
+    });
+
+    it('still uses channel art for a native message', () => {
+      const native = msg({ sourceRoomId: '', badgeVersions: ['subscriber/12'] });
+
+      expect(badgeImages(native, manifest())).toContain('ours-12');
+    });
+  });
+
+  describe('safety', () => {
+    it('escapes the title, even though it came from an API', () => {
+      const evil = manifest({
+        channel: { 'moderator/1': { url: `${CDN}/m.png`, title: '"><script>x</script>' } },
+      });
+
+      const html = badgeImages(msg(), evil);
+
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&quot;&gt;&lt;script&gt;');
+    });
+
+    it('refuses a url that is not on Twitch CDN', () => {
+      const evil = manifest({
+        channel: { 'moderator/1': { url: 'https://evil.example/x.png', title: 'Moderator' } },
+      });
+
+      expect(badgeImages(msg(), evil)).toBe('');
+    });
+
+    it('refuses a javascript: url', () => {
+      // Payload deliberately avoids the literal name of a native dialog:
+      // NativeDialogsTest greps resources/js for those, and an XSS fixture
+      // reads exactly like a real call site.
+      const evil = manifest({
+        channel: { 'moderator/1': { url: 'javascript:void 0', title: 'Moderator' } },
+      });
+
+      expect(badgeImages(msg(), evil)).toBe('');
+    });
+
+    it('never emits the badge key itself', () => {
+      // The key is chatter-influenced (it comes off the IRC tag), so it must
+      // not reach the output even when it looks like markup.
+      const html = badgeImages(msg({ badgeVersions: ['"><img src=x onerror=y>/1'] }), manifest());
+
+      expect(html).toBe('');
+    });
+  });
+});

--- a/resources/js/utils/badgeRenderer.ts
+++ b/resources/js/utils/badgeRenderer.ts
@@ -1,0 +1,128 @@
+import type { ChatMessage } from '@/utils/ircParser';
+
+/**
+ * Twitch chat badge artwork.
+ *
+ * The IRC `badges` tag addresses art as `set/version` (`moderator/1`,
+ * `subscriber/12`), so the manifest is keyed exactly that way and no lookup
+ * here has to know anything about Twitch's response shape.
+ */
+export interface BadgeArt {
+  url: string;
+  title: string;
+}
+
+/**
+ * Two maps, deliberately not merged.
+ *
+ * `channel` is this channel's art (global, with the channel's own overrides
+ * layered on). `global` is what is true in every channel on Twitch.
+ *
+ * A Shared Chat message from a collab partner carries THEIR badge versions,
+ * and their channel-specific art - subscriber, bits, founder - lives in a
+ * manifest this overlay never fetched. Resolving those against `channel` would
+ * render OUR subscriber emblem for someone who subscribes somewhere else,
+ * which is worse than rendering nothing: it states something false about a
+ * viewer. Foreign messages therefore resolve against `global` only, where
+ * moderator, VIP, staff and broadcaster art is correct for anyone anywhere.
+ */
+export interface BadgeManifest {
+  global: Record<string, BadgeArt>;
+  channel: Record<string, BadgeArt>;
+}
+
+export const EMPTY_BADGE_MANIFEST: BadgeManifest = { global: {}, channel: {} };
+
+/**
+ * Normalise the endpoint response.
+ *
+ * Defensive because this arrives over the wire: a failed fetch, an app token
+ * Twitch refused, or an older server must degrade to "no badge art" rather
+ * than throw while building a chat slot.
+ */
+export function toBadgeManifest(raw: unknown): BadgeManifest {
+  if (!raw || typeof raw !== 'object') return EMPTY_BADGE_MANIFEST;
+
+  const source = raw as { global?: unknown; channel?: unknown };
+
+  return {
+    global: toBadgeMap(source.global),
+    channel: toBadgeMap(source.channel),
+  };
+}
+
+function toBadgeMap(raw: unknown): Record<string, BadgeArt> {
+  if (!raw || typeof raw !== 'object') return {};
+
+  const out: Record<string, BadgeArt> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== 'object') continue;
+    const art = value as { url?: unknown; title?: unknown };
+    if (typeof art.url !== 'string' || art.url === '') continue;
+
+    out[key] = {
+      url: art.url,
+      title: typeof art.title === 'string' ? art.title : key.split('/')[0],
+    };
+  }
+  return out;
+}
+
+export function hasBadgeArt(manifest: BadgeManifest): boolean {
+  return Object.keys(manifest.global).length > 0 || Object.keys(manifest.channel).length > 0;
+}
+
+/**
+ * Build the `<img>` markup for one message's badges.
+ *
+ * THIS OUTPUT IS RENDERED WITHOUT ENTITY-ENCODING, as the second entry in the
+ * html-safe field list alongside `chat.N.html`. Everything it emits must
+ * therefore be generated here and never echoed from chat:
+ *
+ * - `src` comes only from the manifest, which came from our own server, which
+ *   got it from Twitch's API. A chatter cannot put a value in it. It is
+ *   additionally restricted to Twitch's own CDN below.
+ * - `alt` is the manifest's title, escaped anyway, because "it came from an
+ *   API" is a weaker guarantee than escaping and the cost is nothing.
+ * - The badge key itself is never interpolated into the output. An unknown key
+ *   produces no element at all, so a chatter cannot smuggle markup through a
+ *   crafted badge name.
+ *
+ * Bracket defusing still applies downstream, exactly as it does for
+ * `chat.N.html`, so a `[[[...]]]` sequence could not survive here either.
+ */
+export function badgeImages(message: ChatMessage, manifest: BadgeManifest): string {
+  const versions = message.badgeVersions;
+  if (!versions || versions.length === 0) return '';
+
+  // A foreign message's channel-specific art is not ours to guess at.
+  const map = message.sourceRoomId ? manifest.global : manifest.channel;
+
+  const parts: string[] = [];
+  for (const key of versions) {
+    const art = map[key];
+    if (!art) continue;
+    if (!isTwitchBadgeUrl(art.url)) continue;
+
+    const alt = escapeAttribute(art.title);
+    parts.push(`<img class="ol-badge" src="${escapeAttribute(art.url)}" alt="${alt}" title="${alt}">`);
+  }
+
+  return parts.join('');
+}
+
+/**
+ * Only Twitch's own badge CDN.
+ *
+ * Belt and braces: the manifest already comes from our server rather than from
+ * chat, so this should never reject anything. It exists so that if the server
+ * side is ever changed to accept a URL from somewhere less trustworthy, the
+ * html-safe path does not silently become an open redirect for image loads.
+ */
+function isTwitchBadgeUrl(url: string): boolean {
+  return url.startsWith('https://static-cdn.jtvnw.net/');
+}
+
+function escapeAttribute(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}

--- a/resources/js/utils/chatFilters.test.ts
+++ b/resources/js/utils/chatFilters.test.ts
@@ -18,6 +18,7 @@ function msg(over: Partial<ChatMessage> = {}): ChatMessage {
     isBroadcaster: false,
     isFirstMessage: false,
     sourceRoomId: '',
+    badgeVersions: [],
     emotes: [],
     ...over,
   };

--- a/resources/js/utils/chatSlots.test.ts
+++ b/resources/js/utils/chatSlots.test.ts
@@ -18,6 +18,7 @@ function msg(over: Partial<ChatMessage> = {}): ChatMessage {
     isBroadcaster: false,
     isFirstMessage: false,
     sourceRoomId: '',
+    badgeVersions: [],
     emotes: [],
     ...over,
   };
@@ -118,5 +119,35 @@ describe('chatSlots / the html slot', () => {
     const afterClear = withChatSlots(withOne, []);
 
     expect(afterClear['chat.0.html']).toBeUndefined();
+  });
+});
+
+describe('chatSlots / the badge_images slot', () => {
+  it('is absent unless a renderer is supplied', () => {
+    // Also rendered WITHOUT escaping. A template asking for badge art before
+    // the manifest lands should get nothing, not broken <img> elements.
+    expect(chatSlots([msg()])['chat.0.badge_images']).toBeUndefined();
+    expect(chatSlots([msg()], () => '<img>')['chat.0.badge_images']).toBeUndefined();
+  });
+
+  it('is produced by the supplied renderer', () => {
+    const slots = chatSlots([msg()], undefined, () => '<img class="ol-badge">');
+
+    expect(slots['chat.0.badge_images']).toBe('<img class="ol-badge">');
+  });
+
+  it('leaves the bare badge names alone', () => {
+    // `msg.badges` is what templates use for CSS classes and must not change
+    // when artwork is added alongside it.
+    const slots = chatSlots([msg({ badges: 'moderator subscriber' })], undefined, () => '<img>');
+
+    expect(slots['chat.0.badges']).toBe('moderator subscriber');
+  });
+
+  it('is cleared along with the rest of the window', () => {
+    const withOne = withChatSlots({}, [msg()], undefined, () => '<img>');
+    const afterClear = withChatSlots(withOne, []);
+
+    expect(afterClear['chat.0.badge_images']).toBeUndefined();
   });
 });

--- a/resources/js/utils/chatSlots.ts
+++ b/resources/js/utils/chatSlots.ts
@@ -27,6 +27,17 @@ export const CHAT_SLOT_PREFIX = 'chat.';
 export type EmoteRenderer = (message: ChatMessage) => string;
 
 /**
+ * Turns a message's badges into SAFE HTML for `chat.N.badge_images`.
+ *
+ * Same contract as EmoteRenderer, and the same reason for being a named type
+ * rather than a bare string: this slot is rendered without entity-encoding, so
+ * a producer that echoes anything from chat into it is writing an XSS hole.
+ * `badgeRenderer.ts` is the only implementation, and it emits `<img>` elements
+ * built entirely from the server-supplied badge manifest.
+ */
+export type BadgeRenderer = (message: ChatMessage) => string;
+
+/**
  * Booleans render as `1` / empty string rather than `true` / `false`.
  *
  * `useConditionalTemplates` treats `'0'` and `''` as falsy but the STRING
@@ -45,7 +56,7 @@ function flag(value: boolean): string {
  * Index 0 is the OLDEST visible message, so a template iterating in order
  * renders top-to-bottom the way Twitch chat reads.
  */
-export function chatSlots(messages: readonly ChatMessage[], toHtml?: EmoteRenderer): Record<string, string> {
+export function chatSlots(messages: readonly ChatMessage[], toHtml?: EmoteRenderer, toBadges?: BadgeRenderer): Record<string, string> {
   const slots: Record<string, string> = {
     'chat.count': String(messages.length),
   };
@@ -55,6 +66,10 @@ export function chatSlots(messages: readonly ChatMessage[], toHtml?: EmoteRender
     // Only emitted when a renderer is supplied, so a caller with no emote
     // pipeline never produces a slot that claims to be safe HTML.
     if (toHtml) slots[`${k}html`] = toHtml(m);
+    // Same rule for badge art: no manifest, no slot. A template asking for
+    // badge images before the manifest loads gets nothing rather than broken
+    // <img> elements pointing at undefined.
+    if (toBadges) slots[`${k}badge_images`] = toBadges(m);
     slots[`${k}id`] = m.id;
     slots[`${k}author`] = m.author;
     slots[`${k}login`] = m.login;
@@ -86,7 +101,12 @@ export function chatSlots(messages: readonly ChatMessage[], toHtml?: EmoteRender
  * while `chat.count` is small, and would reappear the moment the window grew
  * back past it - a deleted message resurrected by an unrelated new one.
  */
-export function withChatSlots(data: Record<string, unknown>, messages: readonly ChatMessage[], toHtml?: EmoteRenderer): Record<string, unknown> {
+export function withChatSlots(
+  data: Record<string, unknown>,
+  messages: readonly ChatMessage[],
+  toHtml?: EmoteRenderer,
+  toBadges?: BadgeRenderer,
+): Record<string, unknown> {
   const next: Record<string, unknown> = {};
 
   for (const key in data) {
@@ -94,5 +114,5 @@ export function withChatSlots(data: Record<string, unknown>, messages: readonly 
     next[key] = data[key];
   }
 
-  return Object.assign(next, chatSlots(messages, toHtml));
+  return Object.assign(next, chatSlots(messages, toHtml, toBadges));
 }

--- a/resources/js/utils/ircParser.test.ts
+++ b/resources/js/utils/ircParser.test.ts
@@ -89,6 +89,30 @@ describe('toChatMessage', () => {
     expect(msg.badges).toBe('broadcaster subscriber');
   });
 
+  it('keeps badge versions alongside the bare names', () => {
+    // `badges` is a published contract used for CSS class names and must stay
+    // version-free. Badge ARTWORK needs the version, because a 3-month and a
+    // 12-month subscriber badge are different images from the same set.
+    const msg = toChatMessage(parseIrcLine(PRIVMSG)!)!;
+
+    expect(msg.badges).toBe('broadcaster subscriber');
+    expect(msg.badgeVersions).toEqual(['broadcaster/1', 'subscriber/12']);
+  });
+
+  it('has no badge versions when the tag is absent', () => {
+    const msg = toChatMessage(parseIrcLine('@id=1 :a!a@a PRIVMSG #c :hi')!)!;
+
+    expect(msg.badgeVersions).toEqual([]);
+  });
+
+  it('ignores a badge entry with no version rather than inventing one', () => {
+    const msg = toChatMessage(parseIrcLine('@id=1;badges=moderator/1,broken :a!a@a PRIVMSG #c :hi')!)!;
+
+    expect(msg.badgeVersions).toEqual(['moderator/1']);
+    // The name still counts for styling and for isMod.
+    expect(msg.badges).toBe('moderator broken');
+  });
+
   it('converts tmi-sent-ts from milliseconds to seconds', () => {
     // Every timestamp in the project is Unix SECONDS; the wire is ms.
     expect(toChatMessage(parseIrcLine(PRIVMSG)!)!.at).toBe(1755273600);
@@ -136,6 +160,9 @@ describe('toChatMessage / Shared Chat', () => {
     // own UI shows - a partner's moderator reads as a moderator.
     expect(msg.badges).toBe('moderator');
     expect(msg.isMod).toBe(true);
+    // Their versions too, so badge art can resolve them - against the GLOBAL
+    // map only, since their channel-specific art is not ours to guess at.
+    expect(msg.badgeVersions).toEqual(['moderator/1']);
   });
 
   it('treats a native message as native even when source-room-id is echoed back', () => {

--- a/resources/js/utils/ircParser.ts
+++ b/resources/js/utils/ircParser.ts
@@ -44,6 +44,12 @@ export interface ChatMessage {
   color: string;
   /** Space-separated badge set names, e.g. `broadcaster moderator subscriber`. */
   badges: string;
+  /**
+   * The same badges WITH their versions, in wire order, e.g.
+   * `['broadcaster/1', 'subscriber/12']`. Badge artwork is keyed this way,
+   * because a 3-month and a 12-month subscriber badge are different images.
+   */
+  badgeVersions: string[];
   /** Unix SECONDS, honouring the project-wide timestamp contract. */
   at: number;
   isMod: boolean;
@@ -218,8 +224,9 @@ function loginFromPrefix(prefix: string | null): string {
  * Badge set names only, dropping the version.
  *
  * `badges=broadcaster/1,subscriber/12` becomes `broadcaster subscriber`, which
- * is what a template wants for styling (`.badge-subscriber`). The versions
- * matter only for rendering Twitch's badge artwork, which is a separate concern.
+ * is what a template wants for styling (`.badge-subscriber`). This stays the
+ * value of `msg.badges` and must not change - templates in the wild use it for
+ * CSS class names.
  */
 function badgeNames(raw: string): string {
   if (!raw) return '';
@@ -228,6 +235,25 @@ function badgeNames(raw: string): string {
     .map((b) => b.split('/')[0])
     .filter(Boolean)
     .join(' ');
+}
+
+/**
+ * Badge identifiers WITH their version, in wire order.
+ *
+ * `badges=broadcaster/1,subscriber/12` becomes `['broadcaster/1',
+ * 'subscriber/12']`. Badge artwork needs the version: a 3-month and a 12-month
+ * subscriber badge are different images from the same set, and the manifest is
+ * keyed exactly this way.
+ *
+ * Kept separate from badgeNames() rather than replacing it, because the two
+ * answer different questions and `msg.badges` is a published contract.
+ */
+function badgeVersions(raw: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((b) => b.trim())
+    .filter((b) => b.includes('/'));
 }
 
 /**
@@ -276,6 +302,7 @@ export function toChatMessage(line: IrcLine): ChatMessage | null {
     isBroadcaster: badgeSet.has('broadcaster'),
     isFirstMessage: t['first-msg'] === '1',
     sourceRoomId,
+    badgeVersions: badgeVersions(effectiveBadges),
     emotes: parseEmoteTag(t['emotes'] ?? ''),
   };
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -119,6 +119,37 @@ Route::prefix('/overlay')->group(function () {
 
         return response()->json($emotes);
     })->middleware(['throttle:60,1'])->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
+
+    // Returns Twitch chat badge art as { global: {...}, channel: {...} }, each
+    // keyed "set/version" to match the IRC `badges` tag (`moderator/1`).
+    // Same shape as the emote endpoint above: server-side app credentials,
+    // cached 24 h, rate-limited.
+    //
+    // global and channel stay SEPARATE because a Shared Chat message carries a
+    // collab partner's badge versions, whose channel-specific art lives in a
+    // manifest we have not fetched. Foreign messages resolve against `global`
+    // only, so they can never render this channel's subscriber emblem for
+    // someone who subscribes elsewhere.
+    Route::get('/badges/{channelId}', function (string $channelId) {
+        if (! ctype_digit($channelId)) {
+            return response()->json(['error' => 'Invalid channel ID'], 400);
+        }
+
+        $badges = Cache::remember(
+            "twitch_channel_badges_{$channelId}",
+            now()->addHours(24),
+            function () use ($channelId) {
+                $appToken = app(TwitchEventSubService::class)->getAppAccessToken();
+                if (! $appToken) {
+                    return ['global' => [], 'channel' => []];
+                }
+
+                return app(TwitchApiService::class)->getChannelBadges($appToken, $channelId);
+            }
+        );
+
+        return response()->json($badges);
+    })->middleware(['throttle:60,1'])->withoutMiddleware([EnsureFrontendRequestsAreStateful::class]);
 });
 
 // Get all template tags (API endpoint)

--- a/tests/Feature/ChatBadgeManifestTest.php
+++ b/tests/Feature/ChatBadgeManifestTest.php
@@ -1,0 +1,199 @@
+<?php
+
+use App\Services\TwitchEventSubService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+uses(DatabaseTransactions::class);
+
+/*
+ * Badge artwork for the chat overlay.
+ *
+ * The endpoint mirrors /emotes/{channelId}: app credentials stay server-side,
+ * the response is cached 24 h, and it is rate-limited.
+ *
+ * `global` and `channel` are returned SEPARATELY on purpose. A Shared Chat
+ * message from a collab partner carries THEIR badge versions, and their
+ * channel-specific art (subscriber, bits, founder) lives in a manifest we never
+ * fetched. Resolving those against this channel's map would render our own
+ * subscriber emblem for someone who subscribes elsewhere - stating something
+ * false about a viewer. Foreign messages resolve against `global` only.
+ */
+
+const BADGE_CDN = 'https://static-cdn.jtvnw.net/badges/v1';
+
+beforeEach(function () {
+    Cache::flush();
+
+    $this->mock(TwitchEventSubService::class, function ($mock) {
+        $mock->shouldReceive('getAppAccessToken')->andReturn('app-token');
+    });
+});
+
+function fakeBadgeApi(array $global, array $channel): void
+{
+    Http::fake([
+        'api.twitch.tv/helix/chat/badges/global*' => Http::response(['data' => $global]),
+        'api.twitch.tv/helix/chat/badges*' => Http::response(['data' => $channel]),
+    ]);
+}
+
+function badgeSet(string $setId, array $versions): array
+{
+    return ['set_id' => $setId, 'versions' => $versions];
+}
+
+function badgeVersion(string $id, string $file, string $title): array
+{
+    return [
+        'id' => $id,
+        'image_url_1x' => BADGE_CDN."/$file/1",
+        'image_url_2x' => BADGE_CDN."/$file/2",
+        'image_url_4x' => BADGE_CDN."/$file/3",
+        'title' => $title,
+    ];
+}
+
+it('rejects a non-numeric channel id', function () {
+    $this->getJson('/api/overlay/badges/not-a-number')
+        ->assertStatus(400);
+});
+
+it('returns global and channel maps keyed set/version', function () {
+    fakeBadgeApi(
+        global: [badgeSet('moderator', [badgeVersion('1', 'mod', 'Moderator')])],
+        channel: [badgeSet('subscriber', [badgeVersion('12', 'ours', 'Subscriber (12 months)')])],
+    );
+
+    $this->getJson('/api/overlay/badges/12345')
+        ->assertOk()
+        ->assertJsonPath('global.moderator/1.title', 'Moderator')
+        ->assertJsonPath('channel.subscriber/12.title', 'Subscriber (12 months)');
+});
+
+it('uses the 2x image', function () {
+    // Twitch's own chat renders badges at 18px, so 2x stays crisp on a 1080p
+    // or 1440p overlay without paying 4x the bytes.
+    fakeBadgeApi(
+        global: [badgeSet('moderator', [badgeVersion('1', 'mod', 'Moderator')])],
+        channel: [],
+    );
+
+    $this->getJson('/api/overlay/badges/12345')
+        ->assertOk()
+        ->assertJsonPath('global.moderator/1.url', BADGE_CDN.'/mod/2');
+});
+
+it('folds global into channel so a native message needs one lookup', function () {
+    fakeBadgeApi(
+        global: [badgeSet('moderator', [badgeVersion('1', 'mod', 'Moderator')])],
+        channel: [badgeSet('subscriber', [badgeVersion('12', 'ours', 'Sub')])],
+    );
+
+    $this->getJson('/api/overlay/badges/12345')
+        ->assertOk()
+        ->assertJsonPath('channel.moderator/1.url', BADGE_CDN.'/mod/2')
+        ->assertJsonPath('channel.subscriber/12.url', BADGE_CDN.'/ours/2');
+});
+
+it('lets the channel override global art for the same set and version', function () {
+    // Subscriber and bits badges exist globally AND per channel. The channel's
+    // own art is the correct one for a native message.
+    fakeBadgeApi(
+        global: [badgeSet('subscriber', [badgeVersion('1', 'generic', 'Subscriber')])],
+        channel: [badgeSet('subscriber', [badgeVersion('1', 'ours', 'Subscriber')])],
+    );
+
+    $this->getJson('/api/overlay/badges/12345')
+        ->assertOk()
+        ->assertJsonPath('channel.subscriber/1.url', BADGE_CDN.'/ours/2')
+        // global stays untouched, which is what a foreign message resolves
+        // against.
+        ->assertJsonPath('global.subscriber/1.url', BADGE_CDN.'/generic/2');
+});
+
+it('keeps a channel-only badge out of the global map', function () {
+    fakeBadgeApi(
+        global: [],
+        channel: [badgeSet('subscriber', [badgeVersion('12', 'ours', 'Sub')])],
+    );
+
+    $response = $this->getJson('/api/overlay/badges/12345')->assertOk();
+
+    expect($response->json('global'))->toBe([])
+        ->and($response->json('channel'))->toHaveKey('subscriber/12');
+});
+
+it('skips malformed sets and versions rather than failing the request', function () {
+    fakeBadgeApi(
+        global: [
+            ['versions' => [badgeVersion('1', 'x', 'X')]],            // no set_id
+            badgeSet('nover', []),                                     // no versions
+            badgeSet('noid', [['image_url_2x' => BADGE_CDN.'/y/2']]),  // version has no id
+            badgeSet('good', [badgeVersion('1', 'good', 'Good')]),
+        ],
+        channel: [],
+    );
+
+    $response = $this->getJson('/api/overlay/badges/12345')->assertOk();
+
+    expect(array_keys($response->json('global')))->toBe(['good/1']);
+});
+
+it('returns empty maps when no app token is available', function () {
+    $this->mock(TwitchEventSubService::class, function ($mock) {
+        $mock->shouldReceive('getAppAccessToken')->andReturnNull();
+    });
+
+    $this->getJson('/api/overlay/badges/12345')
+        ->assertOk()
+        ->assertExactJson(['global' => [], 'channel' => []]);
+});
+
+it('caches so a second request does not hit Twitch again', function () {
+    fakeBadgeApi(
+        global: [badgeSet('moderator', [badgeVersion('1', 'mod', 'Moderator')])],
+        channel: [],
+    );
+
+    $this->getJson('/api/overlay/badges/12345')->assertOk();
+    $this->getJson('/api/overlay/badges/12345')->assertOk();
+
+    // Two calls (global + channel) for the first request, none for the second.
+    Http::assertSentCount(2);
+});
+
+it('caches per channel rather than globally', function () {
+    fakeBadgeApi(
+        global: [badgeSet('moderator', [badgeVersion('1', 'mod', 'Moderator')])],
+        channel: [],
+    );
+
+    $this->getJson('/api/overlay/badges/12345')->assertOk();
+    $this->getJson('/api/overlay/badges/67890')->assertOk();
+
+    Http::assertSentCount(4);
+});
+
+it('never exposes the app token to the client', function () {
+    fakeBadgeApi(
+        global: [badgeSet('moderator', [badgeVersion('1', 'mod', 'Moderator')])],
+        channel: [],
+    );
+
+    $body = $this->getJson('/api/overlay/badges/12345')->assertOk()->content();
+
+    expect($body)->not->toContain('app-token');
+});
+
+it('does not require authentication', function () {
+    // Overlays run in an OBS browser source with no session. Badge art is
+    // public data - the same images Twitch serves to every chat client.
+    fakeBadgeApi(
+        global: [badgeSet('moderator', [badgeVersion('1', 'mod', 'Moderator')])],
+        channel: [],
+    );
+
+    $this->getJson('/api/overlay/badges/12345')->assertOk();
+});


### PR DESCRIPTION
Section 5.3 of the chat handoff, and the last build item before the help page.

```
[[[foreach:chat as msg]]]
  <span class="badges">[[[msg.badge_images]]]</span>
  <b>[[[msg.author]]]</b>: [[[msg.html]]]
[[[endforeach]]]
```

**Verified in a real overlay against the live Twitch API** - badges render.

`[[[msg.badges]]]` is unchanged and still emits bare set names for CSS classes. It is a published contract, and a template that wants a coloured border per badge should not have to load images to get one.

## The version was being thrown away

A 3-month and a 12-month subscriber badge are different images from the same set, so `badgeVersions()` now keeps `subscriber/12` next to the bare name. Deliberately a separate function from `badgeNames()` rather than a replacement - they answer different questions, and one of them is a contract.

## global and channel are two maps, and must stay two maps

The handoff said "use `source-badges` for a foreign message", which is right but incomplete. A collab partner's badge *versions* arrive fine. Their channel-specific **art** - subscriber, bits, founder - lives in a manifest this overlay never fetched.

Merging the maps would render **our** subscriber emblem for someone who subscribes somewhere else. That is worse than rendering nothing: it states something false about a viewer. So foreign messages resolve against `global` only, where moderator, VIP, staff and broadcaster art is correct for anyone anywhere. `channel` already has global folded in, so a native message still needs one lookup.

## The endpoint

`GET /api/overlay/badges/{channelId}` mirrors `/emotes/{channelId}` exactly: app token server-side, 24 h cache, `throttle:60,1`, no auth since badge art is the same public image set Twitch serves every chat client. Keyed `set/version` to match the IRC tag.

Uses `image_url_2x` (36px). Twitch draws badges at 18px, so that survives OBS scaling without paying 4x the bytes for something the size of a full stop.

The manifest fetch is gated on the template actually rendering badge art. Most chat templates want the class names and nothing else, and must not pay for images they never draw - same discipline as the emote library in #238.

## It is the second-ever unescaped field, and it earns that

`badge_images` joins `html` in `HTML_SAFE_FOREACH_FIELDS`. It is safe because `badgeRenderer.ts` echoes **nothing** from chat:

- `src` comes only from the server-fetched manifest, and is additionally pinned to `static-cdn.jtvnw.net`.
- `alt`/`title` are escaped anyway, because "it came from an API" is a weaker guarantee than escaping and the cost is nothing.
- An unrecognised badge key produces **no element at all** rather than being interpolated. The key comes off the IRC tag, so this is what stops a crafted badge name reaching the output.

Each of those three was mutated and confirmed to fail the test written for it.

## Tests

23 frontend, 12 backend. Full suites: **1421 backend**, **113 frontend**, plus `pint --test`, `typecheck`, `lint:check`, `format:check`.

One note for whoever writes the next frontend test: the `javascript:` URL fixture says `void 0` rather than naming a native dialog, because `NativeDialogsTest` greps `resources/js` for those and an XSS payload reads exactly like a real call site. It is a documented trap and it caught this branch - the full suite went red until the fixture changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
