### PR TITLE
fix(security): rate limit template creation, and cap the kit fork amplifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ php artisan pint         # PHP code style fixes
 CI runs the check-mode variants (`pint --test`, `format:check`, `lint:check`) plus `npm test`,
 `npm run typecheck` and `pest`. All of them must pass before a PR merges.
 
+Never use bash heredoc (<<EOF) to write files. Always use the Write or Edit tool directly.
+
 ### Build & Deploy
 ```bash
 npm run build            # Production build

--- a/app/Http/Controllers/KitController.php
+++ b/app/Http/Controllers/KitController.php
@@ -64,7 +64,7 @@ class KitController extends Controller
             'description' => 'nullable|string|max:1000',
             'is_public' => 'required|boolean',
             'thumbnail_url' => 'nullable|url',
-            'template_ids' => 'required|array|min:1',
+            'template_ids' => 'required|array|min:1|max:'.Kit::MAX_TEMPLATES,
             'template_ids.*' => 'exists:overlay_templates,id',
         ]);
 
@@ -187,7 +187,7 @@ class KitController extends Controller
             'description' => 'nullable|string|max:1000',
             'is_public' => 'required|boolean',
             'thumbnail_url' => 'nullable|url',
-            'template_ids' => 'required|array|min:1',
+            'template_ids' => 'required|array|min:1|max:'.Kit::MAX_TEMPLATES,
             'template_ids.*' => 'exists:overlay_templates,id',
         ]);
 

--- a/app/Models/Kit.php
+++ b/app/Models/Kit.php
@@ -61,6 +61,20 @@ class Kit extends Model
 {
     use HasFactory;
 
+    /**
+     * Most templates a kit may hold.
+     *
+     * This is a rate-limiting concern, not a product one. fork() loops the kit's
+     * templates and forks each, so one request to kits.fork creates as many rows
+     * (and burns as many slugs) as the kit holds. Without a ceiling that request
+     * is an unbounded write amplifier, and a per-request throttle cannot cap
+     * something whose per-request cost is unbounded.
+     *
+     * 50 is deliberately far above real use: the largest kit that exists holds
+     * 9 templates and the heaviest user owns 27 in total.
+     */
+    public const MAX_TEMPLATES = 50;
+
     protected $fillable = [
         'owner_id',
         'title',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -176,6 +176,41 @@ class AppServiceProvider extends ServiceProvider
                 });
         });
 
+        // Template creation. Every one of these writes a row and burns a slug,
+        // and until Aug 2026 none of them were limited at all: the only guard on
+        // templates.store and templates.fork was "are you logged in". The other
+        // limiters here all face the overlay-serving and bot-ingress side, so
+        // nothing covered authoring. Keyed per user because creating a template
+        // requires a session, so the Twitch account is the real identity; the IP
+        // fallback is only there for safety if that ever stops being true.
+        // 30/min is far above what a person clicking Copy can manage and far
+        // below what a script does, and the hourly bucket is what actually caps
+        // sustained abuse.
+        RateLimiter::for('template-write', function (Request $request) {
+            $key = $request->user()?->id ?: $request->ip();
+
+            return [
+                Limit::perMinute(30)->by('template-write:'.$key),
+                Limit::perHour(200)->by('template-write:'.$key),
+            ];
+        });
+
+        // Forking a kit is the amplified path: Kit::fork() loops the kit's
+        // templates and forks each one, so a single request creates as many rows
+        // as the kit holds rather than one. Kits are capped at 50 templates
+        // (KitController), so this bucket is deliberately much tighter than
+        // template-write - 10/hour * 50 is already 500 rows. Forking a kit is
+        // also a rare deliberate act: the largest kit in existence holds 9
+        // templates and onboarding forks the starter kit exactly once.
+        RateLimiter::for('kit-fork', function (Request $request) {
+            $key = $request->user()?->id ?: $request->ip();
+
+            return [
+                Limit::perMinute(3)->by('kit-fork:'.$key),
+                Limit::perHour(10)->by('kit-fork:'.$key),
+            ];
+        });
+
         Event::listen(function (SocialiteWasCalled $event) {
             $event->extendSocialite('twitch', Provider::class);
         });

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,18 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 18th, 2026 - fix(security): nothing at all rate limited template creation
+
+Found while answering an idle question about the slug generator: what happens if someone exhausts the slug space? The answer turned out not to be about slugs. **Creating a template was limited by nothing.** `templates.store` and `templates.fork` carried exactly two middlewares, `web` and `RedirectIfUnauthenticated`, and there is no global throttle on the `web` group. The only guard was being logged in.
+
+The seven limiters that do exist all face the other way. `overlay`, `overlay-api`, `overlay-auth-failed`, `overlay-report` guard overlay serving; `cloudinary-upload` guards uploads; `bot-internal` and `bot-gamejam-action` guard bot ingress. Every one is on reads and ingress. Authoring had nothing, and neither did `lockdown`, which is wired across `routes/api.php` and absent from every creation path.
+
+- **`template-write`: 30/minute and 200/hour, keyed per user.** Creating a template requires a session, so the Twitch account is the real identity and the IP fallback is only there in case that stops being true. `templates.store` and `templates.fork` share one bucket deliberately, so the two routes cannot be alternated to double the rate.
+- **`kit-fork` is much tighter at 3/minute and 10/hour, because it is the amplified path.** `Kit::fork()` loops the kit's templates and forks each one, so a single request writes as many rows as the kit holds rather than one. A per-request throttle cannot cap a request whose cost is unbounded, which is the actual reason the second limiter exists rather than reusing the first.
+- **Kits are capped at 50 templates** (`Kit::MAX_TEMPLATES`). `template_ids` validated `min:1` with no `max`, so the amplifier had no ceiling: create N templates, put all N in a kit, then fork it repeatedly. The cap is what makes the `kit-fork` numbers mean anything. 50 is far above real use, where the largest kit that exists holds 9 templates and the heaviest account owns 27 in total.
+- **Slug exhaustion was never the risk, and it is worth saying why.** It takes ~2.7 million templates before slugs even begin growing numeric suffixes, and the generator degrades rather than failing: simulated past 16x total saturation of the base space it never threw once, because the `-NN` retry path multiplies the space by 90. Millions of rows carrying HTML and CSS would wreck disk and the nightly `pg_dump` long before a slug ran out. The gap was unbounded authenticated row creation; slugs were just the symptom that happened to get asked about.
+- **Seven tests pin it, and six were verified to fail without the fix.** They cover the ceiling on each route, that the buckets are per user so one account cannot starve another, that the two template routes share a budget while kit forking has its own, and the kit cap in both directions.
+
 ## August 18th, 2026 - chore(db): drop overlay_hashes, dead since April and unreferenced since this morning
 
 `overlay_hashes` was the original hash-based public-link scheme, superseded by `OverlayAccessToken` and its 64-char fragment token. The April 13th cleanup deleted the model, the controller and the factory, and deliberately kept the migrations because the table still held historical state on existing deployments. What that cleanup could not see was that one reader survived it: `FunSlugGenerationService` was still checking slug uniqueness against this table, four months after slugs had moved to `overlay_templates`. Repointing that check in the entry below left the table referenced by nothing at all.

--- a/routes/web.php
+++ b/routes/web.php
@@ -596,7 +596,8 @@ Route::middleware('auth.redirect')->group(function () {
     Route::prefix('templates')->name('templates.')->group(function () {
         Route::get('/', [OverlayTemplateController::class, 'index'])->name('index');
         Route::get('/create', [OverlayTemplateController::class, 'create'])->name('create');
-        Route::post('/', [OverlayTemplateController::class, 'store'])->name('store');
+        Route::post('/', [OverlayTemplateController::class, 'store'])
+            ->middleware('throttle:template-write')->name('store');
         // Block routes must precede the {template} wildcard.
         Route::get('/blocks/library', [OverlayTemplateController::class, 'blockLibrary'])->name('blocks.library');
         Route::get('/blocks/{template}/snapshot', [OverlayTemplateController::class, 'blockSnapshot'])->name('blocks.snapshot');
@@ -604,7 +605,8 @@ Route::middleware('auth.redirect')->group(function () {
         Route::get('/{template}/edit', [OverlayTemplateController::class, 'edit'])->name('edit');
         Route::put('/{template}', [OverlayTemplateController::class, 'update'])->name('update');
         Route::delete('/{template}', [OverlayTemplateController::class, 'destroy'])->name('destroy');
-        Route::post('/{template}/fork', [OverlayTemplateController::class, 'fork'])->name('fork');
+        Route::post('/{template}/fork', [OverlayTemplateController::class, 'fork'])
+            ->middleware('throttle:template-write')->name('fork');
         Route::put('/{template}/target-overlays', [OverlayTemplateController::class, 'updateTargetOverlays'])->name('target-overlays');
         Route::put('/{template}/triggers', [OverlayTemplateController::class, 'updateTriggers'])->name('triggers');
         Route::put('/{template}/screenshot', [OverlayTemplateController::class, 'updateScreenshot'])->name('screenshot');
@@ -653,7 +655,8 @@ Route::middleware('auth.redirect')->group(function () {
         Route::get('/{kit}/edit', [KitController::class, 'edit'])->name('edit');
         Route::put('/{kit}', [KitController::class, 'update'])->name('update');
         Route::delete('/{kit}', [KitController::class, 'destroy'])->name('destroy');
-        Route::post('/{kit}/fork', [KitController::class, 'fork'])->name('fork');
+        Route::post('/{kit}/fork', [KitController::class, 'fork'])
+            ->middleware('throttle:kit-fork')->name('fork');
     });
 
     // Trigger overview - read-only matrix; per-template editing lives on

--- a/tests/Feature/TemplateCreationRateLimitTest.php
+++ b/tests/Feature/TemplateCreationRateLimitTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use App\Models\Kit;
+use App\Models\OverlayTemplate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\RateLimiter;
+
+uses(DatabaseTransactions::class);
+
+// Every route here writes an overlay_templates row and burns a slug. Until
+// Aug 2026 none of them were limited at all: the only guard was "are you logged
+// in", and every other limiter in AppServiceProvider faces the overlay-serving
+// or bot-ingress side. These tests exist so that cannot silently come back.
+
+beforeEach(function () {
+    RateLimiter::clear('template-write');
+    RateLimiter::clear('kit-fork');
+});
+
+function rlUser(array $attrs = []): User
+{
+    return User::factory()->create(array_merge([
+        'twitch_id' => (string) fake()->unique()->randomNumber(9),
+    ], $attrs));
+}
+
+function templatePayload(): array
+{
+    return ['name' => 'Test overlay', 'html' => '<div></div>', 'type' => 'static'];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// templates.store
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('creating templates is rate limited', function () {
+    $this->actingAs(rlUser());
+
+    // The limiter allows 30/minute per user; the 31st is the one that must fail.
+    foreach (range(1, 30) as $i) {
+        $this->post(route('templates.store'), templatePayload())->assertRedirect();
+    }
+
+    $this->post(route('templates.store'), templatePayload())->assertStatus(429);
+
+    expect(OverlayTemplate::count())->toBe(30);
+});
+
+test('the template limit is per user, so one account cannot starve another', function () {
+    $this->actingAs($first = rlUser());
+    foreach (range(1, 30) as $i) {
+        $this->post(route('templates.store'), templatePayload())->assertRedirect();
+    }
+    $this->post(route('templates.store'), templatePayload())->assertStatus(429);
+
+    // A different account is unaffected by the first one hitting its ceiling.
+    $this->actingAs(rlUser());
+    $this->post(route('templates.store'), templatePayload())->assertRedirect();
+
+    expect(OverlayTemplate::where('owner_id', $first->id)->count())->toBe(30)
+        ->and(OverlayTemplate::count())->toBe(31);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// templates.fork
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('copying a template shares the same budget as creating one', function () {
+    $this->actingAs(rlUser());
+    $source = OverlayTemplate::factory()->create([
+        'owner_id' => rlUser()->id, 'fork_of_id' => null, 'is_public' => true, 'type' => 'static',
+    ]);
+
+    // Spend the whole minute budget on stores, then a copy must still be refused:
+    // both routes draw on one bucket, so they cannot be used to double the rate.
+    foreach (range(1, 30) as $i) {
+        $this->post(route('templates.store'), templatePayload())->assertRedirect();
+    }
+
+    $this->post(route('templates.fork', $source))->assertStatus(429);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// kits.fork - the amplified path
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('forking a kit is limited far more tightly, because one request writes many rows', function () {
+    $owner = rlUser();
+    $kit = Kit::factory()->create(['owner_id' => $owner->id, 'is_public' => true]);
+    $kit->templates()->attach(
+        OverlayTemplate::factory()->count(3)->create([
+            'owner_id' => $owner->id, 'fork_of_id' => null, 'type' => 'static',
+        ])->pluck('id')
+    );
+
+    $this->actingAs(rlUser());
+
+    // 3/minute, so the fourth fails. Each success writes 3 template rows.
+    foreach (range(1, 3) as $i) {
+        $this->post(route('kits.fork', $kit))->assertRedirect();
+    }
+
+    $this->post(route('kits.fork', $kit))->assertStatus(429);
+});
+
+test('kit forking has its own bucket and does not consume the template budget', function () {
+    $owner = rlUser();
+    $kit = Kit::factory()->create(['owner_id' => $owner->id, 'is_public' => true]);
+    $kit->templates()->attach(
+        OverlayTemplate::factory()->create([
+            'owner_id' => $owner->id, 'fork_of_id' => null, 'type' => 'static',
+        ])->id
+    );
+
+    $this->actingAs(rlUser());
+
+    foreach (range(1, 3) as $i) {
+        $this->post(route('kits.fork', $kit))->assertRedirect();
+    }
+    $this->post(route('kits.fork', $kit))->assertStatus(429);
+
+    // Exhausting kit-fork must not lock someone out of ordinary authoring.
+    $this->post(route('templates.store'), templatePayload())->assertRedirect();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// The amplifier itself
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('a kit cannot hold more templates than the fork limit assumes', function () {
+    $user = rlUser();
+    $ids = OverlayTemplate::factory()->count(Kit::MAX_TEMPLATES + 1)->create([
+        'owner_id' => $user->id, 'fork_of_id' => null, 'type' => 'static',
+    ])->pluck('id')->all();
+
+    // Without this ceiling, kits.fork has an unbounded per-request cost and no
+    // per-request throttle can cap it.
+    $this->actingAs($user)
+        ->post(route('kits.store'), [
+            'title' => 'Oversized', 'description' => '', 'is_public' => false, 'template_ids' => $ids,
+        ])
+        ->assertSessionHasErrors('template_ids');
+
+    expect(Kit::where('title', 'Oversized')->exists())->toBeFalse();
+});
+
+test('a kit at exactly the ceiling is still allowed', function () {
+    $user = rlUser();
+    $ids = OverlayTemplate::factory()->count(Kit::MAX_TEMPLATES)->create([
+        'owner_id' => $user->id, 'fork_of_id' => null, 'type' => 'static',
+    ])->pluck('id')->all();
+
+    $this->actingAs($user)
+        ->post(route('kits.store'), [
+            'title' => 'At the line', 'description' => '', 'is_public' => false, 'template_ids' => $ids,
+        ])
+        ->assertSessionHasNoErrors();
+
+    expect(Kit::where('title', 'At the line')->first()->templates()->count())
+        ->toBe(Kit::MAX_TEMPLATES);
+});


### PR DESCRIPTION
Found while answering an idle question about the slug generator: what happens if someone exhausts the slug space? The answer turned out not to be about slugs.

## Creating a template was limited by nothing

`templates.store` and `templates.fork` carried exactly two middlewares:

```
POST templates
  ⇂ web
  ⇂ App\Http\Middleware\RedirectIfUnauthenticated
```

No throttle, and no global one on the `web` group either. The only guard was being logged in.

The seven limiters that already exist all face the other way:

| limiter | guards |
| --- | --- |
| `overlay`, `overlay-api`, `overlay-auth-failed`, `overlay-report` | overlay serving |
| `cloudinary-upload` | uploads |
| `bot-internal`, `bot-gamejam-action` | bot ingress |

Every one is on reads and ingress. Authoring had none. `lockdown` is the same story: wired across `routes/api.php`, absent from every creation path. There is also no per-user template quota anywhere; the only cap in the codebase is 50 controls *per template*.

## The fix

- **`template-write`: 30/minute, 200/hour, keyed per user.** Creating a template requires a session, so the Twitch account is the real identity; the IP fallback is only there in case that stops being true. `templates.store` and `templates.fork` share one bucket deliberately, so the two routes cannot be alternated to double the rate.
- **`kit-fork`: 3/minute, 10/hour** — much tighter, because it is the amplified path. `Kit::fork()` loops the kit's templates and forks each one, so a single request writes as many rows as the kit holds rather than one. A per-request throttle cannot cap a request whose per-request cost is unbounded, which is why this is a separate bucket rather than a reuse of the first.
- **`Kit::MAX_TEMPLATES = 50`.** `template_ids` validated `min:1` with **no `max`**, so the amplifier had no ceiling at all: create N templates, put all N in one kit, fork it repeatedly. The cap is what makes the `kit-fork` numbers mean anything. 50 is far above real use — the largest kit that exists holds 9 templates, and the heaviest account owns 27 in total.

## Slug exhaustion was never the risk

Worth recording, since it is what prompted the look. It takes roughly **2.7 million templates** before slugs even begin growing numeric suffixes, and the generator degrades rather than failing. Simulated past 16x total saturation of the base space it never threw once, because the `-NN` retry path multiplies the space by 90:

```
created         bare%   suffixed%  fallback%  throws
1x the space    90.0    10.0       0.0        0
2x              10.0    90.0       0.0        0
16x             0.0     100.0      0.0        0
```

Millions of rows carrying HTML and CSS bodies would wreck disk and the nightly `pg_dump` long before a slug ran out. The real gap was unbounded authenticated row creation; slugs were just the symptom that happened to get asked about.

## Testing

Seven tests in `TemplateCreationRateLimitTest`, **six of them verified to fail** with the throttles removed and the kit cap raised. They cover the ceiling on each route, that buckets are per user so one account cannot starve another, that the two template routes share a budget while kit forking has its own, and the kit cap in both directions (over the line rejected, exactly on the line allowed).

Full suite: 1454 passed, 6 skipped, 0 failures. Pint clean.

## One thing found but not fixed

`KitController::store()` reads `$validated['description']` unconditionally, but the rule is `nullable` — an absent key is not in `validated()`, so `POST /kits` without a `description` field 500s. Unreachable through the UI, because `useForm` initialises `description: ''` and always sends it, so this is latent and only reachable by a direct API call. Out of scope here and left alone.

Also carries one unrelated commit: the `CLAUDE.md` heredoc rule, authored during the previous session and previously uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
