### PR TITLE
fix(api): guard reads of optional validated keys in two controllers

### DIFF
--- a/app/Http/Controllers/Admin/AdminUpdateController.php
+++ b/app/Http/Controllers/Admin/AdminUpdateController.php
@@ -48,7 +48,7 @@ class AdminUpdateController extends Controller
 
         $update = Update::create([
             'title' => $data['title'],
-            'slug' => Update::makeUniqueSlug($data['slug'] ?: $data['title']),
+            'slug' => Update::makeUniqueSlug(($data['slug'] ?? '') ?: $data['title']),
             'tags' => $this->normalizeTags($data['tags'] ?? null),
             'excerpt' => $data['excerpt'] ?? null,
             'body' => $data['body'],
@@ -77,7 +77,7 @@ class AdminUpdateController extends Controller
     {
         $data = $this->validated($request, $update->id);
 
-        $newSlug = $data['slug'] ?: $update->slug;
+        $newSlug = ($data['slug'] ?? '') ?: $update->slug;
         if ($newSlug !== $update->slug) {
             $newSlug = Update::makeUniqueSlug($newSlug, $update->id);
         }

--- a/app/Http/Controllers/KitController.php
+++ b/app/Http/Controllers/KitController.php
@@ -81,7 +81,7 @@ class KitController extends Controller
         $kit = new Kit;
         $kit->owner_id = $request->user()->id;
         $kit->title = $validated['title'];
-        $kit->description = $validated['description'];
+        $kit->description = $validated['description'] ?? null;
         $kit->is_public = $validated['is_public'];
 
         if ($request->filled('thumbnail_url')) {
@@ -202,7 +202,7 @@ class KitController extends Controller
         }
 
         $kit->title = $validated['title'];
-        $kit->description = $validated['description'];
+        $kit->description = $validated['description'] ?? null;
         $kit->is_public = $validated['is_public'];
 
         if ($request->filled('thumbnail_url')) {

--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -2,6 +2,17 @@
 
 > Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
 
+## August 18th, 2026 - fix(api): omitting an optional field 500'd two endpoints
+
+`nullable` means the key may be **absent**, not merely null. Laravel's `validated()` only returns keys that were actually present in the request, so reading `$validated['optional']` unconditionally throws `Undefined array key` and the request 500s. Two controllers had exactly that shape.
+
+- **`KitController::store()` and `update()` read `$validated['description']`** with the rule `nullable|string|max:1000`. `POST /kits` or `PUT /kits/{kit}` without a `description` field crashed.
+- **`AdminUpdateController::store()` and `update()` read `$data['slug']`** the same way. `?:` does not help here - unlike `??` it still evaluates its left operand, so a missing key throws before the fallback is ever reached. The neighbouring lines in that same method already do `$data['tags'] ?? null`, `$data['excerpt'] ?? null` and `$data['compiled_css'] ?? null`, so `slug` was simply the one that got missed.
+- **Both were unreachable through the UI, which is why they lasted.** Every Vue form initialises its fields (`useForm({ description: '', ... })`) and therefore always sends the key, so only a direct API call could trigger it. That is the sort of bug that stays broken for a year because no browser ever does the thing that breaks it.
+- **Semantics were a choice, not an accident.** An omitted kit description now means "no description": these are `PUT` endpoints where every other field is required, so the payload is the complete state. An omitted update slug instead keeps the existing one, because updates are linkable and indexed and a rename must never silently move a URL.
+- **Found by sweeping for the pattern rather than fixing the one report.** A scan of every `nullable`/`sometimes` rule in `app/` against unguarded `$validated[...]` reads turned up 23 candidates; all but these four were properly guarded by an enclosing `! empty()`, `array_key_exists()` or `??`.
+- **Six tests, four of them verified to fail** against the old code. The two that pass either way are the happy-path guards asserting a supplied value is still honoured.
+
 ## August 18th, 2026 - fix(security): nothing at all rate limited template creation
 
 Found while answering an idle question about the slug generator: what happens if someone exhausts the slug space? The answer turned out not to be about slugs. **Creating a template was limited by nothing.** `templates.store` and `templates.fork` carried exactly two middlewares, `web` and `RedirectIfUnauthenticated`, and there is no global throttle on the `web` group. The only guard was being logged in.

--- a/tests/Feature/OptionalFieldOmittedTest.php
+++ b/tests/Feature/OptionalFieldOmittedTest.php
@@ -1,0 +1,141 @@
+<?php
+
+use App\Models\Kit;
+use App\Models\OverlayTemplate;
+use App\Models\Update;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+uses(DatabaseTransactions::class);
+
+// A `nullable` rule means the key may be ABSENT from the request, not merely
+// null. Laravel's validated() only returns keys that were actually present, so
+// reading $validated['optional'] unconditionally throws "Undefined array key"
+// and the request 500s. These endpoints all had that shape: the Vue forms
+// initialise every field and always send it, so the crash was reachable only by
+// a direct API call, which is exactly the sort of thing that stays broken for a
+// year because no browser ever does it.
+
+function optUser(array $attrs = []): User
+{
+    return User::factory()->create(array_merge([
+        'twitch_id' => (string) fake()->unique()->randomNumber(9),
+    ], $attrs));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Kits - `description`
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('a kit can be created without sending a description at all', function () {
+    $user = optUser();
+    $template = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id, 'fork_of_id' => null, 'type' => 'static',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('kits.store'), [
+            'title' => 'No description key',
+            'is_public' => false,
+            'template_ids' => [$template->id],
+        ])
+        ->assertRedirect();
+
+    $kit = Kit::where('title', 'No description key')->first();
+
+    expect($kit)->not->toBeNull()
+        ->and($kit->description)->toBeNull();
+});
+
+test('a kit can be updated without sending a description at all', function () {
+    $user = optUser();
+    $template = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id, 'fork_of_id' => null, 'type' => 'static',
+    ]);
+    $kit = Kit::factory()->create([
+        'owner_id' => $user->id, 'description' => 'was set before',
+    ]);
+    $kit->templates()->attach($template->id);
+
+    $this->actingAs($user)
+        ->put(route('kits.update', $kit), [
+            'title' => 'Renamed',
+            'is_public' => false,
+            'template_ids' => [$template->id],
+        ])
+        ->assertRedirect();
+
+    // PUT is a full replace here - every other field is required, so an omitted
+    // description means "no description", not "leave it alone".
+    expect($kit->fresh()->title)->toBe('Renamed')
+        ->and($kit->fresh()->description)->toBeNull();
+});
+
+test('a description is still stored when one is sent', function () {
+    $user = optUser();
+    $template = OverlayTemplate::factory()->create([
+        'owner_id' => $user->id, 'fork_of_id' => null, 'type' => 'static',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('kits.store'), [
+            'title' => 'Has one',
+            'description' => 'a real description',
+            'is_public' => false,
+            'template_ids' => [$template->id],
+        ])
+        ->assertRedirect();
+
+    expect(Kit::where('title', 'Has one')->first()->description)
+        ->toBe('a real description');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Admin updates - `slug`
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('an update can be created without sending a slug at all', function () {
+    $this->actingAs(optUser(['role' => 'admin']))
+        ->post(route('admin.updates.store'), [
+            'title' => 'Shipped The Thing',
+            'body' => 'Body copy.',
+        ])
+        ->assertRedirect();
+
+    // An omitted slug falls back to deriving one from the title, which is what
+    // the `?:` was there to do all along.
+    expect(Update::where('title', 'Shipped The Thing')->first()->slug)
+        ->toBe('shipped-the-thing');
+});
+
+test('an update can be edited without sending a slug at all', function () {
+    $update = Update::create([
+        'title' => 'Original', 'slug' => 'original', 'body' => 'Body copy.',
+        'published_at' => now(),
+    ]);
+
+    $this->actingAs(optUser(['role' => 'admin']))
+        ->put(route('admin.updates.update', $update), [
+            'title' => 'Retitled',
+            'body' => 'New body.',
+        ])
+        ->assertRedirect();
+
+    // An omitted slug keeps the existing one: updates are linkable and indexed,
+    // so a rename must not silently move the URL.
+    expect($update->fresh()->slug)->toBe('original')
+        ->and($update->fresh()->title)->toBe('Retitled');
+});
+
+test('an explicit slug still wins when one is sent', function () {
+    $this->actingAs(optUser(['role' => 'admin']))
+        ->post(route('admin.updates.store'), [
+            'title' => 'Ignore This Title',
+            'slug' => 'chosen-by-hand',
+            'body' => 'Body copy.',
+        ])
+        ->assertRedirect();
+
+    expect(Update::where('title', 'Ignore This Title')->first()->slug)
+        ->toBe('chosen-by-hand');
+});


### PR DESCRIPTION
A `nullable` rule means the key may be **absent**, not merely null. Laravel's `validated()` only returns keys that were actually present in the request, so reading `$validated['optional']` unconditionally throws `Undefined array key` and the request 500s.

## What was wrong

Two controllers, four call sites:

- **`KitController::store()` and `update()`** read `$validated['description']` against the rule `nullable|string|max:1000`. `POST /kits` or `PUT /kits/{kit}` without a `description` field crashed.
- **`AdminUpdateController::store()` and `update()`** read `$data['slug']` the same way.

The admin one is the more interesting shape. It read:

```php
'slug' => Update::makeUniqueSlug($data['slug'] ?: $data['title']),
```

**`?:` does not help here.** Unlike `??`, it still evaluates its left operand, so a missing key throws before the fallback is ever reached. The giveaway that this was an oversight rather than a decision is the three adjacent lines in that same method, which already do it correctly:

```php
'tags'         => $this->normalizeTags($data['tags'] ?? null),
'excerpt'      => $data['excerpt'] ?? null,
'compiled_css' => $data['compiled_css'] ?? null,
```

`slug` was simply the one that got missed.

## Why it survived

Both were unreachable through the UI. Every Vue form initialises its fields (`useForm({ description: '', ... })`) and therefore always sends the key, so only a direct API call could trigger either crash. That is the sort of bug that stays broken indefinitely, because no browser ever does the thing that breaks it.

## The semantics are a choice

The two endpoints deliberately get opposite treatment:

- **An omitted kit description means "no description".** These are `PUT` endpoints where every other field is required, so the payload is the complete state and an absent optional field means absent.
- **An omitted update slug keeps the existing one.** Updates are linkable and indexed, so a rename must never silently move a URL.

## Found by sweeping, not by fixing the report

Rather than patching the one reported site, every `nullable`/`sometimes` rule in `app/` was scanned against unguarded `$validated[...]` reads. That produced 23 candidates; 19 turned out to be properly guarded by an enclosing `! empty()`, `array_key_exists()` or `??`, leaving these four.

## Testing

Six tests in `OptionalFieldOmittedTest`, **four verified to fail** against the old code. The two that pass either way are deliberate happy-path guards, asserting a supplied value is still honoured.

Full CI gate run locally: `pint --test`, `format:check`, `lint:check`, `npm test` (129 passed), `typecheck`, `pest` (1460 passed, 6 skipped, 0 failures).

## Deliberately left out

`Update` has no model factory, so the one test needing an existing row constructs it directly. Adding a factory was out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
