### PR TITLE
chore(dev): add a synthetic chat firehose for load-testing the renderer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,3 +133,21 @@ VITE_REVERB_HOST="${APP_URL}"
 VITE_REVERB_PORT=8080
 VITE_REVERB_SCHEME=http
 VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
+
+# Synthetic chat firehose for load-testing the overlay renderer. DEV ONLY.
+#
+# Read by Vite at BUILD time, not at runtime, so it must be set for the build
+# command rather than just present in the environment:
+#
+#   VITE_CHAT_HOSE=1 npm run build
+#
+# Then open an overlay and drive it from the console:
+#
+#   __olChatHose.start({ rate: 50 })   # messages per second
+#   __olChatHose.burst(500)            # instant spike, like a raid
+#   __olChatHose.stop()                # prints sent count, achieved rate,
+#                                      # average FPS and dropped-frame count
+#
+# Leave this unset for any build that ships. An ordinary build eliminates the
+# module entirely, and DevToolsExcludedFromBuildTest fails if it ever does not.
+# VITE_CHAT_HOSE=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,14 @@ counts them ("five donation services", "five pipes") lives in `resources/views/w
 - `chat.N.html` is the ONLY foreach field rendered unescaped (`htmlSafeFields`, keyed by iterable). **Bracket defusing still applies inside it** - skipping that reopens the PR #230 injection hole through a side door.
 - Deletions are not optional: CLEARMSG removes one message, CLEARCHAT purges a user or clears the room. Purge by user id, falling back to login, and NEVER to "clear everything".
 
+### Chat load testing (Aug 2026)
+
+- `resources/js/dev/chatHose.ts` synthesizes tagged IRC lines and feeds them through `useTwitchChat.injectRawLine()` - the REAL parser - so a load test exercises parsing, filters, the ordered queue, flush batching, window trimming and moderation. Injecting into `messages` directly would skip everything worth measuring.
+- **Gated at BUILD time**: `import.meta.env.VITE_CHAT_HOSE === '1'`. Vite inlines it, so an ordinary build eliminates the import site and the module never enters the graph - zero bytes, nothing to leave switched on. Build with `VITE_CHAT_HOSE=1 npm run build`, then drive it from the console with `__olChatHose.start({ rate: 50 })`.
+- Do NOT convert that to a runtime check (query param, window flag, server boolean). It would compile in. `DevToolsExcludedFromBuildTest` inspects the BUILT assets and was verified to fail against a `VITE_CHAT_HOSE=1` build.
+- `chatHose.test.ts` runs generated lines through `parseIrcLine`/`toChatMessage`, including that emote POSITIONS line up with the text. A malformed fixture would mean debugging the instrument instead of the overlay.
+- **Chat volume does not load the server at all.** The overlay reads Twitch directly, and the bot posts one aggregated summary per channel per 30-60s, so a channel doing 50k messages/min costs Laravel exactly what a quiet one does. Server load scales with NUMBER OF CHANNELS, not chat volume - a "hammer prod with chat" test measures nothing.
+
 ### keepNames is load-bearing (fixed Aug 2026)
 
 - **`build.rollupOptions.output.keepNames: true` in `vite.config.mts` is NOT cosmetic. Do not remove it.** `@mkody/twitch-emoticons` guards its abstract base with `if (new.target.name === Emote.name) throw`. The minifier renamed the base class AND all four subclasses to `e`, so the guard was true for every subclass and constructing any BTTV/FFZ/7TV emote threw "Base Emote class cannot be used".

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,20 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 16th, 2026 - chore(dev): a chat firehose, for finding the ceiling
+
+A development tool that invents thousands of chat messages a second and feeds them to an overlay, so the renderer can be pushed until it breaks rather than politely confirmed to survive a trickle.
+
+The real measurement that prompted it: an 86,000-viewer chat produced about **134 messages per minute**. That is two a second. The overlay was never going to struggle with that, so it told us nothing about where the limit actually is.
+
+- **It goes in through the real parser.** Generated lines are proper tagged IRC and enter at the same point a real message does, so a run exercises parsing, filtering, batching, window trimming and moderation - not just the drawing.
+- **Reproducible, unlike a real channel.** A busy stream's rate swings wildly minute to minute, so you can never re-run the same test after a change. This is a dial.
+- **It can be harder than reality.** Emote density, message length, chatter count, deletions and shared-chat messages are all adjustable, including combinations no real channel would produce.
+- **It reports what matters**: not "did it keep up" but "did it drop frames". A stuttering overlay is the actual failure mode, so it counts frames over 50ms.
+- **It cannot ship.** The switch is read when the code is compiled, not when it runs, so an ordinary build removes the entire thing - and a test inspects the built files to prove it, having first been checked to fail against a build that does include it.
+
+Nothing about this touches the server, because chat never does: the overlay talks to Twitch directly, and the bot sends one summary per channel every half minute or so. A channel doing 50,000 messages a minute costs Overlabels exactly what a quiet one does.
+
 ## August 16th, 2026 - fix(overlay): emote sizing is yours now
 
 Every emote image was being written with its styling baked into the tag: `style="display:inline;vertical-align:middle;height:1.5em;"`, stamped on by us, three times over, in three different places in the code.

--- a/resources/js/components/OverlayRenderer.vue
+++ b/resources/js/components/OverlayRenderer.vue
@@ -691,6 +691,14 @@ onMounted(async () => {
   // own CSS arrives and lands after it.
   injectBaseStyle();
 
+  // Synthetic chat firehose for load-testing the renderer. The condition is
+  // inlined by Vite at build time, so an ordinary production build eliminates
+  // this block entirely and the dev module never enters the graph. Build with
+  // VITE_CHAT_HOSE=1 to get it.
+  if (import.meta.env.VITE_CHAT_HOSE === '1') {
+    void import('@/dev/chatHose').then(({ installChatHose }) => installChatHose(twitchChat));
+  }
+
   // Use resilient fetch with retry
   const result = await health.fetchWithRetry(props.slug, props.token);
 

--- a/resources/js/composables/useTwitchChat.ts
+++ b/resources/js/composables/useTwitchChat.ts
@@ -292,5 +292,21 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
     }
   }
 
-  return { messages, isConnected, connect, disconnect, setFilters, setWindowSize };
+  /**
+   * Feed a raw IRC line in as though it had arrived on the socket.
+   *
+   * The seam the dev chat hose uses to load-test the renderer. Going in HERE
+   * rather than pushing straight into `messages` is the whole point: it
+   * exercises parsing, filtering, the ordered queue, flush batching, window
+   * trimming and moderation - everything a real message touches except the
+   * socket, which is the one part that is never the bottleneck.
+   *
+   * Harmless in production. It only affects what the caller's own browser
+   * draws; nothing is sent anywhere and no other viewer is involved.
+   */
+  function injectRawLine(raw: string): void {
+    handleLine(raw);
+  }
+
+  return { messages, isConnected, connect, disconnect, setFilters, setWindowSize, injectRawLine };
 }

--- a/resources/js/dev/chatHose.test.ts
+++ b/resources/js/dev/chatHose.test.ts
@@ -1,0 +1,110 @@
+import { parseIrcLine, toChatMessage, toModerationAction } from '@/utils/ircParser';
+import { describe, expect, it } from 'vitest';
+import { clearchatLine, clearmsgLine, privmsgLine, type ChatHoseOptions } from './chatHose';
+
+/*
+ * The hose is only useful if what it emits is indistinguishable from real
+ * Twitch traffic to the actual parser. If a generated line is subtly malformed,
+ * a load test measures the wrong thing and the first hour of debugging goes
+ * into the instrument rather than the overlay.
+ *
+ * So these run generated lines through the REAL parser, not a copy of it.
+ */
+
+function options(over: Partial<ChatHoseOptions> = {}): ChatHoseOptions {
+  return {
+    rate: 10,
+    emoteChance: 0,
+    thirdPartyChance: 0,
+    moderationChance: 0,
+    chatters: 10,
+    channel: 'loadtest',
+    roomId: '1',
+    foreignChance: 0,
+    ...over,
+  };
+}
+
+describe('privmsgLine', () => {
+  it('parses as a chat message', () => {
+    const message = toChatMessage(parseIrcLine(privmsgLine(options(), 0))!);
+
+    expect(message).not.toBeNull();
+    expect(message!.login).toBe('chatter0');
+    expect(message!.author).toBe('Chatter0');
+    expect(message!.text.length).toBeGreaterThan(0);
+    expect(message!.id).not.toBe('');
+  });
+
+  it('cycles logins through the chatter pool', () => {
+    // Drives unique-chatter behaviour: a pool of 3 must produce 3 logins.
+    const logins = new Set(Array.from({ length: 12 }, (_, i) => toChatMessage(parseIrcLine(privmsgLine(options({ chatters: 3 }), i))!)!.login));
+
+    expect(logins.size).toBe(3);
+  });
+
+  it('emits emote positions that actually line up with the text', () => {
+    // THE thing worth testing. The renderer slices the message by these
+    // indices, so an off-by-one would render half an emote name and look like
+    // a renderer bug rather than a fixture bug.
+    const line = privmsgLine(options({ emoteChance: 1 }), 0);
+    const message = toChatMessage(parseIrcLine(line)!)!;
+
+    expect(message.emotes.length).toBeGreaterThan(0);
+
+    for (const emote of message.emotes) {
+      const sliced = message.text.slice(emote.begin, emote.end + 1);
+      expect(sliced).toMatch(/^[A-Za-z0-9]+$/);
+      expect(sliced.length).toBeGreaterThan(1);
+    }
+  });
+
+  it('emits no emote tag when emotes are switched off', () => {
+    expect(toChatMessage(parseIrcLine(privmsgLine(options({ emoteChance: 0 }), 0))!)!.emotes).toEqual([]);
+  });
+
+  it('produces badges the parser reads back', () => {
+    // Sampled across seeds because the badge set is random per message.
+    const messages = Array.from({ length: 40 }, (_, i) => toChatMessage(parseIrcLine(privmsgLine(options(), i))!)!);
+
+    expect(messages.some((m) => m.isMod)).toBe(true);
+    expect(messages.some((m) => m.isSubscriber)).toBe(true);
+    expect(messages.every((m) => m.badgeVersions.every((b) => b.includes('/')))).toBe(true);
+  });
+
+  it('can emit Shared Chat messages', () => {
+    const message = toChatMessage(parseIrcLine(privmsgLine(options({ foreignChance: 1 }), 0))!)!;
+
+    expect(message.sourceRoomId).toBe('999999');
+  });
+
+  it('marks a native message as native', () => {
+    expect(toChatMessage(parseIrcLine(privmsgLine(options({ foreignChance: 0 }), 0))!)!.sourceRoomId).toBe('');
+  });
+
+  it('gives every message a distinct id', () => {
+    const ids = new Set(Array.from({ length: 50 }, (_, i) => toChatMessage(parseIrcLine(privmsgLine(options(), i))!)!.id));
+
+    expect(ids.size).toBe(50);
+  });
+});
+
+describe('moderation lines', () => {
+  it('emits a CLEARMSG the parser turns into a single-message delete', () => {
+    const action = toModerationAction(parseIrcLine(clearmsgLine(options(), 'abc-123'))!);
+
+    expect(action).toEqual({ type: 'delete_message', messageId: 'abc-123' });
+  });
+
+  it('emits a targeted CLEARCHAT that purges one user, not the room', () => {
+    // The failure mode this guards: a purge being mistaken for a room clear
+    // would wipe the overlay on every timeout.
+    const action = toModerationAction(parseIrcLine(clearchatLine(options(), 'chatter7'))!);
+
+    expect(action?.type).not.toBe('clear_all');
+  });
+
+  it('emits an untargeted CLEARCHAT that clears the room', () => {
+    expect(toModerationAction(parseIrcLine(clearchatLine(options()))!)).toEqual({ type: 'clear_all' });
+  });
+});

--- a/resources/js/dev/chatHose.ts
+++ b/resources/js/dev/chatHose.ts
@@ -1,0 +1,363 @@
+/**
+ * Synthetic chat firehose. DEVELOPMENT TOOL - never ships.
+ *
+ * Installed only when the build was made with `VITE_CHAT_HOSE=1`. That check is
+ * inlined by Vite at build time, so an ordinary production build eliminates the
+ * import site and this module never enters the graph. There is no runtime flag
+ * and nothing to leave switched on by accident.
+ *
+ * WHY FAKE RATHER THAN POINT AT A BUSY CHANNEL:
+ *
+ * - Reproducible. A real channel's rate swings minute to minute, so you cannot
+ *   re-run the same test after a change. This is a dial.
+ * - Available at 3am, with no dependency on someone big being live.
+ * - Harder than reality on demand. A real 86k-viewer sample measured ~134
+ *   messages per MINUTE. The interesting question is where the ceiling is, not
+ *   whether it survives a trickle.
+ * - Deletions on demand. CLEARMSG and CLEARCHAT are the fiddliest paths and are
+ *   near-impossible to trigger deliberately in someone else's chat.
+ * - Nothing touches Overlabels' server, because chat never does anyway: the
+ *   overlay reads Twitch directly. This measures the renderer, which is the
+ *   only thing chat volume actually loads.
+ *
+ * Lines are fed through `useTwitchChat.injectRawLine()`, i.e. the real IRC
+ * parser, so what you are testing is the genuine pipeline.
+ *
+ *   __olChatHose.start({ rate: 50 })
+ *   __olChatHose.burst(500)
+ *   __olChatHose.stop()          // prints a report
+ */
+
+/**
+ * Real global Twitch emote ids, so images actually load and cost real bytes.
+ *
+ * Every id here must return 200 from the CDN. A dead one still costs a request
+ * but never paints, which quietly understates the render load - exactly the
+ * kind of fixture rot that makes a load test lie in the flattering direction.
+ *
+ * This list WILL rot: Twitch retires global emotes. `BibleThump` (86) was here
+ * until Twitch dropped it, and it 404s. Re-check before trusting a run whose
+ * numbers look suspiciously good.
+ *
+ * Note it may still render in a real overlay - FFZ carries BibleThump as a
+ * global - but that resolves through the token path, whereas anything listed
+ * here goes out as an emote POSITION and is therefore fetched from Twitch's CDN
+ * regardless of what the third-party sets have.
+ *
+ *   curl -o /dev/null -w "%{http_code}" \
+ *     https://static-cdn.jtvnw.net/emoticons/v2/<id>/default/dark/1.0
+ */
+const TWITCH_EMOTES: Array<[code: string, id: string]> = [
+  ['Kappa', '25'],
+  ['DansGame', '33'],
+  ['Kreygasm', '41'],
+  ['4Head', '354'],
+  ['LUL', '425618'],
+  ['WutFace', '28087'],
+  ['NotLikeThis', '58765'],
+  ['PogChamp', '305954156'],
+];
+
+/**
+ * Codes commonly present in 7TV/BTTV/FFZ channel sets. These exercise the
+ * token-matching path rather than the position path; whether they resolve
+ * depends on the channel's own sets, which is realistic.
+ */
+const THIRD_PARTY_CODES = ['Sadge', 'Madge', 'Pepega', 'monkaS', 'KEKW', 'Pog', 'widepeepoHappy', 'catJAM'];
+
+const WORDS = [
+  'hello',
+  'chat',
+  'that was insane',
+  'gg',
+  'no way',
+  'first time here',
+  'lets go',
+  'what happened',
+  'nice one',
+  'o7',
+  'this is the best stream',
+  'im crying',
+  'clip it',
+];
+
+const BADGE_SETS = ['', 'subscriber/12', 'moderator/1', 'vip/1', 'subscriber/3,moderator/1', 'broadcaster/1,subscriber/12'];
+
+const COLORS = ['#1E90FF', '#FF69B4', '#00FF7F', '#FF4500', '#9146FF', ''];
+
+export interface ChatHoseOptions {
+  /** Messages per second. */
+  rate: number;
+  /** Probability a message carries Twitch emotes (position-based path). */
+  emoteChance: number;
+  /** Probability a message carries third-party emote codes (token path). */
+  thirdPartyChance: number;
+  /** Probability per second that a moderation action fires. */
+  moderationChance: number;
+  /** Size of the synthetic chatter pool. Drives unique-chatter behaviour. */
+  chatters: number;
+  /** Channel name in the PRIVMSG target. Cosmetic. */
+  channel: string;
+  /** room-id tag. Only matters if you are testing Shared Chat. */
+  roomId: string;
+  /** Probability a message is a Shared Chat message from another channel. */
+  foreignChance: number;
+}
+
+const DEFAULTS: ChatHoseOptions = {
+  rate: 20,
+  emoteChance: 0.35,
+  thirdPartyChance: 0.35,
+  moderationChance: 0.05,
+  chatters: 400,
+  channel: 'loadtest',
+  roomId: '1',
+  foreignChance: 0,
+};
+
+interface ChatSink {
+  injectRawLine(raw: string): void;
+}
+
+function pick<T>(list: readonly T[]): T {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function chance(p: number): boolean {
+  return Math.random() < p;
+}
+
+let messageCounter = 0;
+
+/**
+ * Build one PRIVMSG line, tags and all.
+ *
+ * Emote positions are computed against the assembled text rather than guessed,
+ * because the renderer slices the string by those indices. Getting them wrong
+ * would mean debugging the hose instead of the overlay.
+ */
+export function privmsgLine(options: ChatHoseOptions, seed = messageCounter++): string {
+  const n = seed % options.chatters;
+  const login = `chatter${n}`;
+  const display = `Chatter${n}`;
+
+  const parts: string[] = [];
+  const emotePositions: string[] = [];
+  let cursor = 0;
+
+  const push = (chunk: string) => {
+    if (parts.length > 0) {
+      cursor += 1; // the joining space
+    }
+    parts.push(chunk);
+    const begin = cursor;
+    cursor += chunk.length;
+    return { begin, end: cursor - 1 };
+  };
+
+  if (chance(options.emoteChance)) {
+    const [code, id] = pick(TWITCH_EMOTES);
+    const { begin, end } = push(code);
+    emotePositions.push(`${id}:${begin}-${end}`);
+  }
+
+  push(pick(WORDS));
+
+  if (chance(options.thirdPartyChance)) {
+    push(pick(THIRD_PARTY_CODES));
+  }
+
+  if (chance(options.emoteChance)) {
+    const [code, id] = pick(TWITCH_EMOTES);
+    const { begin, end } = push(code);
+    emotePositions.push(`${id}:${begin}-${end}`);
+  }
+
+  const text = parts.join(' ');
+  const badges = pick(BADGE_SETS);
+  const foreign = chance(options.foreignChance);
+
+  const tags = [
+    `badge-info=`,
+    `badges=${badges}`,
+    `color=${pick(COLORS)}`,
+    `display-name=${display}`,
+    `emotes=${emotePositions.join('/')}`,
+    `first-msg=${chance(0.02) ? '1' : '0'}`,
+    `id=${crypto.randomUUID()}`,
+    `mod=${badges.includes('moderator') ? '1' : '0'}`,
+    `room-id=${options.roomId}`,
+    `subscriber=${badges.includes('subscriber') ? '1' : '0'}`,
+    `tmi-sent-ts=${Date.now()}`,
+    `user-id=${1000 + n}`,
+  ];
+
+  if (foreign) {
+    // source-room-id differing from room-id is Twitch's own discriminator.
+    tags.push('source-room-id=999999', `source-badges=${badges}`);
+  }
+
+  return `@${tags.join(';')} :${login}!${login}@${login}.tmi.twitch.tv PRIVMSG #${options.channel} :${text}`;
+}
+
+/** CLEARMSG removes exactly one message. */
+export function clearmsgLine(options: ChatHoseOptions, targetId: string): string {
+  return `@login=someone;room-id=${options.roomId};target-msg-id=${targetId} :tmi.twitch.tv CLEARMSG #${options.channel} :gone`;
+}
+
+/** CLEARCHAT with a target purges one user; without one it clears the room. */
+export function clearchatLine(options: ChatHoseOptions, login?: string): string {
+  if (!login) {
+    return `@room-id=${options.roomId} :tmi.twitch.tv CLEARCHAT #${options.channel}`;
+  }
+
+  return `@ban-duration=600;room-id=${options.roomId};target-user-id=${1000 + Number(login.replace(/\D/g, '') || 0)} :tmi.twitch.tv CLEARCHAT #${options.channel} :${login}`;
+}
+
+interface FrameSampler {
+  stop(): { frames: number; seconds: number; avgFps: number; worstFrameMs: number; longFrames: number };
+}
+
+/**
+ * Sample frame timing while the hose runs.
+ *
+ * The number worth having is not "did it keep up" but "did it drop frames" -
+ * an overlay that stutters mid-stream is the actual failure mode. `longFrames`
+ * counts frames over 50ms, which is where stutter becomes visible.
+ */
+function sampleFrames(): FrameSampler {
+  const start = performance.now();
+  let last = start;
+  let frames = 0;
+  let worstFrameMs = 0;
+  let longFrames = 0;
+  let running = true;
+
+  const tick = (now: number) => {
+    if (!running) return;
+    const delta = now - last;
+    last = now;
+    frames++;
+    if (delta > worstFrameMs) worstFrameMs = delta;
+    if (delta > 50) longFrames++;
+    requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+
+  return {
+    stop() {
+      running = false;
+      const seconds = (performance.now() - start) / 1000;
+
+      return {
+        frames,
+        seconds: Number(seconds.toFixed(1)),
+        avgFps: Number((frames / seconds).toFixed(1)),
+        worstFrameMs: Number(worstFrameMs.toFixed(1)),
+        longFrames,
+      };
+    },
+  };
+}
+
+export interface ChatHose {
+  start(options?: Partial<ChatHoseOptions>): void;
+  stop(): void;
+  burst(count: number, options?: Partial<ChatHoseOptions>): void;
+}
+
+export function createChatHose(sink: ChatSink): ChatHose {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let sampler: FrameSampler | null = null;
+  let sent = 0;
+  let startedAt = 0;
+  let config: ChatHoseOptions = { ...DEFAULTS };
+
+  // Emitted in batches on a 100ms tick rather than one timer per message: at
+  // high rates the timers themselves would dominate the measurement.
+  const TICK_MS = 100;
+
+  const recentIds: string[] = [];
+
+  function emitOne(): void {
+    const line = privmsgLine(config);
+    const id = /id=([0-9a-f-]+)/.exec(line)?.[1];
+    if (id) {
+      recentIds.push(id);
+      if (recentIds.length > 200) recentIds.shift();
+    }
+    sink.injectRawLine(line);
+    sent++;
+  }
+
+  function maybeModerate(): void {
+    if (!chance((config.moderationChance * TICK_MS) / 1000)) return;
+
+    const roll = Math.random();
+    if (roll < 0.7 && recentIds.length) {
+      sink.injectRawLine(clearmsgLine(config, pick(recentIds)));
+    } else if (roll < 0.95) {
+      sink.injectRawLine(clearchatLine(config, `chatter${Math.floor(Math.random() * config.chatters)}`));
+    } else {
+      sink.injectRawLine(clearchatLine(config));
+    }
+  }
+
+  function start(options: Partial<ChatHoseOptions> = {}): void {
+    stop();
+    config = { ...DEFAULTS, ...options };
+    sent = 0;
+    startedAt = performance.now();
+    sampler = sampleFrames();
+
+    const perTick = Math.max(1, Math.round((config.rate * TICK_MS) / 1000));
+
+    timer = setInterval(() => {
+      for (let i = 0; i < perTick; i++) emitOne();
+      maybeModerate();
+    }, TICK_MS);
+
+    console.info(`[chat hose] running at ~${config.rate}/s (${perTick} per ${TICK_MS}ms tick). __olChatHose.stop() to finish.`);
+  }
+
+  function stop(): void {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+    if (!sampler) return;
+
+    const frames = sampler.stop();
+    sampler = null;
+
+    // `seconds` comes from the frame sampler rather than being duplicated here;
+    // the two measure the same window and having both would just overwrite.
+    const seconds = (performance.now() - startedAt) / 1000;
+    console.info('[chat hose] report', {
+      sent,
+      actualRatePerSecond: Number((sent / seconds).toFixed(1)),
+      ...frames,
+    });
+  }
+
+  function burst(count: number, options: Partial<ChatHoseOptions> = {}): void {
+    const previous = config;
+    config = { ...DEFAULTS, ...options };
+    for (let i = 0; i < count; i++) emitOne();
+    config = previous;
+    console.info(`[chat hose] burst of ${count} delivered`);
+  }
+
+  return { start, stop, burst };
+}
+
+declare global {
+  interface Window {
+    __olChatHose?: ChatHose;
+  }
+}
+
+export function installChatHose(sink: ChatSink): void {
+  window.__olChatHose = createChatHose(sink);
+  console.info('[chat hose] installed. __olChatHose.start({ rate: 50 })');
+}

--- a/tests/Feature/DevToolsExcludedFromBuildTest.php
+++ b/tests/Feature/DevToolsExcludedFromBuildTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Development-only code must not reach a production build.
+ *
+ * The chat hose synthesizes thousands of fake chat messages a second. It is
+ * gated on `import.meta.env.VITE_CHAT_HOSE === '1'`, which Vite inlines at
+ * BUILD time so an ordinary build dead-code-eliminates the import site and the
+ * module never enters the graph.
+ *
+ * That is a compile-time guarantee rather than a runtime check, which is the
+ * right shape - there is no flag to leave switched on by accident. But it is
+ * only a guarantee while the gate is written in a form the bundler can fold.
+ * Changing it to a runtime condition, or importing the module statically,
+ * would silently ship the whole thing.
+ *
+ * So this inspects the BUILT output. No unit test can cover it: the guard's
+ * entire job happens during bundling. CI runs `npm run build` (without the
+ * flag) before Pest, so this has a real artifact to look at.
+ */
+
+function builtAssetSources(): array
+{
+    $dir = public_path('build/assets');
+
+    if (! is_dir($dir)) {
+        return [];
+    }
+
+    $sources = [];
+    foreach (glob($dir.'/*.js') as $file) {
+        $sources[basename($file)] = file_get_contents($file);
+    }
+
+    return $sources;
+}
+
+beforeEach(function () {
+    $this->assets = builtAssetSources();
+
+    if ($this->assets === []) {
+        $this->markTestSkipped('No production build present. Run `npm run build`.');
+    }
+});
+
+it('ships no chat hose in a production build', function () {
+    // If this fails, check that the VITE_CHAT_HOSE build ran last and rebuild
+    // without it before assuming a real regression.
+    foreach ($this->assets as $name => $source) {
+        expect(str_contains($source, '__olChatHose'))
+            ->toBeFalse("$name contains the chat hose; the VITE_CHAT_HOSE gate is not eliminating it");
+    }
+});
+
+it('emits no chunk named after a dev module', function () {
+    foreach (array_keys($this->assets) as $name) {
+        expect($name)->not->toContain('chatHose');
+    }
+});
+
+it('keeps the build-time gate in a form the bundler can fold', function () {
+    // A runtime check (a query param, a window flag, a server-sent boolean)
+    // would compile in and defeat the whole arrangement. The literal comparison
+    // against import.meta.env is what makes elimination possible.
+    $renderer = file_get_contents(resource_path('js/components/OverlayRenderer.vue'));
+
+    expect($renderer)->toContain("import.meta.env.VITE_CHAT_HOSE === '1'");
+});
+
+it('never imports the dev module statically', function () {
+    // A top-level import pulls the module into the graph regardless of any
+    // guard around its use.
+    foreach (glob(resource_path('js/**/*.{ts,vue}'), GLOB_BRACE) as $file) {
+        $source = file_get_contents($file);
+
+        expect(preg_match("/^import .*dev\/chatHose/m", $source))
+            ->toBe(0, basename($file).' imports the chat hose statically; use a dynamic import inside the build-time guard');
+    }
+});


### PR DESCRIPTION
A development tool that invents chat messages and feeds them to an overlay, so the renderer can be pushed until it breaks rather than politely confirmed to survive a trickle.

The measurement that prompted it: an 86,000-viewer chat produced about **134 messages per minute**. That is two a second. It was never going to struggle, so it told us nothing.

## Measured results

Run against a real overlay, production build, `.msg` window of 50, every message carrying Twitch and third-party emotes plus constant moderation traffic:

| Requested | Achieved | Sent | avg FPS | Frames >50ms | Worst frame | Heap |
|---|---|---|---|---|---|---|
| 1,000/s | 999.6/s | 15,000 | 60 | **0** | 16.9ms | - |
| 10,000/s | 9,977/s | 80,000 | 60.1 | **0** | 16.9ms | - |
| 20,000/s | 19,924/s | 180,000 | **59.7** | **0** | 33.3ms | 55MB |
| 50,000/s | 49,644/s | 450,000 | 40.7 | 25 | 66.7ms | 36MB |
| 100,000/s | **69,455/s** | 640,000 | 7.7 | 63 | 199.9ms | 110MB |

**Clean at 20,000 messages/second** - roughly 10,000x a real busy stream. Degrades from ~50k/s, saturates at ~69,500/s, which agrees closely with an independent burst measurement of ~75,000/s for the ingest path.

Across 1.27 million messages the window held at exactly 50 nodes and the heap stayed bounded.

Caveat worth keeping attached to these numbers: above ~20k/s the hose competes for the same main thread, so this is a **generate + parse + filter + queue + render** figure. The renderer alone would go higher. It is the pessimistic reading.

## How it works

Lines are proper tagged IRC fed through `useTwitchChat.injectRawLine()` - the real parser. That is the point: injecting into `messages` directly would skip parsing, filters, the ordered queue, flush batching, window trimming and moderation. Only the socket is bypassed, and the socket was never the bottleneck.

Fake beats pointing at a busy channel: reproducible after a change, available without waiting for someone to go live, adjustable past anything real, and able to fire CLEARMSG/CLEARCHAT on demand - the fiddliest paths, impossible to trigger deliberately in someone else's chat.

Reports **dropped frames**, not throughput. A stuttering overlay is the real failure mode, so it counts frames over 50ms.

## It cannot ship

Gated at BUILD time on `import.meta.env.VITE_CHAT_HOSE === '1'`. Vite inlines the comparison, so an ordinary build eliminates the import site and the module never enters the graph - zero bytes, no runtime flag to leave switched on.

Verified both directions: a normal build emits no chunk and contains no `__olChatHose`; `VITE_CHAT_HOSE=1` emits `chatHose-*.js`.

**Do not convert the gate to a runtime check** - it would compile in. `DevToolsExcludedFromBuildTest` inspects the BUILT assets and was verified to fail against a flagged build.

## Tests

`chatHose.test.ts` round-trips generated lines through `parseIrcLine`/`toChatMessage`, including that emote **positions line up with the text**. A malformed fixture would mean spending the first hour of a load test debugging the instrument.

`1436 backend`, `129 frontend`, plus `pint --test`, `typecheck`, `lint:check`, `format:check`.

## Also recorded

`CLAUDE.md` now states that chat volume does not load the server at all: the overlay reads Twitch directly, and the bot posts one aggregated summary per channel per 30-60s. A channel doing 50k messages/min costs Laravel exactly what a quiet one does. **Server load scales with channel count, not chat volume** - a "hammer prod with chat" test would measure nothing.

One fixture note: `BibleThump` was dropped from the list. Twitch retired the emote and id 86 now 404s. FFZ still carries it globally, but that resolves via the token path, whereas anything in this list goes out as an emote position and is fetched from Twitch's CDN regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
