### PR TITLE
fix(overlay): keep class names so 7TV/BTTV/FFZ emotes work in production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,15 @@ counts them ("five donation services", "five pipes") lives in `resources/views/w
 - `chat.N.html` is the ONLY foreach field rendered unescaped (`htmlSafeFields`, keyed by iterable). **Bracket defusing still applies inside it** - skipping that reopens the PR #230 injection hole through a side door.
 - Deletions are not optional: CLEARMSG removes one message, CLEARCHAT purges a user or clears the room. Purge by user id, falling back to login, and NEVER to "clear everything".
 
+### keepNames is load-bearing (fixed Aug 2026)
+
+- **`build.rollupOptions.output.keepNames: true` in `vite.config.mts` is NOT cosmetic. Do not remove it.** `@mkody/twitch-emoticons` guards its abstract base with `if (new.target.name === Emote.name) throw`. The minifier renamed the base class AND all four subclasses to `e`, so the guard was true for every subclass and constructing any BTTV/FFZ/7TV emote threw "Base Emote class cannot be used".
+- Symptom was **prod-only and silent**: third-party emotes rendered as plain text on prod while Twitch emotes worked (those come from IRC tag positions and never construct a library object), and dev was fine because dev is not minified. `Promise.allSettled` in `useEmoteParser` swallowed all seven failures with no logging.
+- The library's own build script uses esbuild `--keep-names` for exactly this reason. Bundling its `src/` through our build opted us out of that.
+- Cost is ~+18 KB on the (lazy, idle-loaded) emote chunk and ~+190 KB across all JS uncompressed. Correctness wins.
+- Pinned by `tests/Feature/EmoteLibraryMinificationTest.php`, which inspects the BUILT chunk. CI runs `npm run build` before Pest, so it has a real artifact; it skips locally when `public/build` is absent. Verified to fail when `keepNames` is removed. **No unit test can catch this class of bug** - they all run against unminified source, so the suite stays green while prod is broken.
+- `useEmoteParser.initialize()` now names each source and logs which one failed, plus a warning when zero third-party emotes cached. That is the diagnostic that was missing.
+
 ### Chat badge artwork (Aug 2026)
 
 - `[[[msg.badge_images]]]` renders Twitch badge `<img>` tags. `[[[msg.badges]]]` still emits bare set names for CSS classes and MUST NOT change - templates in the wild use it.

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,23 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - fix(overlay): 7TV, BTTV and FFZ emotes were broken on production only
+
+Third-party emotes rendered as plain text on overlabels.com while working perfectly on a local machine. Twitch emotes were fine in both. Same code, same browser, same account.
+
+The cause was a single character. The emote library protects its base class like this:
+
+```js
+if (new.target.name === Emote.name) throw new Error('Base Emote class cannot be used');
+```
+
+That compares class names at runtime. The production minifier renamed the base class to `e` - and all four of its subclasses to `e` as well. So the check meant "is `e` equal to `e`", which it always is, and every single emote threw on construction. Development builds are not minified, so it only ever happened in production.
+
+- **Twitch emotes survived by accident.** They come from position data on the chat message itself and never construct one of the library's objects, so they sailed past the broken guard. That is exactly what made this look so strange: the same message could show a Twitch emote and the literal text "Sadge" side by side.
+- **Nothing said a word about it.** The seven emote sources are loaded together and the results were being thrown away, so seven different failures could happen in silence. They are now loaded by name, and anything that fails says which one it was and why. There is also a warning for the case where everything succeeds and still nothing is cached, which looks identical on screen.
+- **The library's own build already worked around this** - its author passes `--keep-names` to their minifier. Bundling the library's source through our build quietly opted out of that. We now keep names too, which costs about 18 kB on a chunk that is already loaded lazily.
+- **A test now inspects the actual built file**, because no ordinary test could ever have caught this. Every test runs against unminified source, so the entire suite stayed green while production was broken.
+
 ## August 16th, 2026 - docs(chat): the chat overlay, written down
 
 Chat went from nothing to a complete feature in a day, and none of it was documented. [Twitch Chat in an Overlay](/help/chat) covers the lot: the foreach loop, every per-message tag, badges and emotes, what happens during a collab, the display filters, and the four chat controls.

--- a/resources/js/composables/useEmoteParser.ts
+++ b/resources/js/composables/useEmoteParser.ts
@@ -57,22 +57,56 @@ export function useEmoteParser() {
       match: /([a-zA-Z0-9_-]+)/g,
     });
 
-    await Promise.allSettled([
-      fetcher.fetchBTTVEmotes(),
-      fetcher.fetchBTTVEmotes(Number(channelId)),
-      fetcher.fetchSevenTVEmotes(),
-      fetcher.fetchSevenTVEmotes(channelId),
-      fetcher.fetchFFZEmotes(),
-      fetcher.fetchFFZEmotes(Number(channelId)),
-      // Fetch Twitch emotes via backend proxy so credentials never reach the browser
-      fetch(`/api/overlay/emotes/${channelId}`)
-        .then((r) => r.json())
-        .then((entries: TwitchEmoteEntry[]) => {
-          for (const { code, url } of entries) {
-            twitchEmoteMap.set(code, url);
-          }
-        }),
-    ]);
+    // Named so a failure can say WHICH source broke. This used to be a bare
+    // Promise.allSettled with the results discarded, which meant every one of
+    // these could fail and produce no signal at all - the overlay just rendered
+    // emote codes as text forever.
+    //
+    // That is not hypothetical: a minifier collision between the emote
+    // library's base class and its subclasses made every emote constructor
+    // throw in production and nothing anywhere said so. See the keepNames note
+    // in vite.config.mts.
+    const sources: Array<[string, Promise<unknown>]> = [
+      ['bttv:global', fetcher.fetchBTTVEmotes()],
+      ['bttv:channel', fetcher.fetchBTTVEmotes(Number(channelId))],
+      ['7tv:global', fetcher.fetchSevenTVEmotes()],
+      ['7tv:channel', fetcher.fetchSevenTVEmotes(channelId)],
+      ['ffz:global', fetcher.fetchFFZEmotes()],
+      ['ffz:channel', fetcher.fetchFFZEmotes(Number(channelId))],
+      // Twitch emotes via our own proxy, so credentials never reach the browser.
+      [
+        'twitch:proxy',
+        fetch(`/api/overlay/emotes/${channelId}`)
+          .then((r) => r.json())
+          .then((entries: TwitchEmoteEntry[]) => {
+            for (const { code, url } of entries) {
+              twitchEmoteMap.set(code, url);
+            }
+          }),
+      ],
+    ];
+
+    const results = await Promise.allSettled(sources.map(([, promise]) => promise));
+
+    const failed: string[] = [];
+    results.forEach((result, i) => {
+      if (result.status !== 'rejected') return;
+      const name = sources[i][0];
+      failed.push(name);
+      console.warn(`[emotes] ${name} failed:`, result.reason?.message ?? result.reason);
+    });
+
+    // Still a partial failure worth naming: every source can resolve and yet
+    // cache nothing, which looks identical on screen to not loading at all.
+    const thirdPartyCount = fetcher.emotes?.size ?? 0;
+    if (thirdPartyCount === 0) {
+      console.warn(`[emotes] no BTTV/FFZ/7TV emotes cached for channel ${channelId}. ` + 'Those emotes will render as plain text.');
+    }
+
+    console.info(
+      `[emotes] ready - ${thirdPartyCount} third-party, ${twitchEmoteMap.size} twitch` +
+        (failed.length ? `, ${failed.length} source(s) failed: ${failed.join(', ')}` : ''),
+    );
 
     isReady.value = true;
   }

--- a/tests/Feature/EmoteLibraryMinificationTest.php
+++ b/tests/Feature/EmoteLibraryMinificationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * The emote library's abstract base class guards itself with:
+ *
+ *     if (new.target.name === Emote.name) throw new Error('Base Emote class cannot be used');
+ *
+ * That compares CLASS NAMES at runtime. Minification renamed the base class and
+ * all four subclasses to `e`, which made the guard true for every subclass, so
+ * constructing any BTTV/FFZ/7TV emote threw.
+ *
+ * It broke in production only - dev is not minified - and it was completely
+ * silent, because useEmoteParser wrapped the fetches in Promise.allSettled. The
+ * visible symptom was third-party emotes rendering as plain text on prod while
+ * Twitch emotes worked, since those come from IRC tag positions and never
+ * construct a library object.
+ *
+ * `keepNames: true` in vite.config.mts is the fix. This test is the thing that
+ * notices if it is ever removed, because nothing else would: every unit test
+ * runs against unminified source, so the whole suite stays green while
+ * production is broken.
+ *
+ * CI runs `npm run build` before Pest, so this has a real build to inspect.
+ */
+
+function emoteChunkSource(): ?string
+{
+    $manifestPath = public_path('build/manifest.json');
+
+    if (! file_exists($manifestPath)) {
+        return null;
+    }
+
+    $manifest = json_decode(file_get_contents($manifestPath), true) ?: [];
+
+    foreach ($manifest as $key => $entry) {
+        if (! str_contains($key, 'twitch-emoticons')) {
+            continue;
+        }
+
+        $chunk = public_path('build/'.$entry['file']);
+
+        return file_exists($chunk) ? file_get_contents($chunk) : null;
+    }
+
+    return null;
+}
+
+beforeEach(function () {
+    $this->source = emoteChunkSource();
+
+    if ($this->source === null) {
+        $this->markTestSkipped('No production build present. Run `npm run build`.');
+    }
+});
+
+it('keeps the emote base class name through minification', function () {
+    // The guard compares against `Emote.name`. If the class were minified the
+    // literal would be a single letter and this string would not appear.
+    expect($this->source)->toContain('class Emote');
+});
+
+it('keeps every emote subclass name distinct from the base', function () {
+    // These four are what actually broke: all of them collapsed to `e`, the
+    // same name the base class got, so the guard fired on every construction.
+    //
+    // One needle per assertion: toContain() is variadic, so passing a second
+    // argument as a "message" silently asserts it as another needle.
+    foreach (['BTTVEmote', 'FFZEmote', 'SevenTVEmote', 'TwitchEmote'] as $subclass) {
+        expect(str_contains($this->source, "class $subclass"))
+            ->toBeTrue("$subclass lost its name to minification");
+    }
+});
+
+it('still contains the guard it is protecting', function () {
+    // If the library ever drops the abstract guard, this whole test file is
+    // obsolete and keepNames may be reconsidered on its own merits. Failing
+    // here is the signal to go and check, not a bug in itself.
+    expect($this->source)->toContain('new.target.name');
+});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -41,6 +41,29 @@ export default defineConfig(() => ({
         chunkSizeWarningLimit: 1000,
         rollupOptions: {
             output: {
+                // Preserve function and class `name` values through minification.
+                //
+                // NOT cosmetic, and not for debugging. `@mkody/twitch-emoticons`
+                // guards its abstract base class with
+                // `if (new.target.name === Emote.name) throw`, and the minifier
+                // renamed the base class AND all four subclasses to `e`. That
+                // made the guard true for every subclass, so constructing any
+                // BTTV/FFZ/7TV emote threw "Base Emote class cannot be used".
+                //
+                // It only broke in production - dev is unminified - and it was
+                // silent, because useEmoteParser wraps the fetches in
+                // Promise.allSettled. Symptom was third-party emotes rendering
+                // as plain text on prod while Twitch emotes worked, since those
+                // come from IRC tag positions and never construct a library
+                // object.
+                //
+                // The library's own build script uses esbuild `--keep-names` for
+                // exactly this reason. Bundling its `src/` ourselves opted us out.
+                //
+                // Verify with a build, not by reading: `class e extends n` in the
+                // emote chunk means it has regressed.
+                keepNames: true,
+
                 // Rolldown's native chunking API, NOT rollup's `manualChunks`.
                 //
                 // `manualChunks` is a compatibility shim here and it silently


### PR DESCRIPTION
Third-party emotes rendered as plain text on overlabels.com while working perfectly on overlabels.test. Twitch emotes worked in both. Same code, same browser, same account.

## The cause is one character

`@mkody/twitch-emoticons` guards its abstract base class like this:

```js
if (new.target.name === Emote.name) throw new Error('Base Emote class cannot be used');
```

That compares **class names at runtime**. Here is what the deployed chunk actually contained:

```js
class e{ constructor(...){ if(new.target.name===e.name) throw ... } }   // Emote
class e extends n{ ...this.type=`bttv` }                                // BTTVEmote
class e extends n{ ...this.type=`ffz`  }                                // FFZEmote
class e extends n{ ...this.type=`7tv`  }                                // SevenTVEmote
class e extends n{ ...this.type=`twitch` }                              // TwitchEmote
```

The minifier renamed the base class **and all four subclasses** to `e`. So the guard asks "is `e` equal to `e`", which is always true, and **every emote threw on construction**. Dev builds are not minified, so it only ever failed in production.

**Twitch emotes survived by accident.** They are built from IRC tag positions (`useEmoteParser.ts:139`) and never construct a library object, so they sailed past the broken guard. That is what made this look so strange: one message could show a Twitch emote next to the literal text `Sadge`.

## What it was not

Ruled out before finding the real cause, all verified rather than assumed: stale prod build, CSP/COEP headers, CORS (both origins are echoed correctly), API availability (all six endpoints return 200 including the channel ones), wrong channel id, service worker, ad blocker, and browser choice. Every third-party API returns 200 from the prod page - the throw happens *after* the response, during object construction.

## The fix

`keepNames: true` on `build.rollupOptions.output`.

The library's own build script already passes esbuild `--keep-names` for exactly this reason; bundling its `src/` through our build opted us out of that. Verified against a real build - the chunk now contains `class Emote`, `class BTTVEmote`, `class FFZEmote`, `class SevenTVEmote`, `class TwitchEmote`.

Cost is ~18 kB on the emote chunk (339 -> 357 kB), which is lazily loaded at idle since #238, and ~190 kB across all JS uncompressed.

## Why nobody noticed sooner

The seven emote sources are loaded with `Promise.allSettled` and **the results were discarded**. Seven different failures could occur in complete silence.

They are now loaded by name, every rejection logs which source failed and why, and there is a separate warning for the case where everything resolves but nothing caches - which looks identical on screen.

## A test that can actually catch this

`EmoteLibraryMinificationTest` inspects the **built chunk**, because nothing else could. Every ordinary test runs against unminified source, so the entire suite stayed green while production was broken.

CI runs `npm run build` before Pest so it has a real artifact; it skips locally when `public/build` is absent. Verified to fail with `keepNames` removed (2 of its 3 tests go red).

## Verification

**1424 backend** (+3), **113 frontend**, plus `pint --test`, `typecheck`, `lint:check`, `format:check`.

Not covered: the class names are proven to survive in the built output, but no emote has been seen rendering on prod yet. That needs this deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
