### PR TITLE
chore(changelog): drop the birthday line from August

### DIFF
--- a/docs/changelog/changelog-2026-08.md
+++ b/docs/changelog/changelog-2026-08.md
@@ -1,7 +1,5 @@
 # CHANGELOG AUGUST 2026
 
-> Oh, and happy birthday to me. Jasper turns 44 today, and celebrated by finally giving his own repo a licence. 🎂
-
 ## August 18th, 2026 - fix(api): omitting an optional field 500'd two endpoints
 
 `nullable` means the key may be **absent**, not merely null. Laravel's `validated()` only returns keys that were actually present in the request, so reading `$validated['optional']` unconditionally throws `Undefined array key` and the request 500s. Two controllers had exactly that shape.


### PR DESCRIPTION
Removes the birthday note from the top of `docs/changelog/changelog-2026-08.md`. It was a remark about the day rather than a record of a change, and it sat above every entry in the file as though it were one.

No changelog entry accompanies this, deliberately: an entry recording the removal of a non-entry would be the same noise a second time.

Also the first run of the new gated ship flow, so it doubles as a test that `--auto` queues behind the required `ci` and `quality` checks rather than merging straight through.

Full local gate run anyway despite being markdown-only: pint, format:check, lint:check, npm test (129), typecheck, build, pest (1460 passed, 6 skipped, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)