### PR TITLE
fix(overlay): move emote sizing out of inline styles and into base CSS

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,23 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - fix(overlay): emote sizing is yours now
+
+Every emote image was being written with its styling baked into the tag: `style="display:inline;vertical-align:middle;height:1.5em;"`, stamped on by us, three times over, in three different places in the code.
+
+Inline styles beat every selector you can write. So `1.5em` was not a default, it was a decision, and the only way past it was `!important`.
+
+The same three declarations now live in the overlay's base stylesheet as a `.overlay-emote` rule, loaded before your CSS. Nothing looks any different, but this works now:
+
+```css
+.overlay-emote { height: 1em; }
+```
+
+- **1.5em is still the default**, and it earns it: an `em` scales with whatever text the emote sits in, so a feed stays proportional at any overlay size. A pixel value would not.
+- Twitch emotes also carry `twitch-emote`, so you can size those separately from 7TV, BTTV and FFZ ones if you want.
+- Badges never had this problem - they always shipped class-only. Emotes just predated that decision and nobody went back.
+- A test now fails if inline styles reappear on generated markup, because the tempting fix for "my emotes are the wrong size" is to reach for the nearest string template.
+
 ## August 16th, 2026 - feat(chat): how many chat messages is now yours to decide
 
 Chat was the only foreach loop with a limit you could not change. Fifty messages, take it or leave it, while Subscribers, Goals, Followers and Followed channels all had a box on the settings page. That was an oversight rather than a decision.

--- a/resources/help/pages/chat.md
+++ b/resources/help/pages/chat.md
@@ -108,6 +108,18 @@ overlay in OBS to pick up a change.
 Every badge image carries the class `ol-badge`, so you can target them without touching the wrapper.
 Use one, the other, or both - a template that only wants coloured borders never loads any images.
 
+### Sizing emotes
+
+Emote images carry the class `overlay-emote`, and Twitch's own emotes additionally carry
+`twitch-emote`. They default to `height: 1.5em`, which keeps them proportional to whatever text they
+sit in. Override it like any other rule:
+
+```css
+.overlay-emote { height: 1em; }
+```
+
+No `!important` needed - the default is an ordinary stylesheet rule, and yours comes later.
+
 ## Messages that get deleted
 
 If a moderator deletes a message, or times someone out, or clears the room, your overlay follows

--- a/resources/js/components/OverlayRenderer.vue
+++ b/resources/js/components/OverlayRenderer.vue
@@ -472,6 +472,43 @@ watchEffect(
 // declared (see after the alert section).
 const alertContainer = ref<HTMLElement | null>(null);
 
+/**
+ * Defaults for markup the renderer generates itself, rather than the user.
+ *
+ * These used to be inline `style=""` attributes on every emote `<img>`, which
+ * meant a template could only override them with `!important` - inline styles
+ * outrank any selector. As a stylesheet rule at plain class specificity, an
+ * ordinary `.overlay-emote { height: 1em }` in the template now wins, because
+ * this sheet is inserted first in <head>.
+ *
+ * `1.5em` rather than a pixel value on purpose: it scales with the font-size of
+ * whatever the emote sits in, so a feed stays proportional at any overlay
+ * scale. Templates that disagree can say so in one line.
+ *
+ * Badges deliberately have no rule here. They ship class-only (`ol-badge`) and
+ * the help page tells authors to size them, which is the same freedom this
+ * change gives emotes.
+ */
+const BASE_OVERLAY_CSS = `.overlay-emote {
+  display: inline;
+  vertical-align: middle;
+  height: 1.5em;
+}`;
+
+/**
+ * Inserted FIRST in <head> so every later sheet - compiled utilities, and the
+ * template's own CSS - beats it at equal specificity. Order is the whole
+ * mechanism here, so do not switch this to appendChild.
+ */
+function injectBaseStyle() {
+  if (document.getElementById('overlay-base-style')) return;
+
+  const style = document.createElement('style');
+  style.id = 'overlay-base-style';
+  style.textContent = BASE_OVERLAY_CSS;
+  document.head.insertBefore(style, document.head.firstChild);
+}
+
 function injectStyle(styleString: string) {
   const existing = document.getElementById('overlay-style');
   if (existing) existing.remove();
@@ -649,6 +686,10 @@ function injectAlertCompiledStyle(styleString: string) {
 
 onMounted(async () => {
   data.value = {};
+
+  // Before the payload, so it is already first in <head> when the template's
+  // own CSS arrives and lands after it.
+  injectBaseStyle();
 
   // Use resilient fetch with retry
   const result = await health.fetchWithRetry(props.slug, props.token);

--- a/resources/js/composables/useEmoteParser.ts
+++ b/resources/js/composables/useEmoteParser.ts
@@ -53,7 +53,10 @@ export function useEmoteParser() {
 
     const fetcher = new EmoteFetcher(); // No Twitch credentials — BTTV/FFZ/7TV only
     parser = new EmoteParser(fetcher, {
-      template: '<img class="overlay-emote" alt="{name}" src="{link}" style="display:inline;vertical-align:middle;height:1.5em;">',
+      // No inline styles. Sizing lives in the overlay's base stylesheet as a
+      // `.overlay-emote` rule, so a template can override it with an ordinary
+      // selector instead of having to out-shout `style=""` with `!important`.
+      template: '<img class="overlay-emote" alt="{name}" src="{link}">',
       match: /([a-zA-Z0-9_-]+)/g,
     });
 
@@ -124,7 +127,7 @@ export function useEmoteParser() {
   function parseToken(token: string): string {
     const twitchUrl = twitchEmoteMap.get(token);
     if (twitchUrl) {
-      return `<img class="overlay-emote twitch-emote" alt="${encodeHtml(token)}" src="${twitchUrl}" style="display:inline;vertical-align:middle;height:1.5em;">`;
+      return `<img class="overlay-emote twitch-emote" alt="${encodeHtml(token)}" src="${twitchUrl}">`;
     }
     const encoded = encodeHtml(token);
     return parser ? parser.parse(encoded) : encoded;
@@ -169,9 +172,7 @@ export function useEmoteParser() {
       }
       const emoteName = text.slice(emote.begin, emote.end + 1);
       const url = `https://static-cdn.jtvnw.net/emoticons/v2/${emote.id}/default/dark/1.0`;
-      parts.push(
-        `<img class="overlay-emote twitch-emote" alt="${encodeHtml(emoteName)}" src="${url}" style="display:inline;vertical-align:middle;height:1.5em;">`,
-      );
+      parts.push(`<img class="overlay-emote twitch-emote" alt="${encodeHtml(emoteName)}" src="${url}">`);
       lastIndex = emote.end + 1;
     }
 

--- a/tests/Feature/GeneratedMarkupStylingTest.php
+++ b/tests/Feature/GeneratedMarkupStylingTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Markup the renderer generates itself - emote and badge <img> elements - must
+ * carry CLASSES and no inline `style` attribute.
+ *
+ * Inline styles outrank every selector short of `!important`, so an emote with
+ * `style="height:1.5em"` baked in cannot be resized by an ordinary template
+ * rule. Overlabels serves lego bricks; deciding how tall someone's emotes are
+ * is not its job.
+ *
+ * The defaults still exist, as `.overlay-emote` in BASE_OVERLAY_CSS, injected
+ * first in <head> so any template rule at equal specificity beats it. Nothing
+ * changed visually - only who gets the last word.
+ *
+ * This guards the easy regression: someone fixing a sizing complaint reaches
+ * for the nearest string template and adds `style=""` back, and no visual test
+ * would object.
+ */
+
+function generatedMarkupSources(): array
+{
+    return [
+        'useEmoteParser.ts' => resource_path('js/composables/useEmoteParser.ts'),
+        'badgeRenderer.ts' => resource_path('js/utils/badgeRenderer.ts'),
+    ];
+}
+
+it('generates emote and badge markup without inline styles', function () {
+    foreach (generatedMarkupSources() as $name => $path) {
+        $source = file_get_contents($path);
+
+        // Anchored to an actual `<img` tag rather than a bare `style=`, so a
+        // comment explaining why inline styles are avoided does not trip it.
+        expect(preg_match('/<img[^>]*style=/', $source))
+            ->toBe(0, "$name emits an inline style attribute; put the rule in BASE_OVERLAY_CSS instead");
+    }
+});
+
+it('still tags generated markup with the classes templates style against', function () {
+    // The classes are the contract that replaces the inline styles. Losing one
+    // would leave authors with nothing to select.
+    $emotes = file_get_contents(generatedMarkupSources()['useEmoteParser.ts']);
+    $badges = file_get_contents(generatedMarkupSources()['badgeRenderer.ts']);
+
+    expect($emotes)->toContain('class="overlay-emote"')
+        ->and($emotes)->toContain('overlay-emote twitch-emote')
+        ->and($badges)->toContain('class="ol-badge"');
+});
+
+it('keeps the emote defaults in the overlay base stylesheet', function () {
+    // Removing the inline styles without providing the rule would change every
+    // existing overlay's appearance, which this change explicitly does not do.
+    $renderer = file_get_contents(resource_path('js/components/OverlayRenderer.vue'));
+
+    expect($renderer)->toContain('BASE_OVERLAY_CSS')
+        ->and($renderer)->toContain('.overlay-emote')
+        ->and($renderer)->toContain('height: 1.5em');
+});
+
+it('inserts the base stylesheet first so template CSS can override it', function () {
+    // insertBefore(head.firstChild), not appendChild. Order is the entire
+    // mechanism: at equal specificity the later rule wins, and the template's
+    // rule must be the later one.
+    $renderer = file_get_contents(resource_path('js/components/OverlayRenderer.vue'));
+
+    expect($renderer)->toContain('document.head.insertBefore(style, document.head.firstChild)');
+});


### PR DESCRIPTION
Every generated emote `<img>` carried this, written by us, in three separate places in `useEmoteParser`:

```html
style="display:inline;vertical-align:middle;height:1.5em;"
```

Inline styles outrank every selector short of `!important`. So `1.5em` was not a default, it was a decision. Overlabels serves lego bricks; how tall someone's emotes are is not its call.

**Nothing changes visually.** The same three declarations now live in `BASE_OVERLAY_CSS` as a `.overlay-emote` rule. This just works now, with no `!important`:

```css
.overlay-emote { height: 1em; }
```

## Order is the whole mechanism

The base sheet is injected with `insertBefore(document.head.firstChild)`, **not** `appendChild`. At equal specificity the later rule wins, so the base sheet has to be first and the template's CSS has to land after it. Switching that to `appendChild` would silently reverse the entire change, which is why it is called out in a comment and pinned by a test.

Specificity covers the other direction: `.overlay-emote` is a class, so Tailwind preflight's `img { display: block }` cannot beat it regardless of ordering.

## Details

- **`1.5em` stays the default and earns it.** An `em` scales with the font-size of whatever the emote sits in, so a feed stays proportional at any overlay scale. A pixel default would break the moment someone resized their browser source.
- Twitch emotes still carry `twitch-emote` as a second class, so they can be sized separately from 7TV/BTTV/FFZ ones.
- **Badges are untouched.** They already shipped class-only (`ol-badge`) with the help page telling authors to size them; emotes simply predated that decision. This makes the two consistent rather than introducing a new convention.
- Help page documents the override.

## Tests

`GeneratedMarkupStylingTest` fails if inline styles reappear on generated markup - the tempting fix for "my emotes are the wrong size" is to reach for the nearest string template, and no visual test would object.

It is anchored to `<img ... style=` rather than a bare `style=`, because the first version tripped on the comment explaining why inline styles are avoided. Verified to fail when a style attribute is reintroduced.

It also asserts the classes still exist and that the defaults survive in the base sheet, since stripping the inline styles *without* providing the rule would change every existing overlay's appearance.

**1432 backend** (+4), **118 frontend**, plus `pint --test`, `typecheck`, `lint:check`, `format:check`.

Not covered: nobody has loaded an overlay and confirmed the emotes still look identical. The rule is byte-for-byte the same three declarations, but it is worth one glance after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
